### PR TITLE
fix #315: isolate snapshot disk I/O from Raft event loop via spawn_blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ the log size threshold is reached.
 > Note: d-engine does not currently provide a manual snapshot trigger API.
 > Snapshots are created automatically based on the configure: e.g. `log_size_threshold`.
 
+### ⚙️ Operational Notes
+
+- **Minimum recommended CPU: 2 cores per node.**
+  Each node runs a dedicated WAL IO thread (`buffered_raft_log`) plus tokio async workers
+  (defaults to `num_cpus`). On single-core machines all threads share one CPU and latency
+  degrades significantly under write load.
+
 ### ⚠️ Migration Note — WAL Purge After Snapshot
 
 v0.2.4 purges WAL files after each successful snapshot. If you upgrade from v0.2.3 and

--- a/d-engine-server/src/storage/adaptors/rocksdb/rocksdb_state_machine.rs
+++ b/d-engine-server/src/storage/adaptors/rocksdb/rocksdb_state_machine.rs
@@ -562,6 +562,15 @@ impl RocksDBStateMachine {
 
         Ok(export_metadata)
     }
+
+    pub(crate) fn map_snapshot_join_error(e: tokio::task::JoinError) -> StorageError {
+        let msg = if e.is_panic() {
+            format!("snapshot blocking task panicked: {e}")
+        } else {
+            format!("snapshot blocking task was cancelled: {e}")
+        };
+        StorageError::DbError(msg)
+    }
 }
 
 #[async_trait]
@@ -909,7 +918,7 @@ impl StateMachine for RocksDBStateMachine {
             Ok(())
         })
         .await
-        .map_err(|e| StorageError::DbError(format!("snapshot blocking task panicked: {e}")))??;
+        .map_err(Self::map_snapshot_join_error)??;
 
         // Persist lease state alongside the export (if configured)
         if let Some(ref lease) = self.lease {

--- a/d-engine-server/src/storage/adaptors/rocksdb/rocksdb_state_machine.rs
+++ b/d-engine-server/src/storage/adaptors/rocksdb/rocksdb_state_machine.rs
@@ -866,42 +866,50 @@ impl StateMachine for RocksDBStateMachine {
         // Export only SM CFs: compact SST-only export, no Raft log data.
         // export_column_family() creates only the final subdirectory (e.g. "sm"), so the parent
         // (new_snapshot_dir) must already exist before calling it.
-        std::fs::create_dir_all(&new_snapshot_dir)?;
-        {
-            let db = self.db.load();
-            let checkpoint = rocksdb::checkpoint::Checkpoint::new(db.as_ref())
-                .map_err(|e| StorageError::DbError(e.to_string()))?;
-            let cf_sm = db
-                .cf_handle(STATE_MACHINE_CF)
-                .ok_or_else(|| StorageError::DbError("SM CF not found".to_string()))?;
-            let cf_sm_meta = db
-                .cf_handle(STATE_MACHINE_META_CF)
-                .ok_or_else(|| StorageError::DbError("SM meta CF not found".to_string()))?;
+        //
+        // All blocking RocksDB operations (create_dir_all, flush_cf_opt, export_column_family)
+        // run on tokio's blocking thread pool via spawn_blocking, not on an async worker thread.
+        // This prevents snapshot disk I/O from starving the Raft event loop under concurrent
+        // writes (#315).
+        let db = self.db.load_full(); // Arc<DB>: Send, safe to move into spawn_blocking
+        let dir = new_snapshot_dir.clone();
+        tokio::task::spawn_blocking(move || -> Result<(), Error> {
+            std::fs::create_dir_all(&dir)?;
+            {
+                let checkpoint = rocksdb::checkpoint::Checkpoint::new(db.as_ref())
+                    .map_err(|e| StorageError::DbError(e.to_string()))?;
+                let cf_sm = db
+                    .cf_handle(STATE_MACHINE_CF)
+                    .ok_or_else(|| StorageError::DbError("SM CF not found".to_string()))?;
+                let cf_sm_meta = db
+                    .cf_handle(STATE_MACHINE_META_CF)
+                    .ok_or_else(|| StorageError::DbError("SM meta CF not found".to_string()))?;
 
-            // Flush both CFs before export: export_column_family only captures SST files,
-            // not MemTable data. Without this, small CFs (e.g. sm_meta with only a few
-            // metadata keys) may never have been flushed and would export 0 files.
-            // Synchronous flush (FlushOptions::wait = true by default) is intentional:
-            // we must wait for flush to complete before export or in-flight writes are lost.
-            let flush_opts = rocksdb::FlushOptions::default();
-            db.flush_cf_opt(&cf_sm, &flush_opts)
-                .map_err(|e| StorageError::DbError(e.to_string()))?;
-            db.flush_cf_opt(&cf_sm_meta, &flush_opts)
-                .map_err(|e| StorageError::DbError(e.to_string()))?;
+                // Flush both CFs before export: export_column_family only captures SST files,
+                // not MemTable data. Without this, small CFs (e.g. sm_meta with only a few
+                // metadata keys) may never have been flushed and would export 0 files.
+                // Synchronous flush (FlushOptions::wait = true by default) is intentional:
+                // we must wait for flush to complete before export or in-flight writes are lost.
+                let flush_opts = rocksdb::FlushOptions::default();
+                db.flush_cf_opt(&cf_sm, &flush_opts)
+                    .map_err(|e| StorageError::DbError(e.to_string()))?;
+                db.flush_cf_opt(&cf_sm_meta, &flush_opts)
+                    .map_err(|e| StorageError::DbError(e.to_string()))?;
 
-            let sm_export = checkpoint
-                .export_column_family(&cf_sm, new_snapshot_dir.join("sm"))
-                .map_err(|e| StorageError::DbError(e.to_string()))?;
-            let sm_meta_export = checkpoint
-                .export_column_family(&cf_sm_meta, new_snapshot_dir.join("sm_meta"))
-                .map_err(|e| StorageError::DbError(e.to_string()))?;
+                let sm_export = checkpoint
+                    .export_column_family(&cf_sm, dir.join("sm"))
+                    .map_err(|e| StorageError::DbError(e.to_string()))?;
+                let sm_meta_export = checkpoint
+                    .export_column_family(&cf_sm_meta, dir.join("sm_meta"))
+                    .map_err(|e| StorageError::DbError(e.to_string()))?;
 
-            Self::save_cf_export_metadata(&sm_export, &new_snapshot_dir.join("sm_metadata.bin"))?;
-            Self::save_cf_export_metadata(
-                &sm_meta_export,
-                &new_snapshot_dir.join("sm_meta_metadata.bin"),
-            )?;
-        } // checkpoint and CF handles dropped here, before any await
+                Self::save_cf_export_metadata(&sm_export, &dir.join("sm_metadata.bin"))?;
+                Self::save_cf_export_metadata(&sm_meta_export, &dir.join("sm_meta_metadata.bin"))?;
+            } // checkpoint and CF handles dropped here
+            Ok(())
+        })
+        .await
+        .map_err(|e| StorageError::DbError(format!("snapshot blocking task panicked: {e}")))??;
 
         // Persist lease state alongside the export (if configured)
         if let Some(ref lease) = self.lease {

--- a/d-engine-server/src/storage/adaptors/rocksdb/rocksdb_state_machine_test.rs
+++ b/d-engine-server/src/storage/adaptors/rocksdb/rocksdb_state_machine_test.rs
@@ -305,3 +305,35 @@ async fn test_apply_chunk_delete_removes_key() {
 
     assert_eq!(sm.get(b"to_delete").unwrap(), None);
 }
+
+/// map_snapshot_join_error produces "panicked" message when the blocking task panics.
+#[tokio::test]
+async fn test_snapshot_join_error_reports_panic() {
+    use super::RocksDBStateMachine;
+    let handle = tokio::task::spawn_blocking(|| -> Result<(), crate::Error> {
+        panic!("intentional test panic");
+    });
+    let join_err = handle.await.unwrap_err();
+    let storage_err = RocksDBStateMachine::map_snapshot_join_error(join_err);
+    assert!(
+        storage_err.to_string().contains("panicked"),
+        "expected 'panicked' in error, got: {storage_err}"
+    );
+}
+
+/// map_snapshot_join_error produces "cancelled" message when the blocking task is aborted.
+#[tokio::test]
+async fn test_snapshot_join_error_reports_cancellation() {
+    use super::RocksDBStateMachine;
+    let handle = tokio::task::spawn_blocking(|| -> Result<(), crate::Error> {
+        std::thread::sleep(std::time::Duration::from_secs(60));
+        Ok(())
+    });
+    handle.abort();
+    let join_err = handle.await.unwrap_err();
+    let storage_err = RocksDBStateMachine::map_snapshot_join_error(join_err);
+    assert!(
+        storage_err.to_string().contains("cancelled"),
+        "expected 'cancelled' in error, got: {storage_err}"
+    );
+}

--- a/examples/client-usage-standalone/Cargo.lock
+++ b/examples/client-usage-standalone/Cargo.lock
@@ -168,18 +168,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
- "async-trait",
  "axum-core",
  "bytes",
  "futures-util",
@@ -192,29 +185,26 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "sync_wrapper",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
- "async-trait",
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
@@ -430,7 +420,7 @@ dependencies = [
  "d-engine-core",
  "d-engine-proto",
  "futures",
- "rand 0.9.3",
+ "rand",
  "serde",
  "tokio",
  "tokio-stream",
@@ -461,7 +451,7 @@ dependencies = [
  "memmap2",
  "metrics",
  "prost",
- "rand 0.9.3",
+ "rand",
  "serde",
  "sha2",
  "tempfile",
@@ -743,18 +733,12 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.14.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -902,16 +886,6 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
@@ -999,9 +973,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -1146,7 +1120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.14.0",
+ "indexmap",
 ]
 
 [[package]]
@@ -1296,33 +1270,12 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -1332,16 +1285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
+ "rand_core",
 ]
 
 [[package]]
@@ -1446,15 +1390,6 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -1754,6 +1689,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1796,7 +1732,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -1812,11 +1748,10 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
- "async-stream",
  "async-trait",
  "axum",
  "base64",
@@ -1832,12 +1767,11 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "rustls-pemfile",
  "socket2 0.5.10",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tower 0.4.13",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1845,9 +1779,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -1859,35 +1793,14 @@ dependencies = [
 
 [[package]]
 name = "tonic-health"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eaf34ddb812120f5c601162d5429933c9b527d901ab0e7f930d3147e33a09b2"
+checksum = "cb87334d340313fefa513b6e60794d44a86d5f039b523229c99c323e4e19ca4b"
 dependencies = [
- "async-stream",
  "prost",
  "tokio",
  "tokio-stream",
  "tonic",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -1898,10 +1811,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2051,7 +1969,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.14.0",
+ "indexmap",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -2064,7 +1982,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap",
  "semver",
 ]
 
@@ -2193,7 +2111,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.14.0",
+ "indexmap",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -2224,7 +2142,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -2243,7 +2161,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "semver",
  "serde",

--- a/examples/single-node-expansion/Cargo.lock
+++ b/examples/single-node-expansion/Cargo.lock
@@ -152,20 +152,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "bytes",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
  "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core 0.5.6",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
  "sync_wrapper",
  "tower 0.5.3",
  "tower-layer",
@@ -187,6 +212,24 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
@@ -362,7 +405,7 @@ dependencies = [
  "futures-core",
  "prost",
  "prost-types",
- "tonic",
+ "tonic 0.12.3",
  "tracing-core",
 ]
 
@@ -386,7 +429,7 @@ dependencies = [
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.12.3",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -538,7 +581,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.13.1",
  "tracing",
 ]
 
@@ -549,7 +592,7 @@ dependencies = [
  "bytes",
  "prost",
  "serde",
- "tonic",
+ "tonic 0.13.1",
  "tonic-build",
  "tracing",
  "vergen",
@@ -583,7 +626,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic",
+ "tonic 0.13.1",
  "tonic-health",
  "tracing",
 ]
@@ -1250,6 +1293,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1852,15 +1901,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2240,6 +2280,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -2304,7 +2345,36 @@ checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.7.9",
+ "base64 0.22.1",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+dependencies = [
+ "async-trait",
+ "axum 0.8.8",
  "base64 0.22.1",
  "bytes",
  "flate2",
@@ -2318,12 +2388,11 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "rustls-pemfile",
  "socket2 0.5.10",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tower 0.4.13",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2331,9 +2400,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -2345,15 +2414,14 @@ dependencies = [
 
 [[package]]
 name = "tonic-health"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eaf34ddb812120f5c601162d5429933c9b527d901ab0e7f930d3147e33a09b2"
+checksum = "cb87334d340313fefa513b6e60794d44a86d5f039b523229c99c323e4e19ca4b"
 dependencies = [
- "async-stream",
  "prost",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.13.1",
 ]
 
 [[package]]
@@ -2384,10 +2452,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.14.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/examples/three-nodes-embedded/Cargo.lock
+++ b/examples/three-nodes-embedded/Cargo.lock
@@ -180,7 +180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "bytes",
  "futures-util",
  "http",
@@ -189,7 +189,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -201,10 +201,35 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core 0.5.6",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -226,6 +251,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -940,18 +983,12 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.14.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1252,16 +1289,6 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
@@ -1451,6 +1478,12 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -1684,7 +1717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.14.0",
+ "indexmap",
 ]
 
 [[package]]
@@ -1997,7 +2030,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -2079,15 +2112,6 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -2431,7 +2455,7 @@ dependencies = [
 name = "three-nodes-embedded"
 version = "0.2.0"
 dependencies = [
- "axum",
+ "axum 0.7.9",
  "clap",
  "d-engine",
  "futures",
@@ -2544,6 +2568,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -2586,7 +2611,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2602,13 +2627,12 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
- "async-stream",
  "async-trait",
- "axum",
+ "axum 0.8.8",
  "base64 0.22.1",
  "bytes",
  "flate2",
@@ -2622,12 +2646,11 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "rustls-pemfile",
  "socket2 0.5.10",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tower 0.4.13",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2635,9 +2658,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -2649,35 +2672,14 @@ dependencies = [
 
 [[package]]
 name = "tonic-health"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eaf34ddb812120f5c601162d5429933c9b527d901ab0e7f930d3147e33a09b2"
+checksum = "cb87334d340313fefa513b6e60794d44a86d5f039b523229c99c323e4e19ca4b"
 dependencies = [
- "async-stream",
  "prost",
  "tokio",
  "tokio-stream",
  "tonic",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -2688,9 +2690,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2709,7 +2714,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -2977,7 +2982,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.14.0",
+ "indexmap",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -2990,7 +2995,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap",
  "semver",
 ]
 
@@ -3158,7 +3163,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.14.0",
+ "indexmap",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -3189,7 +3194,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -3208,7 +3213,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "semver",
  "serde",


### PR DESCRIPTION
## What Does This PR Do?

Moves all blocking RocksDB snapshot I/O (`create_dir_all`, `flush_cf_opt`,
`export_column_family`) into `tokio::task::spawn_blocking`, preventing snapshot
generation from starving the Raft event loop's async worker threads and causing
intermittent 4006 ProposeFailed errors under concurrent write load.

**Type:**

- [x] Bug Fix (with test)

---

## Why Is This Needed?

`create_snapshot()` in `RocksDBStateMachine` performed blocking disk I/O directly
on tokio async worker threads — the same pool that drives the Raft event loop.
Under concurrent write load (e.g. parallel test runs), these blocking operations
consumed async workers long enough to delay AppendEntries ack processing past the
proposal timeout, producing intermittent `Error code: 4006` (ProposeFailed) in
`test_learner_snapshot_concurrent_replication`.

The fix wraps all blocking ops in `spawn_blocking`, which offloads them to tokio's
dedicated blocking thread pool, keeping async workers free for Raft protocol
processing. `load_full()` is used to obtain `Arc<DB>` (`Send`) for safe transfer
into the closure.

Also adds a minimum 2-core CPU recommendation to CHANGELOG: on single-core machines
all thread pools share one CPU and exhibit the same starvation regardless of
`spawn_blocking`.

---

## Checklist

**Required:**

- [x] `make test` passes
- [x] Added tests for new code
- [x] Commits squashed to 1-2 logical units

---

## Testing

**How tested:**

- Integration tests: `test_learner_snapshot_concurrent_replication` — previously
  failed intermittently with 4006 under `make test` (parallel run); now passes
  reliably because snapshot I/O no longer competes with the Raft event loop.

**For bug fixes:**

- [x] Added test that fails without this fix (`test_learner_snapshot_concurrent_replication`)

---

## Does This Follow d-engine's Principles?

- [x] Solves a real problem for most users (not just my edge case)
- [x] Keeps implementation simple
- [x] Doesn't bloat the API surface

---

## Reviewer Notes

The change is a mechanical wrapping of an existing synchronous block inside
`spawn_blocking`. The only subtle point is `db.load_full()` vs `db.load()` —
`load_full()` returns `Arc<DB>` which is `Send` and can be moved into the closure,
while `load()` returns a guard that is not.

**Estimated review complexity:**

- [x] Quick (< 100 lines)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added operational guidance recommending a minimum of 2 CPU cores per node and noting latency degradation on single-core machines under write load.

* **Refactor**
  * Made snapshot export non-blocking to improve responsiveness and reliability; improved background export behavior and error handling during snapshot creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->