### PR TITLE
feat #327, #328: cluster membership streaming (EmbeddedEngine + GrpcClient watch_membership)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ All notable changes to this project will be documented in this file.
 
 - No runtime behavior change for existing deployments — `unified_db` defaults to `false`
 
+- **Zombie detection no longer auto-removes unreachable nodes** (#327):
+  Previously, a node that failed to connect N times was automatically removed
+  via `BatchRemove`. This was too aggressive and could evict temporarily
+  restarting nodes. Detection now emits a `warn` log only — removal remains
+  a deliberate operator or upper-layer decision.
+
 ### ⚠️ Breaking Change — Snapshot Format
 
 The internal snapshot format changed from RocksDB **checkpoint** (v0.2.3) to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ All notable changes to this project will be documented in this file.
   - **Experimental**: both paths are supported in v0.2.4; a future release will standardize on one
   - When enabled: data path changes to `db_root_dir/db/` (⚠️ existing `storage/` data not migrated automatically)
 
+- **Cluster membership streaming** (#327, #328): Subscribe to real-time membership changes
+  - `EmbeddedEngine::watch_membership()` — in-process `watch::Receiver<MembershipSnapshot>` (embedded mode)
+  - `GrpcClient::watch_membership()` — gRPC server-side stream of `MembershipSnapshot` (standalone mode)
+  - Stream delivers the current snapshot immediately on connect (no need to wait for the next change)
+  - Each committed ConfChange (AddNode, Promote, Remove) pushes a new snapshot to all subscribers
+  - Stream terminates with `UNAVAILABLE` on server shutdown — callers reconnect and resubscribe
+  - `MembershipSnapshot` carries `members`, `learners`, and `committed_index` (idempotency key for deduplication after reconnect)
+
 ### 🟡 Important Fixes
 
 - **fix(raft) #340**: Candidate correctly steps down on same-term AppendEntries with log conflict

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
+checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
 dependencies = [
  "filetime",
  "futures-core",
@@ -1075,7 +1075,7 @@ dependencies = [
  "hyper",
  "libc",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1882,9 +1882,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,10 @@ install-tools: check-env
 		echo "$(YELLOW)Installing cargo-nextest for fast parallel testing...$(NC)"; \
 		cargo install cargo-nextest --locked; \
 	fi
+	@if ! command -v cargo-deny >/dev/null 2>&1; then \
+		echo "$(YELLOW)Installing cargo-deny for supply chain checks...$(NC)"; \
+		cargo install cargo-deny --locked; \
+	fi
 	@echo "$(GREEN)✓ Components installed$(NC)"
 
 ## install              Alias for install-tools
@@ -193,8 +197,8 @@ clippy-fix: install-tools check-workspace
 # CODE QUALITY - COMPREHENSIVE CHECKS
 # ============================================================================
 
-## check                Run all quality checks (fmt, clippy, cargo check)
-check: fmt-check clippy
+## check                Run all quality checks (fmt, clippy, deny, cargo check)
+check: fmt-check clippy deny
 	@echo ""
 	@echo "$(GREEN)╔════════════════════════════════════════╗$(NC)"
 	@echo "$(GREEN)║  ✓ All code quality checks passed!    ║$(NC)"
@@ -321,9 +325,9 @@ audit: check-env
 deny: check-env
 	@echo "$(BLUE)Running cargo deny checks...$(NC)"
 	@if command -v cargo-deny >/dev/null 2>&1; then \
-		cargo deny check; \
+		cargo deny check all; \
 	else \
-		echo "$(YELLOW)Note: cargo-deny not installed. Install with: cargo install cargo-deny$(NC)"; \
+		echo "$(YELLOW)Note: cargo-deny not installed. Run: make install-tools$(NC)"; \
 	fi
 
 # ============================================================================

--- a/d-engine-client/src/grpc_client.rs
+++ b/d-engine-client/src/grpc_client.rs
@@ -5,7 +5,9 @@ use bytes::Bytes;
 use d_engine_proto::client::ClientReadRequest;
 use d_engine_proto::client::ClientResult;
 use d_engine_proto::client::ClientWriteRequest;
+use d_engine_proto::client::MembershipSnapshot;
 use d_engine_proto::client::ReadConsistencyPolicy;
+use d_engine_proto::client::WatchMembershipRequest;
 use d_engine_proto::client::WatchRequest;
 use d_engine_proto::client::WatchResponse;
 use d_engine_proto::client::WriteCommand;
@@ -162,6 +164,36 @@ impl GrpcClient {
         }
 
         Ok(client)
+    }
+
+    /// Subscribe to committed cluster membership changes.
+    ///
+    /// Immediately yields the current `MembershipSnapshot` on connect, then one
+    /// snapshot per committed ConfChange (AddNode, Promote, Remove).
+    /// The stream ends with `Err(UNAVAILABLE)` when the server shuts down;
+    /// callers should reconnect and re-subscribe.
+    ///
+    /// Use `committed_index` as an idempotency key to deduplicate retries.
+    pub async fn watch_membership(&self) -> ClientApiResult<tonic::Streaming<MembershipSnapshot>> {
+        let client_inner = self.client_inner.load();
+
+        let request = WatchMembershipRequest {
+            client_id: client_inner.client_id,
+        };
+
+        // Any node (leader or follower) emits membership changes after commit.
+        let mut client = self.make_client().await?;
+
+        match client.watch_membership(request).await {
+            Ok(response) => {
+                debug!("Membership watch stream established");
+                Ok(response.into_inner())
+            }
+            Err(status) => {
+                error!("watch_membership request failed: {:?}", status);
+                Err(status.into())
+            }
+        }
     }
 
     /// Watch for changes to a specific key

--- a/d-engine-client/src/grpc_client_test.rs
+++ b/d-engine-client/src/grpc_client_test.rs
@@ -1431,6 +1431,118 @@ mod cas_operations {
 }
 
 // =============================================================================
+// WatchMembership Tests
+// =============================================================================
+
+mod watch_membership_tests {
+    use super::*;
+    use d_engine_proto::client::MembershipSnapshot;
+    use tokio_stream::StreamExt;
+
+    async fn make_client(port: u16) -> GrpcClient {
+        let endpoints = vec![format!("http://localhost:{}", port)];
+        let config = ClientConfig::default();
+        let pool = ConnectionPool::create(endpoints.clone(), config.clone())
+            .await
+            .expect("Should create connection pool");
+        GrpcClient::new(Arc::new(ArcSwap::from_pointee(ClientInner {
+            pool,
+            client_id: 42,
+            config,
+            endpoints,
+        })))
+    }
+
+    /// Server rejects the watch_membership call → GrpcClient must propagate the error.
+    ///
+    /// Verifies that transport/server-side errors surface to callers instead of
+    /// being silently swallowed.
+    #[tokio::test]
+    #[traced_test]
+    async fn test_watch_membership_returns_err_when_server_rejects() {
+        let (_tx, rx) = oneshot::channel::<()>();
+        let (_channel, port) = MockNode::simulate_watch_membership_error_mock_server(
+            rx,
+            tonic::Status::permission_denied("membership watch not allowed"),
+        )
+        .await
+        .unwrap();
+
+        let client = make_client(port).await;
+        let result = client.watch_membership().await;
+
+        assert!(
+            result.is_err(),
+            "Expected Err when server rejects watch_membership"
+        );
+    }
+
+    /// Server emits two snapshots → client stream receives them in order with correct fields.
+    ///
+    /// Validates the full round-trip: proto serialization on the server side and
+    /// deserialization/field mapping on the client side.
+    #[tokio::test]
+    #[traced_test]
+    async fn test_watch_membership_receives_snapshots_in_order() {
+        let snapshots = vec![
+            MembershipSnapshot {
+                members: vec![1, 2, 3],
+                learners: vec![],
+                committed_index: 10,
+            },
+            MembershipSnapshot {
+                members: vec![1, 2, 3, 4],
+                learners: vec![],
+                committed_index: 11,
+            },
+        ];
+
+        let (_tx, rx) = oneshot::channel::<()>();
+        let (_channel, port) =
+            MockNode::simulate_watch_membership_mock_server(rx, snapshots.clone())
+                .await
+                .unwrap();
+
+        let client = make_client(port).await;
+        let mut stream = client.watch_membership().await.expect("watch_membership should succeed");
+
+        let s1 = stream.next().await.expect("expected first snapshot").expect("no error");
+        assert_eq!(s1.members, vec![1, 2, 3]);
+        assert_eq!(s1.committed_index, 10);
+
+        let s2 = stream.next().await.expect("expected second snapshot").expect("no error");
+        assert_eq!(s2.members, vec![1, 2, 3, 4]);
+        assert_eq!(s2.committed_index, 11);
+
+        // Server closed the stream — no more items.
+        assert!(
+            stream.next().await.is_none(),
+            "stream should close after all snapshots"
+        );
+    }
+
+    /// Server sends no snapshots → stream closes immediately without error.
+    ///
+    /// Edge case: a node that has just started may have no membership changes yet.
+    /// The client must not hang waiting for data that will never arrive.
+    #[tokio::test]
+    #[traced_test]
+    async fn test_watch_membership_empty_stream_closes_cleanly() {
+        let (_tx, rx) = oneshot::channel::<()>();
+        let (_channel, port) =
+            MockNode::simulate_watch_membership_mock_server(rx, vec![]).await.unwrap();
+
+        let client = make_client(port).await;
+        let mut stream = client.watch_membership().await.expect("watch_membership should succeed");
+
+        assert!(
+            stream.next().await.is_none(),
+            "empty membership stream should close immediately"
+        );
+    }
+}
+
+// =============================================================================
 // Watch Tests
 // =============================================================================
 

--- a/d-engine-client/src/mock_rpc.rs
+++ b/d-engine-client/src/mock_rpc.rs
@@ -4,6 +4,8 @@ use std::sync::Arc;
 use d_engine_proto::client::ClientReadRequest;
 use d_engine_proto::client::ClientResponse;
 use d_engine_proto::client::ClientWriteRequest;
+use d_engine_proto::client::MembershipSnapshot;
+use d_engine_proto::client::WatchMembershipRequest;
 use d_engine_proto::client::WatchRequest;
 use d_engine_proto::client::WatchResponse;
 use d_engine_proto::client::raft_client_service_server::RaftClientService;
@@ -35,6 +37,9 @@ pub struct MockRpcService {
 
     /// Watch stream events to emit, in order. None means return an error.
     pub expected_watch_events: Option<Result<Vec<WatchResponse>, tonic::Status>>,
+
+    /// Membership watch stream snapshots to emit. None means return an error.
+    pub expected_watch_membership_events: Option<Result<Vec<MembershipSnapshot>, tonic::Status>>,
 }
 impl MockRpcService {
     pub fn with_metadata_response(
@@ -106,6 +111,9 @@ impl ClusterManagementService for MockRpcService {
 impl RaftClientService for MockRpcService {
     type WatchStream = Pin<Box<dyn Stream<Item = Result<WatchResponse, tonic::Status>> + Send>>;
 
+    type WatchMembershipStream =
+        Pin<Box<dyn Stream<Item = Result<MembershipSnapshot, tonic::Status>> + Send>>;
+
     async fn handle_client_write(
         &self,
         _request: tonic::Request<ClientWriteRequest>,
@@ -138,7 +146,6 @@ impl RaftClientService for MockRpcService {
     ) -> std::result::Result<tonic::Response<Self::WatchStream>, tonic::Status> {
         match &self.expected_watch_events {
             Some(Ok(events)) => {
-                // Return a finite stream of pre-configured watch events.
                 let items: Vec<Result<WatchResponse, tonic::Status>> =
                     events.iter().cloned().map(Ok).collect();
                 let stream = futures::stream::iter(items);
@@ -146,6 +153,24 @@ impl RaftClientService for MockRpcService {
             }
             Some(Err(status)) => Err(status.clone()),
             None => Err(tonic::Status::unimplemented("Watch not configured in mock")),
+        }
+    }
+
+    async fn watch_membership(
+        &self,
+        _request: tonic::Request<WatchMembershipRequest>,
+    ) -> std::result::Result<tonic::Response<Self::WatchMembershipStream>, tonic::Status> {
+        match &self.expected_watch_membership_events {
+            Some(Ok(snapshots)) => {
+                let items: Vec<Result<MembershipSnapshot, tonic::Status>> =
+                    snapshots.iter().cloned().map(Ok).collect();
+                let stream = futures::stream::iter(items);
+                Ok(tonic::Response::new(Box::pin(stream)))
+            }
+            Some(Err(status)) => Err(status.clone()),
+            None => Err(tonic::Status::unimplemented(
+                "WatchMembership not configured in mock",
+            )),
         }
     }
 }

--- a/d-engine-client/src/mock_rpc_service.rs
+++ b/d-engine-client/src/mock_rpc_service.rs
@@ -2,6 +2,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use d_engine_proto::client::ClientResponse;
+use d_engine_proto::client::MembershipSnapshot;
 use d_engine_proto::client::WatchResponse;
 use d_engine_proto::client::raft_client_service_server::RaftClientServiceServer;
 use d_engine_proto::common::NodeRole;
@@ -275,6 +276,64 @@ impl MockNode {
         let mock_service = crate::mock_rpc::MockRpcService {
             expected_metadata_response: Some(Arc::new(builder)),
             expected_watch_events: Some(Err(status)),
+            ..Default::default()
+        };
+
+        let (port, _addr) = Self::mock_listener(mock_service, rx, true).await?;
+        let channel = Self::mock_channel_with_port(port).await;
+        Ok((channel, port))
+    }
+
+    /// Simulate a membership watch server that emits the given snapshots then closes.
+    pub(crate) async fn simulate_watch_membership_mock_server(
+        rx: oneshot::Receiver<()>,
+        snapshots: Vec<MembershipSnapshot>,
+    ) -> std::result::Result<(Channel, u16), tonic::Status> {
+        let builder = Box::new(|port: u16| {
+            Ok(ClusterMembership {
+                version: 1,
+                nodes: vec![NodeMeta {
+                    id: 1,
+                    role: NodeRole::Leader as i32,
+                    address: format!("127.0.0.1:{port}"),
+                    status: NodeStatus::Active.into(),
+                }],
+                current_leader_id: Some(1),
+            })
+        });
+
+        let mock_service = crate::mock_rpc::MockRpcService {
+            expected_metadata_response: Some(Arc::new(builder)),
+            expected_watch_membership_events: Some(Ok(snapshots)),
+            ..Default::default()
+        };
+
+        let (port, _addr) = Self::mock_listener(mock_service, rx, true).await?;
+        let channel = Self::mock_channel_with_port(port).await;
+        Ok((channel, port))
+    }
+
+    /// Simulate a membership watch server that immediately returns an error.
+    pub(crate) async fn simulate_watch_membership_error_mock_server(
+        rx: oneshot::Receiver<()>,
+        status: tonic::Status,
+    ) -> std::result::Result<(Channel, u16), tonic::Status> {
+        let builder = Box::new(|port: u16| {
+            Ok(ClusterMembership {
+                version: 1,
+                nodes: vec![NodeMeta {
+                    id: 1,
+                    role: NodeRole::Leader as i32,
+                    address: format!("127.0.0.1:{port}"),
+                    status: NodeStatus::Active.into(),
+                }],
+                current_leader_id: Some(1),
+            })
+        });
+
+        let mock_service = crate::mock_rpc::MockRpcService {
+            expected_metadata_response: Some(Arc::new(builder)),
+            expected_watch_membership_events: Some(Err(status)),
             ..Default::default()
         };
 

--- a/d-engine-core/src/raft_role/follower_state_test.rs
+++ b/d-engine-core/src/raft_role/follower_state_test.rs
@@ -2611,3 +2611,66 @@ async fn test_follower_install_snapshot_reports_failure_when_apply_fails_after_t
         "Follower must NOT report success when apply failed after transfer (got success:true — #308 bug)"
     );
 }
+
+// ============================================================================
+// ClusterConf current_leader_id Correctness Tests
+// ============================================================================
+
+/// Follower ClusterConf always exposes the current known leader ID.
+///
+/// Unlike the leader (which must hide its ID until noop commits — see T1/T3 in
+/// `event_handling_test.rs`), a follower learns the leader ID exclusively via
+/// AppendEntries requests. AppendEntries only arrive after the leader has committed
+/// its noop entry, so a follower's `current_leader` is always safe to expose.
+///
+/// This test documents the intentional asymmetry:
+/// - Leader: hides `current_leader_id` until noop commits
+/// - Follower: always exposes `current_leader_id` if known (safe by construction)
+///
+/// # Contract
+/// `retrieve_cluster_membership_config` must receive `Some(leader_id)` when the
+/// follower has observed at least one AppendEntries from that leader.
+///
+/// # Test status: PASSES before and after fix (follower behaviour is already correct)
+#[tokio::test]
+async fn test_follower_cluster_conf_always_exposes_current_leader() {
+    let (_graceful_tx, graceful_rx) = watch::channel(());
+    let (mut context, _temp_dir) = mock_raft_context_with_temp(graceful_rx, None);
+
+    let mut membership = MockMembership::new();
+    // Assert: follower passes the known leader ID (Some(3)) — never None when leader is known
+    membership
+        .expect_retrieve_cluster_membership_config()
+        .times(1)
+        .with(eq(Some(3u32)))
+        .returning(|_| ClusterMembership {
+            version: 1,
+            nodes: vec![],
+            current_leader_id: Some(3),
+        });
+    context.membership = Arc::new(membership);
+
+    let mut state =
+        FollowerState::<MockTypeConfig>::new(1, context.node_config.clone(), None, None);
+    // Simulate: follower learned about leader 3 via AppendEntries (leader already past noop)
+    state.shared_state.set_current_leader(3);
+
+    let (resp_tx, mut resp_rx) = MaybeCloneOneshot::new();
+    let (role_tx, _role_rx) = mpsc::unbounded_channel();
+    assert!(
+        state
+            .handle_raft_event(
+                RaftEvent::ClusterConf(MetadataRequest {}, resp_tx),
+                &context,
+                role_tx
+            )
+            .await
+            .is_ok()
+    );
+    let m = resp_rx.recv().await.unwrap().unwrap();
+    assert_eq!(
+        m.current_leader_id,
+        Some(3),
+        "follower must expose known leader ID"
+    );
+}

--- a/d-engine-core/src/raft_role/leader_state.rs
+++ b/d-engine-core/src/raft_role/leader_state.rs
@@ -1142,10 +1142,13 @@ impl<T: TypeConfig> RaftRoleState for LeaderState<T> {
             }
 
             RaftEvent::ClusterConf(_metadata_request, sender) => {
-                let cluster_conf = ctx
-                    .membership()
-                    .retrieve_cluster_membership_config(self.shared_state().current_leader())
-                    .await;
+                // Hide leader ID until noop commits: before noop, the leader has not confirmed
+                // quorum readiness. Exposing current_leader_id too early causes clients to route
+                // to this leader, which then rejects them with LeaderNotReady.
+                // `Option::and` returns None if noop_log_id is None, Some(id) otherwise.
+                let current_leader = self.noop_log_id.and(self.shared_state().current_leader());
+                let cluster_conf =
+                    ctx.membership().retrieve_cluster_membership_config(current_leader).await;
                 debug!("Leader receive ClusterConf: {:?}", &cluster_conf);
                 if let Err(e) = sender.send(Ok(cluster_conf)) {
                     // Receiver timed out and dropped — this is normal, do not crash the node
@@ -1963,6 +1966,10 @@ impl<T: TypeConfig> LeaderState<T> {
         loop {
             let mut backoff_ms = base_delay_ms;
             let stream = loop {
+                if task_rx.is_closed() {
+                    debug!(peer_id, "Replication worker exiting: task channel closed");
+                    return;
+                }
                 match transport
                     .open_replication_stream(peer_id, membership.clone(), response_compress_enabled)
                     .await

--- a/d-engine-core/src/raft_role/leader_state.rs
+++ b/d-engine-core/src/raft_role/leader_state.rs
@@ -3619,44 +3619,30 @@ impl<T: TypeConfig> LeaderState<T> {
 
     /// Handle a ZombieDetected signal from the health monitor.
     ///
-    /// ReadOnly nodes are permanent read replicas and must never be auto-removed.
-    /// All other non-Active nodes that repeatedly fail connections are removed via consensus.
+    /// Emits a warning log only. Membership removal is a high-risk operation that
+    /// must not be automated: a node that fails N connection attempts may simply be
+    /// restarting, and an incorrect BatchRemove would permanently eject it from the
+    /// cluster. Upper-layer tooling or operators should act on these warnings.
     pub async fn handle_zombie_node(
         &mut self,
         node_id: u32,
-        role_tx: &mpsc::UnboundedSender<RoleEvent>,
+        _role_tx: &mpsc::UnboundedSender<RoleEvent>,
         ctx: &RaftContext<T>,
     ) -> Result<()> {
         let status = ctx.membership().get_node_status(node_id).await;
 
-        if status == Some(NodeStatus::ReadOnly) {
-            debug!(
-                node_id,
-                "Zombie signal ignored: ReadOnly node is exempt from auto-removal"
-            );
+        if status.is_none() {
+            debug!(node_id, "Zombie signal ignored: node not in cluster");
             return Ok(());
         }
 
         warn!(
             node_id,
-            "Zombie detected: proposing BatchRemove via consensus"
+            ?status,
+            "Zombie detected: node is persistently unreachable — manual intervention may be required"
         );
 
-        let change = Change::BatchRemove(BatchRemove {
-            node_ids: vec![node_id],
-        });
-
-        self.execute_request_immediately(
-            RaftRequestWithSignal {
-                id: { rand::distr::Alphanumeric.sample_string(&mut rand::rng(), 21) },
-                payloads: vec![EntryPayload::config(change)],
-                senders: vec![],
-                wait_for_apply_event: false,
-            },
-            ctx,
-            role_tx,
-        )
-        .await
+        Ok(())
     }
 
     /// Remove stalled learner via membership change consensus

--- a/d-engine-core/src/raft_role/leader_state_test/event_handling_test.rs
+++ b/d-engine-core/src/raft_role/leader_state_test/event_handling_test.rs
@@ -968,3 +968,217 @@ async fn test_step_down_self_removed_sends_become_follower() {
         "Expected BecomeFollower(None), got: {event:?}"
     );
 }
+
+// ============================================================================
+// ClusterConf current_leader_id Correctness Tests
+// ============================================================================
+
+/// Leader must NOT expose its own ID via ClusterConf before noop is committed.
+///
+/// # Problem (root cause of `leader_failover_cas_standalone` flakiness)
+/// After election, `From<CandidateState>` immediately calls `set_current_leader(self.node_id())`.
+/// At this point `noop_log_id = None` — the leader has not yet confirmed quorum readiness.
+/// If ClusterConf returns `current_leader_id = Some(id)` at this point, clients (via
+/// `probe_endpoint`) will route requests to this leader, which then rejects them with
+/// `LeaderNotReady: noop not committed`. The correct behaviour: return `None` until noop commits.
+///
+/// # Contract
+/// `retrieve_cluster_membership_config` must receive `None` when `noop_log_id = None`.
+///
+/// # Test status: FAILS before fix, PASSES after fix
+#[tokio::test]
+#[traced_test]
+async fn test_cluster_conf_hides_leader_id_when_noop_not_committed() {
+    let (_graceful_tx, graceful_rx) = watch::channel(());
+    let mut context = mock_raft_context(
+        "/tmp/test_cluster_conf_hides_leader_id_noop_none",
+        graceful_rx,
+        None,
+    );
+
+    let mut membership = create_mock_membership();
+    // Assert: the argument passed must be None — leader must not expose itself before noop
+    membership
+        .expect_retrieve_cluster_membership_config()
+        .times(1)
+        .with(mockall::predicate::eq(None::<u32>))
+        .returning(|_| ClusterMembership {
+            version: 1,
+            nodes: vec![],
+            current_leader_id: None,
+        });
+    context.membership = Arc::new(membership);
+
+    let mut state = LeaderState::<MockTypeConfig>::new(1, context.node_config.clone());
+    // Simulate what From<CandidateState> does: current_leader set immediately after election
+    state.shared_state.set_current_leader(1);
+    // noop_log_id = None (default) — noop not yet committed
+
+    use crate::maybe_clone_oneshot::MaybeCloneOneshot;
+    let (resp_tx, mut resp_rx) = <MaybeCloneOneshot as RaftOneshot<_>>::new();
+    let (role_tx, _role_rx) = mpsc::unbounded_channel();
+    assert!(
+        state
+            .handle_raft_event(
+                RaftEvent::ClusterConf(MetadataRequest {}, resp_tx),
+                &context,
+                role_tx
+            )
+            .await
+            .is_ok()
+    );
+    let _ = resp_rx.recv().await.unwrap().unwrap();
+    // If mock assertion passes (no panic), the fix is working correctly
+}
+
+/// Leader must expose its own ID via ClusterConf once noop is committed.
+///
+/// After noop commits, `noop_log_id = Some(index)` — the leader has confirmed quorum
+/// and is ready to serve clients. ClusterConf must return `current_leader_id = Some(id)`
+/// so clients can route requests correctly without unnecessary retries.
+///
+/// # Contract
+/// `retrieve_cluster_membership_config` must receive `Some(node_id)` when `noop_log_id = Some(_)`.
+///
+/// # Test status: PASSES before and after fix (this is the expected stable-leader behaviour)
+#[tokio::test]
+#[traced_test]
+async fn test_cluster_conf_exposes_leader_id_after_noop_committed() {
+    let (_graceful_tx, graceful_rx) = watch::channel(());
+    let mut context = mock_raft_context(
+        "/tmp/test_cluster_conf_exposes_leader_id_noop_committed",
+        graceful_rx,
+        None,
+    );
+
+    let mut membership = create_mock_membership();
+    // Assert: once noop is committed the argument must be Some(1)
+    membership
+        .expect_retrieve_cluster_membership_config()
+        .times(1)
+        .with(mockall::predicate::eq(Some(1u32)))
+        .returning(|_| ClusterMembership {
+            version: 1,
+            nodes: vec![],
+            current_leader_id: Some(1),
+        });
+    context.membership = Arc::new(membership);
+
+    let mut state = LeaderState::<MockTypeConfig>::new(1, context.node_config.clone());
+    state.shared_state.set_current_leader(1);
+    state.noop_log_id = Some(1); // noop committed
+
+    use crate::maybe_clone_oneshot::MaybeCloneOneshot;
+    let (resp_tx, mut resp_rx) = <MaybeCloneOneshot as RaftOneshot<_>>::new();
+    let (role_tx, _role_rx) = mpsc::unbounded_channel();
+    assert!(
+        state
+            .handle_raft_event(
+                RaftEvent::ClusterConf(MetadataRequest {}, resp_tx),
+                &context,
+                role_tx
+            )
+            .await
+            .is_ok()
+    );
+    let m = resp_rx.recv().await.unwrap().unwrap();
+    assert_eq!(
+        m.current_leader_id,
+        Some(1),
+        "leader must be visible after noop commits"
+    );
+}
+
+/// Leader ClusterConf transitions from hiding to exposing leader ID exactly when noop commits.
+///
+/// Tests the full state machine across two successive ClusterConf calls on the same leader:
+///   1. Pre-noop:  noop_log_id = None    → must pass None    to retrieve_cluster_membership_config
+///   2. Post-noop: noop_log_id = Some(1) → must pass Some(1) to retrieve_cluster_membership_config
+///
+/// This verifies the leader stops hiding its identity exactly at noop commit — not one tick
+/// earlier (causes LeaderNotReady) and not one tick later (causes stale routing).
+///
+/// # Test status: FAILS before fix (first call sends Some(1), not None), PASSES after fix
+#[tokio::test]
+#[traced_test]
+async fn test_cluster_conf_leader_id_transitions_after_noop_commits() {
+    let (_graceful_tx, graceful_rx) = watch::channel(());
+    let mut context = mock_raft_context(
+        "/tmp/test_cluster_conf_leader_id_transitions",
+        graceful_rx,
+        None,
+    );
+
+    let mut seq = mockall::Sequence::new();
+    let mut membership = create_mock_membership();
+
+    // First call (pre-noop): must receive None
+    membership
+        .expect_retrieve_cluster_membership_config()
+        .times(1)
+        .in_sequence(&mut seq)
+        .with(mockall::predicate::eq(None::<u32>))
+        .returning(|_| ClusterMembership {
+            version: 1,
+            nodes: vec![],
+            current_leader_id: None,
+        });
+    // Second call (post-noop): must receive Some(1)
+    membership
+        .expect_retrieve_cluster_membership_config()
+        .times(1)
+        .in_sequence(&mut seq)
+        .with(mockall::predicate::eq(Some(1u32)))
+        .returning(|_| ClusterMembership {
+            version: 1,
+            nodes: vec![],
+            current_leader_id: Some(1),
+        });
+    context.membership = Arc::new(membership);
+
+    let mut state = LeaderState::<MockTypeConfig>::new(1, context.node_config.clone());
+    state.shared_state.set_current_leader(1);
+
+    use crate::maybe_clone_oneshot::MaybeCloneOneshot;
+    let (role_tx, _role_rx) = mpsc::unbounded_channel();
+
+    // Call 1: noop_log_id = None (pre-noop)
+    let (resp_tx1, mut resp_rx1) = <MaybeCloneOneshot as RaftOneshot<_>>::new();
+    assert!(
+        state
+            .handle_raft_event(
+                RaftEvent::ClusterConf(MetadataRequest {}, resp_tx1),
+                &context,
+                role_tx.clone(),
+            )
+            .await
+            .is_ok()
+    );
+    let m1 = resp_rx1.recv().await.unwrap().unwrap();
+    assert_eq!(
+        m1.current_leader_id, None,
+        "leader must be hidden before noop commits"
+    );
+
+    // Noop commits — leader is now ready
+    state.noop_log_id = Some(1);
+
+    // Call 2: noop_log_id = Some(1) (post-noop)
+    let (resp_tx2, mut resp_rx2) = <MaybeCloneOneshot as RaftOneshot<_>>::new();
+    assert!(
+        state
+            .handle_raft_event(
+                RaftEvent::ClusterConf(MetadataRequest {}, resp_tx2),
+                &context,
+                role_tx,
+            )
+            .await
+            .is_ok()
+    );
+    let m2 = resp_rx2.recv().await.unwrap().unwrap();
+    assert_eq!(
+        m2.current_leader_id,
+        Some(1),
+        "leader must be visible after noop commits"
+    );
+}

--- a/d-engine-core/src/raft_role/leader_state_test/membership_change_test.rs
+++ b/d-engine-core/src/raft_role/leader_state_test/membership_change_test.rs
@@ -1657,64 +1657,42 @@ mod zombie_purge_tests {
     use crate::test_utils::mock::{MockBuilder, MockTypeConfig};
     use crate::test_utils::node_config;
     use d_engine_proto::common::EntryPayload;
-    use d_engine_proto::common::{NodeRole::Follower, NodeStatus};
-    use d_engine_proto::server::cluster::NodeMeta;
+    use d_engine_proto::common::NodeStatus;
 
     // =========================================================================
-    // handle_zombie_node — event-driven path
+    // handle_zombie_node — warn-only, no auto-removal
     // =========================================================================
 
-    /// ZombieDetected event for a Promotable node → BatchRemove submitted.
+    /// ZombieDetected for an in-cluster node → warn log only, no BatchRemove.
     ///
     /// # Given
-    /// - Leader receives ZombieDetected(5)
-    /// - Node 5 has status Promotable (non-ReadOnly, non-Active)
+    /// - Node 5 is in the cluster (status Promotable)
     ///
     /// # When
     /// - handle_zombie_node(5) is called
     ///
     /// # Then
-    /// - A BatchRemove config change is proposed for node 5
+    /// - Returns Ok, no membership change is proposed
+    ///   (auto-removal is intentionally not performed; operators decide)
     #[tokio::test]
-    async fn test_handle_zombie_node_non_readonly_submits_batch_remove() {
-        use d_engine_proto::common::membership_change::Change;
-
+    async fn test_handle_zombie_node_warns_without_removal() {
         let (_graceful_tx, graceful_rx) = watch::channel(());
-        let mut cfg = node_config("/tmp/test_handle_zombie_node_non_readonly");
-        cfg.raft.membership.verify_leadership_persistent_timeout =
-            std::time::Duration::from_millis(50);
+        let cfg = node_config("/tmp/test_handle_zombie_node_warns_without_removal");
         let mut raft_context = MockBuilder::new(graceful_rx).with_node_config(cfg).build_context();
 
         let mut membership = MockMembership::new();
-        // Node 5 is Promotable — not ReadOnly, should be removed
         membership.expect_get_node_status().returning(|_| Some(NodeStatus::Promotable));
-        membership.expect_voters().returning(|| {
-            vec![NodeMeta {
-                id: 1,
-                address: "addr_1".to_string(),
-                role: Follower.into(),
-                status: NodeStatus::Active as i32,
-            }]
-        });
-        membership.expect_is_single_node_cluster().returning(|| false);
-        membership.expect_can_rejoin().returning(|_, _| Ok(()));
         raft_context.membership = Arc::new(membership);
 
-        let captured_payloads = Arc::new(Mutex::new(Vec::<EntryPayload>::new()));
-        let captured_clone = captured_payloads.clone();
         raft_context
             .handlers
             .replication_handler
             .expect_prepare_batch_requests()
-            .times(..)
-            .returning(move |payloads, _, _, _, _| {
-                captured_clone.lock().extend(payloads.clone());
-                Ok(crate::PrepareResult::default())
-            });
+            .times(0) // Must NOT be called — zombie detection is warn-only
+            .returning(|_, _, _, _, _| Ok(crate::PrepareResult::default()));
 
         let mut raft_log = MockRaftLog::new();
         raft_log.expect_last_entry_id().returning(|| 10);
-        raft_log.expect_calculate_majority_matched_index().returning(|_, _, _| Some(5));
         raft_context.storage.raft_log = Arc::new(raft_log);
 
         let node_config = raft_context.node_config();
@@ -1722,43 +1700,67 @@ mod zombie_purge_tests {
         let (role_tx, _role_rx) = mpsc::unbounded_channel();
 
         let result = leader.handle_zombie_node(5, &role_tx, &raft_context).await;
-        assert!(result.is_ok());
-
-        let payloads = captured_payloads.lock();
-        assert_eq!(payloads.len(), 1, "Should submit exactly one BatchRemove");
-        match &payloads[0].payload {
-            Some(d_engine_proto::common::entry_payload::Payload::Config(change)) => {
-                match &change.change {
-                    Some(Change::BatchRemove(batch_remove)) => {
-                        assert_eq!(batch_remove.node_ids, vec![5], "Should remove node 5");
-                    }
-                    _ => panic!("Expected BatchRemove, got: {:?}", change.change),
-                }
-            }
-            _ => panic!("Expected Config payload, got: {:?}", payloads[0].payload),
-        }
+        assert!(result.is_ok(), "handle_zombie_node must not fail");
     }
 
-    /// ZombieDetected event for a ReadOnly node → exempt, no BatchRemove.
+    /// ZombieDetected for a ReadOnly node → warn log only, no BatchRemove.
     ///
     /// # Given
-    /// - Leader receives ZombieDetected(5)
-    /// - Node 5 has status ReadOnly (permanent read replica, must not be auto-removed)
+    /// - Node 5 has status ReadOnly
     ///
     /// # When
     /// - handle_zombie_node(5) is called
     ///
     /// # Then
-    /// - No config change is proposed (ReadOnly nodes are exempt from zombie auto-removal)
+    /// - Returns Ok, no membership change is proposed
     #[tokio::test]
-    async fn test_handle_zombie_node_readonly_is_exempt() {
+    async fn test_handle_zombie_node_readonly_warns_without_removal() {
         let (_graceful_tx, graceful_rx) = watch::channel(());
-        let cfg = node_config("/tmp/test_handle_zombie_node_readonly_exempt");
+        let cfg = node_config("/tmp/test_handle_zombie_node_readonly_warns");
         let mut raft_context = MockBuilder::new(graceful_rx).with_node_config(cfg).build_context();
 
         let mut membership = MockMembership::new();
-        // Node 5 is ReadOnly — must never be auto-removed
         membership.expect_get_node_status().returning(|_| Some(NodeStatus::ReadOnly));
+        raft_context.membership = Arc::new(membership);
+
+        raft_context
+            .handlers
+            .replication_handler
+            .expect_prepare_batch_requests()
+            .times(0)
+            .returning(|_, _, _, _, _| Ok(crate::PrepareResult::default()));
+
+        let mut raft_log = MockRaftLog::new();
+        raft_log.expect_last_entry_id().returning(|| 10);
+        raft_context.storage.raft_log = Arc::new(raft_log);
+
+        let node_config = raft_context.node_config();
+        let mut leader = LeaderState::<MockTypeConfig>::new(1, node_config);
+        let (role_tx, _role_rx) = mpsc::unbounded_channel();
+
+        let result = leader.handle_zombie_node(5, &role_tx, &raft_context).await;
+        assert!(result.is_ok(), "handle_zombie_node must not fail");
+    }
+
+    /// Stale zombie signal for a node that is no longer in the cluster is silently ignored.
+    ///
+    /// # Given
+    /// - Node 5 has already been removed (get_node_status returns None)
+    ///
+    /// # When
+    /// - handle_zombie_node(5) is called (e.g. stale signal arrived after BatchRemove committed)
+    ///
+    /// # Then
+    /// - No config change is proposed (node is gone; re-proposing BatchRemove would flood the Raft log)
+    #[tokio::test]
+    async fn test_handle_zombie_node_absent_node_is_ignored() {
+        let (_graceful_tx, graceful_rx) = watch::channel(());
+        let cfg = node_config("/tmp/test_handle_zombie_node_absent_ignored");
+        let mut raft_context = MockBuilder::new(graceful_rx).with_node_config(cfg).build_context();
+
+        let mut membership = MockMembership::new();
+        // Node 5 is not in the cluster
+        membership.expect_get_node_status().returning(|_| None);
         raft_context.membership = Arc::new(membership);
 
         let captured_payloads = Arc::new(Mutex::new(Vec::<EntryPayload>::new()));
@@ -1767,7 +1769,7 @@ mod zombie_purge_tests {
             .handlers
             .replication_handler
             .expect_prepare_batch_requests()
-            .times(0) // Must NOT be called — ReadOnly node is exempt
+            .times(0) // Must NOT be called — node is already removed
             .returning(move |payloads, _, _, _, _| {
                 captured_clone.lock().extend(payloads.clone());
                 Ok(crate::PrepareResult::default())
@@ -1785,7 +1787,7 @@ mod zombie_purge_tests {
         assert!(result.is_ok());
         assert!(
             captured_payloads.lock().is_empty(),
-            "ReadOnly node must not be auto-removed"
+            "Absent node must not trigger a BatchRemove"
         );
     }
 }

--- a/d-engine-core/src/raft_role/leader_state_test/worker_lifecycle_test.rs
+++ b/d-engine-core/src/raft_role/leader_state_test/worker_lifecycle_test.rs
@@ -10,6 +10,7 @@
 //! actually executes `send_to_worker_or_spawn`.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use bytes::Bytes;
 use d_engine_proto::common::{EntryPayload, NodeRole::Follower, NodeStatus};
@@ -347,5 +348,99 @@ async fn test_worker_rebuilt_after_death() {
     assert!(
         matches!(event, RoleEvent::AppendResult { follower_id: 2, .. }),
         "expected AppendResult for peer 2, got {event:?}"
+    );
+}
+
+/// Replication worker exits its inner reconnect loop when the task channel is closed.
+///
+/// # Scenario
+/// - Transport always fails `open_replication_stream` (peer unreachable).
+/// - Worker is spawned via `process_batch`; it enters the inner reconnect loop.
+/// - The `LeaderState` is dropped, which drops `ReplicationWorkerHandle` and closes `task_rx`.
+/// - On the next iteration the worker checks `task_rx.is_closed()` and must exit cleanly
+///   without making further connection attempts.
+///
+/// # Guarantees checked
+/// - After the handle is dropped, `open_replication_stream` call count stops increasing.
+///   This proves the `if task_rx.is_closed() { return; }` guard fires correctly,
+///   preventing an infinite reconnect loop that would flood the Raft event loop with
+///   zombie signals and block heartbeats (regression: zombie detection + dead peer).
+#[tokio::test]
+#[traced_test]
+async fn test_replication_worker_exits_when_handle_dropped() {
+    let (_graceful_tx, graceful_rx) = watch::channel(());
+    let mut ctx = mock_raft_context(
+        "/tmp/test_replication_worker_exits_when_handle_dropped",
+        graceful_rx,
+        None,
+    );
+
+    ctx.membership = Arc::new(two_peer_membership());
+
+    ctx.handlers
+        .replication_handler
+        .expect_prepare_batch_requests()
+        .times(1)
+        .returning(|_, _, _, _, _| {
+            Ok(crate::PrepareResult {
+                append_requests: vec![(2, stub_request())],
+                snapshot_targets: vec![],
+            })
+        });
+
+    // Transport: open_replication_stream always fails (simulates dead peer).
+    // Counts total invocations so we can assert the worker stopped retrying after drop.
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let call_count_clone = Arc::clone(&call_count);
+    // Notifier fires after the first failure so the test knows the worker has entered the loop.
+    let (first_attempt_tx, mut first_attempt_rx) = tokio::sync::mpsc::channel::<()>(1);
+
+    let mut transport = MockTransport::<MockTypeConfig>::new();
+    transport
+        .expect_send_append_request()
+        .returning(|_, _, _, _, _| Ok(stub_response()));
+    transport.expect_open_replication_stream().returning(move |_, _, _| {
+        let n = call_count_clone.fetch_add(1, Ordering::SeqCst) + 1;
+        if n == 1 {
+            // Signal test that worker reached the reconnect loop.
+            let _ = first_attempt_tx.try_send(());
+        }
+        Err(crate::NetworkError::ConnectError("peer unreachable".into()).into())
+    });
+    ctx.transport = Arc::new(transport);
+
+    let mut raft_log = MockRaftLog::new();
+    raft_log.expect_last_entry_id().returning(|| 0);
+    raft_log.expect_flush().returning(|| Ok(()));
+    raft_log.expect_save_hard_state().returning(|_| Ok(()));
+    ctx.storage.raft_log = Arc::new(raft_log);
+
+    let mut state = LeaderState::<MockTypeConfig>::new(1, ctx.node_config.clone());
+    state.init_cluster_metadata(&ctx.membership).await.unwrap();
+
+    let (role_tx, _role_rx) = mpsc::unbounded_channel();
+    state.process_batch(one_entry_batch(), &role_tx, &ctx).await.unwrap();
+
+    // Wait until the worker has attempted at least one connection (entered inner loop).
+    tokio::time::timeout(std::time::Duration::from_secs(5), first_attempt_rx.recv())
+        .await
+        .expect("timed out waiting for first reconnect attempt");
+
+    // Drop LeaderState — drops all ReplicationWorkerHandles — closes task_rx for all workers.
+    drop(state);
+
+    // Record call count at drop time.
+    let count_at_drop = call_count.load(Ordering::SeqCst);
+
+    // Give the worker enough time to loop back and hit the is_closed() check.
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    let count_after_wait = call_count.load(Ordering::SeqCst);
+
+    assert_eq!(
+        count_at_drop, count_after_wait,
+        "open_replication_stream must not be called after task channel is closed \
+         (got {} calls at drop, {} after wait — worker did not exit)",
+        count_at_drop, count_after_wait
     );
 }

--- a/d-engine-core/src/raft_role/leader_state_test/worker_lifecycle_test.rs
+++ b/d-engine-core/src/raft_role/leader_state_test/worker_lifecycle_test.rs
@@ -424,7 +424,8 @@ async fn test_replication_worker_exits_when_handle_dropped() {
     // Wait until the worker has attempted at least one connection (entered inner loop).
     tokio::time::timeout(std::time::Duration::from_secs(5), first_attempt_rx.recv())
         .await
-        .expect("timed out waiting for first reconnect attempt");
+        .expect("timed out waiting for first reconnect attempt")
+        .expect("signal channel closed without a send — worker never entered reconnect loop");
 
     // Drop LeaderState — drops all ReplicationWorkerHandles — closes task_rx for all workers.
     drop(state);

--- a/d-engine-core/src/test_utils/mock/mock_rpc.rs
+++ b/d-engine-core/src/test_utils/mock/mock_rpc.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use d_engine_proto::client::ClientReadRequest;
 use d_engine_proto::client::ClientResponse;
 use d_engine_proto::client::ClientWriteRequest;
+use d_engine_proto::client::MembershipSnapshot as ProtoMembershipSnapshot;
+use d_engine_proto::client::WatchMembershipRequest;
 use d_engine_proto::client::WatchRequest;
 use d_engine_proto::client::WatchResponse;
 use d_engine_proto::client::raft_client_service_server::RaftClientService;
@@ -167,6 +169,9 @@ impl ClusterManagementService for MockRpcService {
 impl RaftClientService for MockRpcService {
     type WatchStream = tokio_stream::wrappers::ReceiverStream<Result<WatchResponse, tonic::Status>>;
 
+    type WatchMembershipStream =
+        tokio_stream::wrappers::ReceiverStream<Result<ProtoMembershipSnapshot, tonic::Status>>;
+
     async fn handle_client_write(
         &self,
         _request: tonic::Request<ClientWriteRequest>,
@@ -197,11 +202,17 @@ impl RaftClientService for MockRpcService {
         &self,
         _request: tonic::Request<WatchRequest>,
     ) -> std::result::Result<tonic::Response<Self::WatchStream>, tonic::Status> {
-        // Mock implementation: return an empty stream
         let (_tx, rx) = tokio::sync::mpsc::channel(1);
         Ok(tonic::Response::new(
             tokio_stream::wrappers::ReceiverStream::new(rx),
         ))
+    }
+
+    async fn watch_membership(
+        &self,
+        _request: tonic::Request<WatchMembershipRequest>,
+    ) -> std::result::Result<tonic::Response<Self::WatchMembershipStream>, tonic::Status> {
+        Err(tonic::Status::unimplemented("not used in mock"))
     }
 }
 

--- a/d-engine-proto/proto/client/client_api.proto
+++ b/d-engine-proto/proto/client/client_api.proto
@@ -177,7 +177,7 @@ service RaftClientService {
   // Watch for committed cluster membership changes.
   //
   // Immediately pushes the current MembershipSnapshot on connect, then pushes
-  // a new snapshot on every committed ConfChange (AddNode, Promote, Remove).
+  // a new snapshot on every committed ConfChange (AddNode, BatchPromote, BatchRemove).
   // All nodes (leader, follower, learner) emit the event after the entry commits.
   //
   // Stream lifecycle:

--- a/d-engine-proto/proto/client/client_api.proto
+++ b/d-engine-proto/proto/client/client_api.proto
@@ -100,6 +100,27 @@ message ReadResults {
   repeated ClientResult results = 1;
 }
 
+// Request to start a server-side membership watch stream.
+message WatchMembershipRequest {
+  uint32 client_id = 1;
+}
+
+// Point-in-time snapshot of committed cluster membership.
+//
+// Delivered on every committed ConfChange entry.
+// `committed_index` is strictly monotonically increasing and serves as an
+// idempotency key for schedulers.
+message MembershipSnapshot {
+  // Current voting members (Follower / Leader role).
+  repeated uint32 members = 1;
+
+  // Current non-voting learners.
+  repeated uint32 learners = 2;
+
+  // Raft log index of the ConfChange entry that produced this snapshot.
+  uint64 committed_index = 3;
+}
+
 // Watch event type indicating the type of change that occurred
 enum WatchEventType {
   // A key was inserted or updated
@@ -139,7 +160,7 @@ service RaftClientService {
   rpc HandleClientWrite(ClientWriteRequest) returns (ClientResponse);
   rpc HandleClientRead(ClientReadRequest) returns (ClientResponse);
 
-  // Watch for changes on a specific key
+  // Watch for changes to a specific key.
   //
   // Returns a stream of WatchResponse events whenever the watched key changes.
   // The stream remains open until the client cancels or disconnects.
@@ -152,4 +173,19 @@ service RaftClientService {
   // - If the internal event buffer is full, events may be dropped
   // - Clients should use Read API to re-sync if they detect gaps
   rpc Watch(WatchRequest) returns (stream WatchResponse);
+
+  // Watch for committed cluster membership changes.
+  //
+  // Immediately pushes the current MembershipSnapshot on connect, then pushes
+  // a new snapshot on every committed ConfChange (AddNode, Promote, Remove).
+  // All nodes (leader, follower, learner) emit the event after the entry commits.
+  //
+  // Stream lifecycle:
+  // - Stays open until the client cancels or the server shuts down.
+  // - On server shutdown the stream closes with Status::UNAVAILABLE.
+  //   Clients should reconnect and re-subscribe.
+  //
+  // Idempotency:
+  // - Use `committed_index` as an idempotency key in the receiver.
+  rpc WatchMembership(WatchMembershipRequest) returns (stream MembershipSnapshot);
 }

--- a/d-engine-proto/src/generated/d_engine.client.rs
+++ b/d-engine-proto/src/generated/d_engine.client.rs
@@ -118,6 +118,31 @@ pub struct ReadResults {
     #[prost(message, repeated, tag = "1")]
     pub results: ::prost::alloc::vec::Vec<ClientResult>,
 }
+/// Request to start a server-side membership watch stream.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct WatchMembershipRequest {
+    #[prost(uint32, tag = "1")]
+    pub client_id: u32,
+}
+/// Point-in-time snapshot of committed cluster membership.
+///
+/// Delivered on every committed ConfChange entry.
+/// `committed_index` is strictly monotonically increasing and serves as an
+/// idempotency key for schedulers.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MembershipSnapshot {
+    /// Current voting members (Follower / Leader role).
+    #[prost(uint32, repeated, tag = "1")]
+    pub members: ::prost::alloc::vec::Vec<u32>,
+    /// Current non-voting learners.
+    #[prost(uint32, repeated, tag = "2")]
+    pub learners: ::prost::alloc::vec::Vec<u32>,
+    /// Raft log index of the ConfChange entry that produced this snapshot.
+    #[prost(uint64, tag = "3")]
+    pub committed_index: u64,
+}
 /// Request to watch for changes on a specific key
 ///
 /// In v1, only exact key matching is supported.
@@ -372,7 +397,7 @@ pub mod raft_client_service_client {
                 );
             self.inner.unary(req, path, codec).await
         }
-        /// Watch for changes on a specific key
+        /// Watch for changes to a specific key.
         ///
         /// Returns a stream of WatchResponse events whenever the watched key changes.
         /// The stream remains open until the client cancels or disconnects.
@@ -408,6 +433,48 @@ pub mod raft_client_service_client {
                 .insert(GrpcMethod::new("d_engine.client.RaftClientService", "Watch"));
             self.inner.server_streaming(req, path, codec).await
         }
+        /// Watch for committed cluster membership changes.
+        ///
+        /// Immediately pushes the current MembershipSnapshot on connect, then pushes
+        /// a new snapshot on every committed ConfChange (AddNode, Promote, Remove).
+        /// All nodes (leader, follower, learner) emit the event after the entry commits.
+        ///
+        /// Stream lifecycle:
+        /// - Stays open until the client cancels or the server shuts down.
+        /// - On server shutdown the stream closes with Status::UNAVAILABLE.
+        ///   Clients should reconnect and re-subscribe.
+        ///
+        /// Idempotency:
+        /// - Use `committed_index` as an idempotency key in the receiver.
+        pub async fn watch_membership(
+            &mut self,
+            request: impl tonic::IntoRequest<super::WatchMembershipRequest>,
+        ) -> std::result::Result<
+            tonic::Response<tonic::codec::Streaming<super::MembershipSnapshot>>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/d_engine.client.RaftClientService/WatchMembership",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "d_engine.client.RaftClientService",
+                        "WatchMembership",
+                    ),
+                );
+            self.inner.server_streaming(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -437,7 +504,7 @@ pub mod raft_client_service_server {
             >
             + std::marker::Send
             + 'static;
-        /// Watch for changes on a specific key
+        /// Watch for changes to a specific key.
         ///
         /// Returns a stream of WatchResponse events whenever the watched key changes.
         /// The stream remains open until the client cancels or disconnects.
@@ -453,6 +520,32 @@ pub mod raft_client_service_server {
             &self,
             request: tonic::Request<super::WatchRequest>,
         ) -> std::result::Result<tonic::Response<Self::WatchStream>, tonic::Status>;
+        /// Server streaming response type for the WatchMembership method.
+        type WatchMembershipStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<super::MembershipSnapshot, tonic::Status>,
+            >
+            + std::marker::Send
+            + 'static;
+        /// Watch for committed cluster membership changes.
+        ///
+        /// Immediately pushes the current MembershipSnapshot on connect, then pushes
+        /// a new snapshot on every committed ConfChange (AddNode, Promote, Remove).
+        /// All nodes (leader, follower, learner) emit the event after the entry commits.
+        ///
+        /// Stream lifecycle:
+        /// - Stays open until the client cancels or the server shuts down.
+        /// - On server shutdown the stream closes with Status::UNAVAILABLE.
+        ///   Clients should reconnect and re-subscribe.
+        ///
+        /// Idempotency:
+        /// - Use `committed_index` as an idempotency key in the receiver.
+        async fn watch_membership(
+            &self,
+            request: tonic::Request<super::WatchMembershipRequest>,
+        ) -> std::result::Result<
+            tonic::Response<Self::WatchMembershipStream>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct RaftClientServiceServer<T> {
@@ -659,6 +752,54 @@ pub mod raft_client_service_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = WatchSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.server_streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/d_engine.client.RaftClientService/WatchMembership" => {
+                    #[allow(non_camel_case_types)]
+                    struct WatchMembershipSvc<T: RaftClientService>(pub Arc<T>);
+                    impl<
+                        T: RaftClientService,
+                    > tonic::server::ServerStreamingService<
+                        super::WatchMembershipRequest,
+                    > for WatchMembershipSvc<T> {
+                        type Response = super::MembershipSnapshot;
+                        type ResponseStream = T::WatchMembershipStream;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::WatchMembershipRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as RaftClientService>::watch_membership(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = WatchMembershipSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/d-engine-server/src/api/embedded.rs
+++ b/d-engine-server/src/api/embedded.rs
@@ -146,6 +146,7 @@ struct Inner {
     shutdown_tx: watch::Sender<()>,
     client: Arc<EmbeddedClient>,
     leader_elected_rx: watch::Receiver<Option<crate::LeaderInfo>>,
+    membership_rx: watch::Receiver<crate::membership::MembershipSnapshot>,
     is_stopped: Mutex<bool>,
     node_id: u32,
 }
@@ -325,8 +326,9 @@ impl EmbeddedEngine {
             .start()
             .await?;
 
-        // Get leader change notifier before moving node
+        // Get notifiers before node is moved into the background task.
         let leader_elected_rx = node.leader_change_notifier();
+        let membership_rx = node.membership_change_notifier();
 
         // Create client before spawning
         #[cfg(not(feature = "watch"))]
@@ -372,6 +374,7 @@ impl EmbeddedEngine {
                 shutdown_tx,
                 client,
                 leader_elected_rx,
+                membership_rx,
                 is_stopped: Mutex::new(false),
                 node_id,
             }),
@@ -471,6 +474,37 @@ impl EmbeddedEngine {
     /// ```
     pub fn leader_change_notifier(&self) -> watch::Receiver<Option<crate::LeaderInfo>> {
         self.inner.leader_elected_rx.clone()
+    }
+
+    /// Subscribe to committed membership change notifications.
+    ///
+    /// Returns a `watch::Receiver` that fires whenever a `ConfChange` entry
+    /// (node join, removal, or learner promotion) is committed by a majority.
+    ///
+    /// All nodes — leader, follower, and learner — fire the notification because
+    /// every node walks the same `CommitHandler::apply_config_change()` path.
+    ///
+    /// The first `borrow()` returns the current membership state immediately
+    /// without waiting for a change.
+    ///
+    /// ## Distinguishing this from other notifiers
+    ///
+    /// - [`leader_change_notifier`]: fires on leader election changes, **not** membership changes
+    /// - [`ready_notifier`]: fires when the local RPC server is ready, **not** membership changes
+    ///
+    /// ## Usage
+    /// ```ignore
+    /// let mut rx = engine.watch_membership();
+    /// while rx.changed().await.is_ok() {
+    ///     let snapshot = rx.borrow_and_update().clone();
+    ///     // snapshot.members — current voters
+    ///     // snapshot.learners — current non-voting learners
+    ///     // snapshot.committed_index — idempotency key
+    ///     scheduler.on_membership_changed(snapshot).await;
+    /// }
+    /// ```
+    pub fn watch_membership(&self) -> watch::Receiver<crate::membership::MembershipSnapshot> {
+        self.inner.membership_rx.clone()
     }
 
     /// Returns true if the current node is the Raft leader.

--- a/d-engine-server/src/lib.rs
+++ b/d-engine-server/src/lib.rs
@@ -115,6 +115,7 @@ pub mod storage;
 // -------------------- Primary Entry Points --------------------
 pub use api::EmbeddedEngine;
 pub use api::StandaloneEngine;
+pub use membership::MembershipSnapshot;
 // -------------------- Error Types --------------------
 /// Unified error type for all d-engine operations
 pub use d_engine_core::Error;

--- a/d-engine-server/src/membership/membership_snapshot.rs
+++ b/d-engine-server/src/membership/membership_snapshot.rs
@@ -1,0 +1,46 @@
+use std::collections::BTreeSet;
+
+/// A point-in-time snapshot of committed cluster membership.
+///
+/// Delivered via [`EmbeddedEngine::watch_membership`] whenever a `ConfChange`
+/// entry commits.  The snapshot reflects the membership state **after** the
+/// change has been applied, so `borrow()` always returns a consistent view.
+///
+/// ## Idempotency
+///
+/// `committed_index` is the Raft log index of the `ConfChange` entry that
+/// triggered this snapshot.  It is strictly monotonically increasing across
+/// snapshots and can be used as an idempotency key:
+///
+/// ```ignore
+/// if snapshot.committed_index <= self.last_applied {
+///     return; // already handled
+/// }
+/// self.last_applied = snapshot.committed_index;
+/// scheduler.rebalance(&snapshot);
+/// ```
+///
+/// ## Diff computation
+///
+/// No diff fields are included.  Because `watch::channel` is lossy (only the
+/// latest value is retained), a diff embedded in the snapshot could be stale
+/// if the receiver is slow and skips an intermediate change.  Callers that
+/// need a diff should compute it against their own previous snapshot:
+///
+/// ```ignore
+/// let prev = std::mem::replace(&mut self.prev_snapshot, snapshot.clone());
+/// let joined: BTreeSet<_> = snapshot.members.difference(&prev.members).copied().collect();
+/// let left:   BTreeSet<_> = prev.members.difference(&snapshot.members).copied().collect();
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct MembershipSnapshot {
+    /// Current voting members (Follower / Leader role, Active status).
+    pub members: BTreeSet<u32>,
+
+    /// Current non-voting learners (Learner role, Promotable or ReadOnly status).
+    pub learners: BTreeSet<u32>,
+
+    /// Raft log index of the ConfChange entry that produced this snapshot.
+    /// Monotonically increasing; use as an idempotency key.
+    pub committed_index: u64,
+}

--- a/d-engine-server/src/membership/mod.rs
+++ b/d-engine-server/src/membership/mod.rs
@@ -1,6 +1,8 @@
 mod membership_guard;
+mod membership_snapshot;
 mod raft_membership;
 pub(crate) use membership_guard::*;
+pub use membership_snapshot::*;
 pub use raft_membership::*;
 
 #[cfg(test)]

--- a/d-engine-server/src/membership/raft_membership.rs
+++ b/d-engine-server/src/membership/raft_membership.rs
@@ -12,6 +12,7 @@
 //! by `rpc_peer_channels`) but depends on its correct initialization. All Raft
 //! protocol decisions are made based on the state maintained here.
 
+use std::collections::BTreeSet;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
@@ -43,6 +44,7 @@ use tracing::info;
 use tracing::warn;
 
 use super::MembershipGuard;
+use super::MembershipSnapshot;
 use crate::network::ConnectionCache;
 use crate::network::HealthChecker;
 use crate::network::HealthCheckerApis;
@@ -62,6 +64,9 @@ where
     initial_cluster_size: usize,
     pub(super) health_monitor: RaftHealthMonitor,
     pub(super) connection_cache: ConnectionCache,
+    /// Sender for committed membership change notifications.
+    /// Fires in `notify_config_applied()` after every ConfChange commit.
+    membership_notifier_tx: tokio::sync::watch::Sender<MembershipSnapshot>,
     _phantom: PhantomData<T>,
 }
 
@@ -436,13 +441,22 @@ where
         info!("Adding learner node: {} with status: {:?}", node_id, status);
         self.membership
             .blocking_write(|guard| {
-                if guard.nodes.contains_key(&node_id) {
+                if let Some(existing) = guard.nodes.get(&node_id) {
+                    if existing.role == Learner as i32 {
+                        // Idempotent: learner already present. This happens when a learner node
+                        // applies its own committed AddNode entry while it already has itself
+                        // in its initial cluster config. The state is correct; no-op.
+                        info!(
+                            "[node-{}] AddLearner: node {} already a learner, treating as idempotent",
+                            self.node_id, node_id
+                        );
+                        return Ok(());
+                    }
                     error!(
-                        "[node-{}] Adding a learner node failed: node already exists. {}",
-                        self.node_id, node_id
+                        "[node-{}] Adding a learner node failed: node {} already exists as non-learner role={}",
+                        self.node_id, node_id, existing.role
                     );
                     return Err(MembershipError::NodeAlreadyExists(node_id).into());
-                    // return  Ok(());
                 }
                 guard.nodes.insert(
                     node_id,
@@ -592,7 +606,10 @@ where
         // Use cached connection if available
         match self.connection_cache.get_channel(node_id, conn_type, addr).await {
             Ok(channel) => {
-                self.health_monitor.record_success(node_id).await;
+                // Do NOT call record_success here: tonic Endpoint::connect() is lazy and
+                // returns Ok even for stopped peers. Health state must be driven by actual
+                // RPC results, not by channel acquisition. Use on_peer_stream_failed() when
+                // stream_append_entries (or equivalent) fails.
                 Some(channel)
             }
             Err(e) => {
@@ -687,17 +704,28 @@ where
         &self,
         index: u64,
     ) {
-        // TODO:
-        // // Update replication layer
-        // self.config.replication_layer.update_peers(
-        //     self.replication_peers().await
-        // ).await;
-
-        // // Update leader routing
-        // if let Some(leader) = self.get_cluster_conf_version().await {
-        //     self.config.router.update_leader(leader);
-        // }
-        info!("Config change applied at index {}", index);
+        let snapshot = self
+            .membership
+            .blocking_read(|guard| {
+                let mut members = BTreeSet::new();
+                let mut learners = BTreeSet::new();
+                for node in guard.nodes.values() {
+                    if node.role == Learner as i32 {
+                        learners.insert(node.id);
+                    } else {
+                        members.insert(node.id);
+                    }
+                }
+                MembershipSnapshot {
+                    members,
+                    learners,
+                    committed_index: index,
+                }
+            })
+            .await;
+        // send_replace never fails — silently drops the value if all receivers are gone.
+        self.membership_notifier_tx.send_replace(snapshot);
+        info!("Membership change committed at index {}", index);
     }
 
     async fn can_rejoin(
@@ -725,6 +753,9 @@ where
 {
     /// Returns `(Self, zombie_rx)`. Caller must pass `zombie_rx` to the Raft event loop
     /// so that `ZombieDetected` signals reach the leader.
+    ///
+    /// Call [`subscribe_membership`] on the returned `Self` to obtain a
+    /// `watch::Receiver<MembershipSnapshot>` for in-process change notifications.
     pub(crate) fn new(
         node_id: u32,
         initial_nodes: Vec<NodeMeta>,
@@ -734,6 +765,27 @@ where
         let connection_cache = ConnectionCache::new(config.network.clone());
         let initial_cluster_size = initial_nodes.len();
         let (health_monitor, zombie_rx) = RaftHealthMonitor::new(zombie_threshold);
+
+        // Build the initial snapshot from the configured nodes so that the
+        // first `borrow()` on any receiver returns a valid state.
+        let initial_snapshot = {
+            let mut members = BTreeSet::new();
+            let mut learners = BTreeSet::new();
+            for node in &initial_nodes {
+                if node.role == Learner as i32 {
+                    learners.insert(node.id);
+                } else {
+                    members.insert(node.id);
+                }
+            }
+            MembershipSnapshot {
+                members,
+                learners,
+                committed_index: 0,
+            }
+        };
+        let (membership_notifier_tx, _initial_rx) = tokio::sync::watch::channel(initial_snapshot);
+
         (
             Self {
                 node_id,
@@ -743,9 +795,18 @@ where
                 _phantom: PhantomData,
                 health_monitor,
                 connection_cache,
+                membership_notifier_tx,
             },
             zombie_rx,
         )
+    }
+
+    /// Subscribe to committed membership change notifications.
+    ///
+    /// The returned receiver immediately has the current snapshot available
+    /// via `borrow()` — no need to wait for a change event.
+    pub fn subscribe_membership(&self) -> tokio::sync::watch::Receiver<MembershipSnapshot> {
+        self.membership_notifier_tx.subscribe()
     }
 
     /// Returns true if the zombie signal for `node_id` should still be acted on.
@@ -758,6 +819,32 @@ where
         node_id: u32,
     ) -> bool {
         self.health_monitor.is_zombie_valid(node_id)
+    }
+
+    /// Called by the transport layer when `stream_append_entries` succeeds.
+    /// Resets the failure counter so that transient errors don't accumulate into
+    /// a false zombie signal for a healthy peer.
+    ///
+    /// Intentionally NOT on the `Membership` trait — no dyn dispatch.
+    pub(crate) async fn on_peer_stream_success(
+        &self,
+        node_id: u32,
+    ) {
+        self.health_monitor.record_success(node_id).await;
+    }
+
+    /// Called by the transport layer when `stream_append_entries` (or any peer RPC)
+    /// fails. Evicts the stale cached channel and records a health failure so that
+    /// zombie detection can fire at the configured threshold.
+    ///
+    /// Intentionally NOT on the `Membership` trait — this is a concrete-type method
+    /// that keeps health monitoring out of the trait boundary (no dyn dispatch).
+    pub(crate) async fn on_peer_stream_failed(
+        &self,
+        node_id: u32,
+    ) {
+        self.connection_cache.remove_node(node_id);
+        self.health_monitor.record_failure(node_id).await;
     }
 
     /// Updates a single node atomically

--- a/d-engine-server/src/membership/raft_membership.rs
+++ b/d-engine-server/src/membership/raft_membership.rs
@@ -446,10 +446,18 @@ where
                         // Idempotent: learner already present. This happens when a learner node
                         // applies its own committed AddNode entry while it already has itself
                         // in its initial cluster config. The state is correct; no-op.
-                        info!(
-                            "[node-{}] AddLearner: node {} already a learner, treating as idempotent",
-                            self.node_id, node_id
-                        );
+                        if existing.address != address {
+                            warn!(
+                                "[node-{}] AddLearner idempotent: node {} address mismatch \
+                                 (stored={}, incoming={}) — keeping stored address",
+                                self.node_id, node_id, existing.address, address
+                            );
+                        } else {
+                            info!(
+                                "[node-{}] AddLearner: node {} already a learner, treating as idempotent",
+                                self.node_id, node_id
+                            );
+                        }
                         return Ok(());
                     }
                     error!(

--- a/d-engine-server/src/membership/raft_membership_test.rs
+++ b/d-engine-server/src/membership/raft_membership_test.rs
@@ -1129,14 +1129,72 @@ async fn test_health_monitoring_integration() {
         "ZombieDetected signal should fire for node 100"
     );
 
-    // Test 3: Record success resets failures
-    // Update to valid address (using mock would be better in real impl)
+    // Test 3: get_peer_channel success does NOT reset failure counts.
+    // tonic Endpoint::connect() is lazy — channel creation succeeds even for a stopped peer.
+    // Health state must be driven by RPC results (on_peer_stream_failed), not by channel acquisition.
     let (_tx, rx) = oneshot::channel::<()>();
     let service = MockRpcService::default();
     let (port, _addr) = MockNode::mock_listener(service, rx, true).await.unwrap();
     membership.update_node_address(100, format!("127.0.0.1:{port}")).await.unwrap();
-    membership.get_peer_channel(100, ConnectionType::Control).await; // Should "succeed"
-    assert!(membership.health_monitor.failure_counts.get(&100).is_none());
+    membership.get_peer_channel(100, ConnectionType::Control).await;
+    assert!(
+        membership.health_monitor.failure_counts.get(&100).is_some(),
+        "get_peer_channel success must NOT reset failure counts: health state is driven by RPC results only"
+    );
+}
+
+/// `on_peer_stream_failed` must evict the cached channel AND record a connection failure.
+///
+/// When `stream_append_entries` fails on a tonic lazy channel (which reports Ok at creation
+/// but fails on first RPC), the caller invokes `on_peer_stream_failed` to:
+/// 1. Evict the stale channel so the next attempt creates a fresh one.
+/// 2. Increment the failure count so zombie detection can fire.
+#[tokio::test]
+#[traced_test]
+async fn test_on_peer_stream_failed_evicts_cache_and_records_failure() {
+    let mut config = RaftNodeConfig::default();
+    config.raft.membership.zombie.threshold = 1;
+
+    let (membership, mut zombie_rx) = RaftMembership::<MockTypeConfig>::new(1, vec![], config);
+
+    // Add a node with a live address so get_peer_channel can populate the cache.
+    let (_tx, rx) = oneshot::channel::<()>();
+    let service = MockRpcService::default();
+    let (port, _addr) = MockNode::mock_listener(service, rx, true).await.unwrap();
+    membership
+        .add_learner(200, format!("127.0.0.1:{port}"), NodeStatus::Active)
+        .await
+        .unwrap();
+
+    // Warm the connection cache for node 200.
+    let channel = membership.get_peer_channel(200, ConnectionType::Data).await;
+    assert!(
+        channel.is_some(),
+        "Initial channel acquisition must succeed"
+    );
+    let cached = membership.connection_cache.cache.iter().any(|e| e.key().0 == 200);
+    assert!(
+        cached,
+        "Cache must hold an entry for node 200 after get_peer_channel"
+    );
+
+    // Simulate bidi stream failure (e.g. stream_append_entries returned an error).
+    membership.on_peer_stream_failed(200).await;
+
+    // Cache entry for node 200 must be fully evicted (all connection types).
+    let still_cached = membership.connection_cache.cache.iter().any(|e| e.key().0 == 200);
+    assert!(
+        !still_cached,
+        "on_peer_stream_failed must evict all cached channels for node 200"
+    );
+
+    // record_failure must have been called → with threshold=1 the zombie signal fires immediately.
+    let signal = zombie_rx.try_recv();
+    assert_eq!(
+        signal.ok(),
+        Some(200),
+        "on_peer_stream_failed must trigger zombie signal at threshold=1"
+    );
 }
 
 #[cfg(test)]

--- a/d-engine-server/src/network/grpc/grpc_raft_service.rs
+++ b/d-engine-server/src/network/grpc/grpc_raft_service.rs
@@ -15,6 +15,8 @@ use d_engine_core::TypeConfig;
 use d_engine_proto::client::ClientReadRequest;
 use d_engine_proto::client::ClientResponse;
 use d_engine_proto::client::ClientWriteRequest;
+use d_engine_proto::client::MembershipSnapshot as ProtoMembershipSnapshot;
+use d_engine_proto::client::WatchMembershipRequest;
 use d_engine_proto::client::WatchRequest;
 use d_engine_proto::client::raft_client_service_server::RaftClientService;
 use d_engine_proto::server::cluster::ClusterConfChangeRequest;
@@ -37,7 +39,6 @@ use d_engine_proto::server::storage::SnapshotChunk;
 use d_engine_proto::server::storage::SnapshotResponse;
 use d_engine_proto::server::storage::snapshot_service_server::SnapshotService;
 use futures::Stream;
-#[cfg(feature = "watch")]
 use futures::StreamExt;
 use tokio::select;
 use tokio::sync::mpsc;
@@ -49,7 +50,6 @@ use tonic::Status;
 use tonic::Streaming;
 use tracing::debug;
 use tracing::error;
-#[cfg(feature = "watch")]
 use tracing::info;
 use tracing::warn;
 
@@ -380,6 +380,9 @@ where
     type WatchStream =
         Pin<Box<dyn Stream<Item = Result<d_engine_proto::client::WatchResponse, Status>> + Send>>;
 
+    type WatchMembershipStream =
+        Pin<Box<dyn Stream<Item = Result<ProtoMembershipSnapshot, Status>> + Send>>;
+
     /// Processes client write requests requiring consensus
     /// # Raft Protocol Logic
     /// - Entry point for client proposals (Section 7)
@@ -515,6 +518,43 @@ where
         Err(Status::unimplemented(
             "Watch feature is not compiled in this build",
         ))
+    }
+
+    /// Stream committed membership snapshots to the client.
+    ///
+    /// Sends the current snapshot immediately on connect (via `mark_changed`), then
+    /// one snapshot per committed ConfChange. Closes with UNAVAILABLE on server shutdown
+    /// so clients know to reconnect.
+    async fn watch_membership(
+        &self,
+        _request: tonic::Request<WatchMembershipRequest>,
+    ) -> std::result::Result<tonic::Response<Self::WatchMembershipStream>, tonic::Status> {
+        if !self.is_rpc_ready() {
+            warn!("[watch_membership] Node-{} is not ready", self.node_id);
+            return Err(Status::unavailable("Service is not ready"));
+        }
+
+        let mut rx = self.membership_rx.clone();
+        // Deliver the current snapshot immediately; subsequent items arrive on each ConfChange.
+        rx.mark_changed();
+
+        info!(node_id = self.node_id, "Membership watch stream opened");
+
+        let stream = tokio_stream::wrappers::WatchStream::new(rx)
+            .map(|s| {
+                Ok(ProtoMembershipSnapshot {
+                    members: s.members.into_iter().collect(),
+                    learners: s.learners.into_iter().collect(),
+                    committed_index: s.committed_index,
+                })
+            })
+            .chain(futures::stream::once(async {
+                Err(Status::unavailable(
+                    "Membership watch stream closed: server shut down. Reconnect to re-subscribe.",
+                ))
+            }));
+
+        Ok(tonic::Response::new(Box::pin(stream)))
     }
 }
 

--- a/d-engine-server/src/network/grpc/grpc_raft_service_test.rs
+++ b/d-engine-server/src/network/grpc/grpc_raft_service_test.rs
@@ -14,6 +14,7 @@ use d_engine_core::convert::safe_kv_bytes;
 use d_engine_proto::client::ClientReadRequest;
 use d_engine_proto::client::ClientWriteRequest;
 use d_engine_proto::client::ReadConsistencyPolicy;
+use d_engine_proto::client::WatchMembershipRequest;
 use d_engine_proto::client::WriteCommand;
 use d_engine_proto::client::raft_client_service_server::RaftClientService;
 use d_engine_proto::common::LogId;
@@ -390,4 +391,73 @@ async fn test_handle_rpc_services_successfully() {
 
     // Assert if the handle client propose result is ok.
     assert!(service_response.is_ok());
+}
+
+// =============================================================================
+// WatchMembership unit tests
+// =============================================================================
+
+/// Node not ready → watch_membership must return UNAVAILABLE immediately.
+///
+/// Guards the readiness check path; without it, clients could subscribe to a
+/// node that hasn't joined the cluster yet and receive stale/empty data.
+#[tokio::test]
+#[traced_test]
+async fn test_watch_membership_returns_unavailable_when_node_not_ready() {
+    let (_shutdown_tx, shutdown_rx) = watch::channel(());
+    let node = mock_node("/tmp/test_watch_membership_not_ready", shutdown_rx, None);
+    node.set_rpc_ready(false);
+
+    let result = node
+        .watch_membership(Request::new(WatchMembershipRequest { client_id: 1 }))
+        .await;
+
+    assert!(result.is_err());
+    assert_eq!(result.err().unwrap().code(), Code::Unavailable);
+}
+
+/// Node ready with default (empty) snapshot → stream yields the current snapshot
+/// immediately (via mark_changed), then the sentinel UNAVAILABLE when the sender
+/// is dropped (mock_node drops the membership_tx).
+///
+/// This test validates the two-phase stream lifecycle:
+/// 1. Initial state delivery on connect (mark_changed behavior)
+/// 2. Sentinel error delivery when the server-side channel closes
+#[tokio::test]
+#[traced_test]
+async fn test_watch_membership_yields_current_snapshot_then_sentinel_on_sender_drop() {
+    use tokio_stream::StreamExt;
+
+    let (_shutdown_tx, shutdown_rx) = watch::channel(());
+    let node = mock_node(
+        "/tmp/test_watch_membership_snapshot_then_sentinel",
+        shutdown_rx,
+        None,
+    );
+    node.set_rpc_ready(true);
+
+    let response = node
+        .watch_membership(Request::new(WatchMembershipRequest { client_id: 1 }))
+        .await
+        .expect("watch_membership should succeed when node is ready");
+
+    let mut stream = response.into_inner();
+
+    // First item: current snapshot (mark_changed causes immediate delivery).
+    // mock_node initialises membership_rx with MembershipSnapshot::default().
+    let first = stream.next().await.expect("stream must yield at least one item");
+    assert!(first.is_ok(), "first item must be Ok(snapshot)");
+    let snap = first.unwrap();
+    assert!(snap.members.is_empty(), "default snapshot has no voters");
+    assert!(snap.learners.is_empty(), "default snapshot has no learners");
+    assert_eq!(snap.committed_index, 0, "default committed_index is 0");
+
+    // Second item: sentinel error — mock_node drops the sender, so WatchStream ends
+    // and the chained sentinel fires.
+    let second = stream.next().await.expect("stream must yield sentinel");
+    assert!(second.is_err(), "sentinel must be Err(UNAVAILABLE)");
+    assert_eq!(second.unwrap_err().code(), Code::Unavailable);
+
+    // Stream is exhausted after the sentinel.
+    assert!(stream.next().await.is_none());
 }

--- a/d-engine-server/src/network/grpc/grpc_transport.rs
+++ b/d-engine-server/src/network/grpc/grpc_transport.rs
@@ -74,6 +74,15 @@ where
 
     peer_appenders: Arc<DashMap<u32, PeerAppender>>,
 
+    /// Fire-and-forget channel to report peer stream failures for zombie detection.
+    /// `None` in tests that construct via `GrpcTransport::new(node_id)`.
+    peer_failure_tx: Option<mpsc::Sender<u32>>,
+
+    /// Fire-and-forget channel to report peer stream success for health recovery.
+    /// Resets the failure counter so transient errors don't accumulate into false zombies.
+    /// `None` in tests that construct via `GrpcTransport::new(node_id)`.
+    peer_success_tx: Option<mpsc::Sender<u32>>,
+
     // -- Type System Marker --
     /// Phantom data for type parameter anchoring
     _marker: PhantomData<T>,
@@ -508,10 +517,22 @@ where
                 .send_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Gzip);
         }
-        let response = client
-            .stream_append_entries(tonic::Request::new(req_stream))
-            .await
-            .map_err(|e| NetworkError::TonicStatusError(Box::new(e)))?;
+        let response = match client.stream_append_entries(tonic::Request::new(req_stream)).await {
+            Ok(r) => {
+                // TCP handshake confirmed: reset failure counter to prevent false zombie signals.
+                if let Some(tx) = &self.peer_success_tx {
+                    let _ = tx.try_send(peer_id);
+                }
+                r
+            }
+            Err(e) => {
+                // Actual TCP failure: notify health monitor so zombie detection can fire.
+                if let Some(tx) = &self.peer_failure_tx {
+                    let _ = tx.try_send(peer_id);
+                }
+                return Err(NetworkError::TonicStatusError(Box::new(e)).into());
+            }
+        };
 
         let receiver = response.into_inner().boxed();
 
@@ -573,10 +594,32 @@ impl<T> GrpcTransport<T>
 where
     T: TypeConfig,
 {
+    #[cfg(test)]
     pub(crate) fn new(node_id: u32) -> Self {
         Self {
             my_id: node_id,
             peer_appenders: Arc::new(DashMap::new()),
+            peer_failure_tx: None,
+            peer_success_tx: None,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Constructs a transport wired to peer-failure and peer-success channels.
+    ///
+    /// `peer_failure_tx` is fired when `stream_append_entries` fails (enables zombie detection).
+    /// `peer_success_tx` is fired on success (resets failure counter, prevents false zombies).
+    /// Use in production builds via `NodeBuilder`; tests use `new()`.
+    pub(crate) fn new_with_channels(
+        node_id: u32,
+        peer_failure_tx: mpsc::Sender<u32>,
+        peer_success_tx: mpsc::Sender<u32>,
+    ) -> Self {
+        Self {
+            my_id: node_id,
+            peer_appenders: Arc::new(DashMap::new()),
+            peer_failure_tx: Some(peer_failure_tx),
+            peer_success_tx: Some(peer_success_tx),
             _marker: PhantomData,
         }
     }

--- a/d-engine-server/src/node/builder.rs
+++ b/d-engine-server/src/node/builder.rs
@@ -325,7 +325,13 @@ where
             log.start(receiver, Some(role_tx.clone()))
         };
 
-        let transport = self.transport.take().unwrap_or(GrpcTransport::new(node_id));
+        // Peer health channels: transport fires try_send(peer_id) on stream failure/success.
+        // Bridge tasks below relay to membership so zombie detection and health recovery both work.
+        let (peer_failure_tx, peer_failure_rx) = mpsc::channel::<u32>(64);
+        let (peer_success_tx, peer_success_rx) = mpsc::channel::<u32>(64);
+        let transport = self.transport.take().unwrap_or_else(|| {
+            GrpcTransport::new_with_channels(node_id, peer_failure_tx, peer_success_tx)
+        });
 
         let snapshot_policy = self.snapshot_policy.take().unwrap_or(LogSizePolicy::new(
             node_config.raft.snapshot.max_log_entries_before_snapshot,
@@ -392,6 +398,8 @@ where
             },
         );
         let membership = Arc::new(membership_inner);
+        // Capture the membership watch receiver before membership is moved into Node.
+        let membership_rx = membership.subscribe_membership();
 
         let purge_executor = DefaultPurgeExecutor::new(raft_log.clone());
 
@@ -414,6 +422,26 @@ where
                 if membership_for_zombie.is_zombie_valid(node_id) {
                     let _ = role_tx_for_zombie.send(RoleEvent::ZombieDetected(node_id));
                 }
+            }
+        });
+
+        // Bridge peer stream failures from transport → health monitor.
+        // Exits naturally when transport (and its peer_failure_tx) drops (channel closed → recv None).
+        let membership_for_peer_failure = Arc::clone(&membership);
+        tokio::spawn(async move {
+            let mut peer_failure_rx = peer_failure_rx;
+            while let Some(failed_peer_id) = peer_failure_rx.recv().await {
+                membership_for_peer_failure.on_peer_stream_failed(failed_peer_id).await;
+            }
+        });
+
+        // Bridge peer stream successes from transport → health monitor.
+        // Resets failure counter so transient errors during failover don't accumulate into false zombies.
+        let membership_for_peer_success = Arc::clone(&membership);
+        tokio::spawn(async move {
+            let mut peer_success_rx = peer_success_rx;
+            while let Some(succeeded_peer_id) = peer_success_rx.recv().await {
+                membership_for_peer_success.on_peer_stream_success(succeeded_peer_id).await;
             }
         });
 
@@ -529,6 +557,7 @@ where
             ready: AtomicBool::new(false),
             rpc_ready_tx,
             leader_notifier,
+            membership_rx,
             node_config: node_config_arc,
             #[cfg(feature = "watch")]
             watch_registry: watch_system.as_ref().map(|(_, reg, _)| Arc::clone(reg)),

--- a/d-engine-server/src/node/mod.rs
+++ b/d-engine-server/src/node/mod.rs
@@ -93,6 +93,9 @@ where
     /// Notifies when leader is elected (includes leader changes)
     pub(crate) leader_notifier: LeaderNotifier,
 
+    /// Current membership snapshot; fires on every committed ConfChange.
+    pub(crate) membership_rx: watch::Receiver<crate::membership::MembershipSnapshot>,
+
     /// Raft node config
     pub(crate) node_config: Arc<RaftNodeConfig>,
 
@@ -304,6 +307,17 @@ where
     /// ```
     pub fn leader_change_notifier(&self) -> watch::Receiver<Option<crate::LeaderInfo>> {
         self.leader_notifier.subscribe()
+    }
+
+    /// Subscribe to committed membership change notifications.
+    ///
+    /// Returns a `watch::Receiver` that fires whenever a `ConfChange` entry
+    /// commits.  The first `borrow()` returns the current membership state
+    /// without waiting for a change.
+    pub fn membership_change_notifier(
+        &self
+    ) -> watch::Receiver<crate::membership::MembershipSnapshot> {
+        self.membership_rx.clone()
     }
 
     /// Returns this node's unique identifier.

--- a/d-engine-server/src/test_utils/mock/mock_node_builder.rs
+++ b/d-engine-server/src/test_utils/mock/mock_node_builder.rs
@@ -38,6 +38,7 @@ use tracing::trace;
 
 use super::MockTypeConfig;
 use crate::Node;
+use crate::membership::MembershipSnapshot;
 use crate::network::grpc;
 use crate::node::LeaderNotifier;
 
@@ -317,6 +318,7 @@ impl MockBuilder {
         let membership = raft.ctx.membership.clone();
         let (rpc_ready_tx, _rpc_ready_rx) = watch::channel(false);
         let leader_notifier = LeaderNotifier::new();
+        let (_membership_tx, membership_rx) = watch::channel(MembershipSnapshot::default());
 
         Node::<MockTypeConfig> {
             node_id: raft.node_id,
@@ -327,6 +329,7 @@ impl MockBuilder {
             ready: AtomicBool::new(false),
             rpc_ready_tx,
             leader_notifier,
+            membership_rx,
             node_config,
             #[cfg(feature = "watch")]
             watch_registry: None,
@@ -364,6 +367,7 @@ impl MockBuilder {
         let node_config_arc = Arc::new(node_config);
         let (rpc_ready_tx, _rpc_ready_rx) = watch::channel(false);
         let leader_notifier = LeaderNotifier::new();
+        let (_membership_tx, membership_rx) = watch::channel(MembershipSnapshot::default());
 
         let node = Arc::new(Node::<MockTypeConfig> {
             node_id: raft.node_id,
@@ -374,6 +378,7 @@ impl MockBuilder {
             ready: AtomicBool::new(false),
             rpc_ready_tx,
             leader_notifier,
+            membership_rx,
             node_config: node_config_arc.clone(),
             #[cfg(feature = "watch")]
             watch_registry: None,

--- a/d-engine-server/src/test_utils/mock/mock_rpc.rs
+++ b/d-engine-server/src/test_utils/mock/mock_rpc.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use d_engine_proto::client::ClientReadRequest;
 use d_engine_proto::client::ClientResponse;
 use d_engine_proto::client::ClientWriteRequest;
+use d_engine_proto::client::MembershipSnapshot as ProtoMembershipSnapshot;
+use d_engine_proto::client::WatchMembershipRequest;
 use d_engine_proto::client::WatchRequest;
 use d_engine_proto::client::WatchResponse;
 use d_engine_proto::client::raft_client_service_server::RaftClientService;
@@ -168,6 +170,9 @@ impl ClusterManagementService for MockRpcService {
 impl RaftClientService for MockRpcService {
     type WatchStream = tokio_stream::wrappers::ReceiverStream<Result<WatchResponse, tonic::Status>>;
 
+    type WatchMembershipStream =
+        tokio_stream::wrappers::ReceiverStream<Result<ProtoMembershipSnapshot, tonic::Status>>;
+
     async fn handle_client_write(
         &self,
         _request: tonic::Request<ClientWriteRequest>,
@@ -198,11 +203,17 @@ impl RaftClientService for MockRpcService {
         &self,
         _request: tonic::Request<WatchRequest>,
     ) -> std::result::Result<tonic::Response<Self::WatchStream>, tonic::Status> {
-        // Mock implementation: return an empty stream
         let (_tx, rx) = tokio::sync::mpsc::channel(1);
         Ok(tonic::Response::new(
             tokio_stream::wrappers::ReceiverStream::new(rx),
         ))
+    }
+
+    async fn watch_membership(
+        &self,
+        _request: tonic::Request<WatchMembershipRequest>,
+    ) -> std::result::Result<tonic::Response<Self::WatchMembershipStream>, tonic::Status> {
+        Err(tonic::Status::unimplemented("not used in mock"))
     }
 }
 

--- a/d-engine-server/tests/cas_operations/leader_failover_cas_standalone.rs
+++ b/d-engine-server/tests/cas_operations/leader_failover_cas_standalone.rs
@@ -215,8 +215,30 @@ async fn test_leader_failover_cas_standalone() -> Result<(), ClientApiError> {
     );
 
     // Phase 5: Verify final lock state
+    //
+    // Same cascading-election resilience as Phase 2+3: a linearizable read requires
+    // the leader to confirm quorum via heartbeat. If a cascading election is still
+    // settling after Phase 4's CAS, that heartbeat quorum confirmation can timeout.
+    // Retry refresh() + get() until a stable leader can serve the read end-to-end.
     info!("Phase 5: Verify final lock state");
-    let final_value = client.get(lock_key).await?;
+    let final_value = loop {
+        client.refresh(None).await?;
+        match client.get(lock_key).await {
+            Ok(value) => break value,
+            Err(ClientApiError::Business {
+                code: ErrorCode::StaleOperation,
+                ..
+            }) => continue,
+            Err(ClientApiError::Network {
+                code: ErrorCode::ConnectionTimeout,
+                ..
+            }) => {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                continue;
+            }
+            Err(e) => return Err(e),
+        }
+    };
     assert_eq!(
         final_value,
         Some(b"client_b".to_vec().into()),

--- a/d-engine-server/tests/cas_operations/snapshot_recovery_standalone.rs
+++ b/d-engine-server/tests/cas_operations/snapshot_recovery_standalone.rs
@@ -14,6 +14,7 @@ use crate::common::create_node_config;
 use crate::common::get_available_ports;
 use crate::common::node_config;
 use crate::common::start_node;
+use crate::common::wait_for_stable_leader;
 use tempfile::TempDir;
 
 /// Test CAS state survives snapshot and recovery (standalone mode)
@@ -122,11 +123,14 @@ async fn test_snapshot_recovery_standalone() -> Result<(), ClientApiError> {
     ctx.graceful_txs[1] = graceful_tx;
     ctx.node_handles[1] = node_handle;
 
-    tokio::time::sleep(Duration::from_secs(WAIT_FOR_NODE_READY_IN_SEC)).await;
+    // Wait for TCP port up, then wait for a stable leader.
+    // Node 2 restart may trigger cascading elections (it rejoins with a stale term and
+    // immediately starts an election, causing the current leader to step down). A TCP
+    // check only confirms the process is listening — wait_for_stable_leader() probes
+    // with a linearizable read, which is the authoritative proof that the cluster has
+    // a leader capable of serving requests end-to-end.
     check_cluster_is_ready(&format!("127.0.0.1:{}", ports[1]), 10).await?;
-
-    // Refresh client so it rediscovers the current leader after node restart
-    client.refresh(None).await.ok();
+    wait_for_stable_leader(&client).await?;
 
     // Step 5: Verify lock persists after restart
     // Use eventual read — goal is to verify data persistence, not consistency

--- a/d-engine-server/tests/cluster_lifecycle/scale_single_to_three_node_embedded.rs
+++ b/d-engine-server/tests/cluster_lifecycle/scale_single_to_three_node_embedded.rs
@@ -6,6 +6,7 @@ use d_engine_server::EmbeddedEngine;
 use tracing::info;
 use tracing_test::traced_test;
 
+use crate::common::create_rejoin_node_config;
 use crate::common::get_available_ports;
 use crate::common::node_config;
 
@@ -566,23 +567,11 @@ election_timeout_max = 6000
     let (node1_storage, node1_state_machine) = RocksDBUnifiedEngine::open(&node1_db_path)?;
 
     // Node 1 config: rejoining as existing follower
-    let node1_config_str = format!(
-        r#"
-[cluster]
-node_id = 1
-listen_address = '127.0.0.1:{}'
-initial_cluster = [
-    {{ id = 1, name = 'n1', address = '127.0.0.1:{}', role = 1, status = 3 }},
-    {{ id = 2, name = 'n2', address = '127.0.0.1:{}', role = 1, status = 3 }},
-    {{ id = 3, name = 'n3', address = '127.0.0.1:{}', role = 1, status = 3 }}
-]
-db_root_dir = '{}'
-
-[raft]
-election_timeout_ms = 150
-heartbeat_idle_flush_interval_ms = 50
-"#,
-        ports[0], ports[0], ports[1], ports[2], db_root
+    let node1_config_str = create_rejoin_node_config(
+        1,
+        ports[0],
+        &[(1, ports[0]), (2, ports[1]), (3, ports[2])],
+        &db_root,
     );
 
     let node1_config_path = "/tmp/d-engine-test-node1-phase6.toml".to_string();

--- a/d-engine-server/tests/common/mod.rs
+++ b/d-engine-server/tests/common/mod.rs
@@ -1,13 +1,10 @@
 #![allow(dead_code)]
 
-use std::path::Path;
-use std::path::PathBuf;
-use std::sync::Arc;
-use std::time::Duration;
-
 use bytes::Bytes;
 use bytes::BytesMut;
 use config::Config;
+use d_engine_client::Client;
+use d_engine_core::ClientApi;
 use d_engine_core::ClientApiError;
 use d_engine_core::alias::SMOF;
 use d_engine_core::alias::SOF;
@@ -23,6 +20,7 @@ use d_engine_core::convert::safe_kv_bytes;
 use d_engine_proto::client::WriteCommand;
 use d_engine_proto::common::Entry;
 use d_engine_proto::common::EntryPayload;
+use d_engine_proto::error::ErrorCode;
 use d_engine_proto::server::election::VotedFor;
 use d_engine_server::FileStateMachine;
 use d_engine_server::FileStorageEngine;
@@ -35,6 +33,10 @@ use d_engine_server::NodeBuilder;
 use d_engine_server::StorageEngine;
 use d_engine_server::node::RaftTypeConfig;
 use prost::Message;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
 use tokio::fs::remove_dir_all;
 use tokio::fs::{self};
 use tokio::net::TcpStream;
@@ -539,6 +541,74 @@ pub async fn check_cluster_is_ready(
             let err_msg =
                 format!("Node({peer_addr:?}) did not become ready within {timeout_secs} seconds.");
             Err(std::io::Error::new(std::io::ErrorKind::TimedOut, err_msg))
+        }
+    }
+}
+
+/// Create TOML config for a node rejoining an existing all-voter cluster.
+///
+/// Uses `election_timeout_min = 3000ms` so the rejoining node's election timer
+/// outlasts the replication worker's max reconnect backoff (`max_delay_ms = 1000ms`),
+/// ensuring the leader's first heartbeat arrives before any election fires.
+pub fn create_rejoin_node_config(
+    node_id: u32,
+    port: u16,
+    peers: &[(u32, u16)],
+    db_root_dir: &str,
+) -> String {
+    let cluster_entries = peers
+        .iter()
+        .map(|(id, p)| {
+            format!(
+                "{{ id = {id}, name = 'n{id}', address = '127.0.0.1:{p}', role = 1, status = 3 }}"
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",\n    ");
+
+    format!(
+        r#"[cluster]
+node_id = {node_id}
+listen_address = '127.0.0.1:{port}'
+initial_cluster = [
+    {cluster_entries}
+]
+db_root_dir = '{db_root_dir}'
+
+[raft]
+general_raft_timeout_duration_in_ms = 5000
+[raft.election]
+election_timeout_min = 3000
+election_timeout_max = 6000
+"#
+    )
+}
+
+/// Wait until the cluster has a stable leader capable of serving linearizable reads.
+///
+/// After a node restart or failover, cascading elections may occur before a stable
+/// leader emerges. A single `refresh()` is insufficient — the discovered leader may
+/// step down before completing a request. This function is the authoritative check:
+/// a successful linearizable read proves the leader is actively serving end-to-end.
+///
+/// Equivalent to the Phase 2+3 retry loop in `leader_failover_cas_standalone`.
+pub async fn wait_for_stable_leader(client: &Client) -> Result<(), ClientApiError> {
+    loop {
+        client.refresh(None).await.ok();
+        match client.get(b"__stability_probe__").await {
+            Ok(_) => return Ok(()),
+            Err(ClientApiError::Business {
+                code: ErrorCode::StaleOperation,
+                ..
+            }) => continue,
+            Err(ClientApiError::Network {
+                code: ErrorCode::ConnectionTimeout,
+                ..
+            }) => {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                continue;
+            }
+            Err(e) => return Err(e),
         }
     }
 }

--- a/d-engine-server/tests/failover_and_recovery/leader_failover_standalone.rs
+++ b/d-engine-server/tests/failover_and_recovery/leader_failover_standalone.rs
@@ -16,6 +16,7 @@ use crate::common::create_node_config;
 use crate::common::get_available_ports;
 use crate::common::node_config;
 use crate::common::start_node;
+use crate::common::wait_for_stable_leader;
 
 /// Test 3-node cluster failover: kill leader, verify re-election and data consistency
 #[tokio::test]
@@ -91,11 +92,9 @@ async fn test_3_node_failover() -> Result<(), ClientApiError> {
 
     info!("Node 1 killed. Waiting for re-election");
 
-    // Wait for leader re-election (typically 1-2s)
-    tokio::time::sleep(Duration::from_secs(3)).await;
-
-    // Refresh client to discover new leader
-    client.refresh(None).await?;
+    // Wait for stable leader: killing the leader triggers cascading elections;
+    // only a successful linearizable read proves a leader is actively serving end-to-end.
+    wait_for_stable_leader(&client).await?;
 
     info!("Re-election complete. Verifying cluster still operational");
 

--- a/d-engine-server/tests/watch_and_subscriptions/mod.rs
+++ b/d-engine-server/tests/watch_and_subscriptions/mod.rs
@@ -10,4 +10,5 @@
 
 mod watch_events_embedded;
 mod watch_events_grpc_standalone;
+mod watch_membership_embedded;
 mod watch_performance_gate_embedded;

--- a/d-engine-server/tests/watch_and_subscriptions/mod.rs
+++ b/d-engine-server/tests/watch_and_subscriptions/mod.rs
@@ -11,4 +11,5 @@
 mod watch_events_embedded;
 mod watch_events_grpc_standalone;
 mod watch_membership_embedded;
+mod watch_membership_standalone;
 mod watch_performance_gate_embedded;

--- a/d-engine-server/tests/watch_and_subscriptions/watch_membership_embedded.rs
+++ b/d-engine-server/tests/watch_and_subscriptions/watch_membership_embedded.rs
@@ -139,11 +139,11 @@ max_delay_ms = 5000
 }
 
 /// Append a `[raft.membership.zombie]` override so that a single AppendEntries
-/// failure immediately triggers zombie detection and node removal.
+/// failure immediately triggers zombie detection (warn-only; no auto-removal).
 ///
-/// Used only in tests 3 and 7 where we stop a node and wait for `BatchRemove`
-/// to commit via Raft consensus.  Kept separate from `node_toml` to avoid
-/// spurious zombie signals in other tests during startup.
+/// Used only in test 3 (`test_watch_membership_zombie_warns_without_removal`).
+/// Kept separate from `node_toml` to avoid spurious zombie signals in other
+/// tests during startup.
 fn with_fast_zombie(base_toml: &str) -> String {
     format!(
         "{base_toml}
@@ -468,7 +468,7 @@ async fn test_watch_membership_zombie_warns_without_removal()
 /// Test 4: `watch_membership()` fires when a learner is promoted to voter.
 ///
 /// Promotion happens automatically via the `BatchPromote` Raft path:
-/// 1. Learner starts with `status = Promotable (2)` and `role = Learner (4)`.
+/// 1. Learner starts with `status = Promotable (1)` and `role = Learner (4)`.
 /// 2. On boot the learner sends `JoinCluster` RPC → leader commits `AddNode`;
 ///    watch fires with node 3 in `learners` (change 1).
 /// 3. The learner replicates the log.  Within `learner_check_throttle_ms = 100 ms`
@@ -476,7 +476,7 @@ async fn test_watch_membership_zombie_warns_without_removal()
 ///    with node 3 moved from `learners` to `members` (change 2).
 ///
 /// Setup:  2-node voter cluster (nodes 1, 2).  Subscribe on node 1.
-/// Action: start node 3 as Promotable Learner (role=4, status=2).
+/// Action: start node 3 as Promotable Learner (role=4, status=1).
 /// Assert: second `changed()` shows node 3 in `members`, not in `learners`.
 #[tokio::test]
 #[traced_test]
@@ -532,7 +532,7 @@ async fn test_watch_membership_fires_on_learner_promote() -> Result<(), Box<dyn 
     // the subsequent BatchPromote notifications.
     let mut rx = engine1.watch_membership();
 
-    // Node 3 starts as a Promotable Learner.  Its status=2 (Promotable) is read from
+    // Node 3 starts as a Promotable Learner.  Its status=1 (Promotable) is read from
     // initial_cluster and sent to the leader in the JoinRequest.  Once it catches up
     // (gap ≤ learner_catchup_threshold), the leader auto-promotes it via BatchPromote.
     let engine3 = start_engine(

--- a/d-engine-server/tests/watch_and_subscriptions/watch_membership_embedded.rs
+++ b/d-engine-server/tests/watch_and_subscriptions/watch_membership_embedded.rs
@@ -1,0 +1,984 @@
+//! Integration tests for `EmbeddedEngine::watch_membership()` — Ticket #327
+//!
+//! Verifies in-process membership change notifications via `watch::Receiver<MembershipSnapshot>`.
+//!
+//! ## What is tested
+//!
+//! | # | Test | Key assertion |
+//! |---|------|---------------|
+//! | 1 | [`test_watch_membership_returns_initial_snapshot_without_waiting`] | First `borrow()` returns current members immediately |
+//! | 2 | [`test_watch_membership_fires_on_node_join`] | Watch fires when a new learner joins the cluster |
+//! | 3 | [`test_watch_membership_zombie_warns_without_removal`] | Zombie detection emits warn log; watch does NOT fire (no auto-removal) |
+//! | 4 | [`test_watch_membership_fires_on_learner_promote`] | Watch fires when a learner auto-promotes to voter |
+//! | 5 | [`test_watch_membership_all_nodes_receive_notification`] | Leader, follower, and learner all receive the notification |
+//! | 6 | [`test_watch_membership_multiple_subscribers_all_notified`] | Multiple `watch_membership()` receivers all fire independently |
+//! | 7 | [`test_watch_membership_committed_index_monotonically_increasing`] | `committed_index` increases across consecutive changes |
+//!
+//! ## Design notes
+//!
+//! - `watch::Receiver` semantics: lossy (latest value only), no diff carried.
+//!   Callers compute diff from their own previous snapshot.
+//! - `committed_index` is the idempotency key; callers use it to detect replayed
+//!   snapshots after reconnect or restart.
+//! - Notification fires on **every** node (leader / follower / learner) because
+//!   all walk the same `CommitHandler::apply_config_change()` path.
+//!
+//! ## How conf changes reach the watch channel
+//!
+//! Only Raft-consensus-backed conf changes trigger the watch.  The three paths used
+//! in these tests are:
+//!
+//! 1. **`JoinCluster` RPC**: New learner node (role=4) calls `join_cluster()` on boot.
+//!    Leader appends `AddNode(Config)` entry → commits → `CommitHandler::apply_config_change`
+//!    → `notify_config_applied` → watch fires on all nodes.
+//!
+//! 2. **Zombie detection** (warn-only): When a node's connection failure count reaches
+//!    `zombie.threshold`, the leader emits a `warn` log — no `BatchRemove` is proposed.
+//!    Auto-removal is intentionally absent; see zombie_detection_decision.md.
+//!    Test 3 uses `threshold=1` to trigger the warning quickly and verify no watch fires.
+//!
+//! 3. **Auto-promotion** (`BatchPromote`): When a learner with `status=Promotable(2)` catches
+//!    up to the leader's commit index (within `learner_check_throttle_ms = 100 ms`), the
+//!    leader proposes `BatchPromote(Config)` → commits → watch fires.
+//!
+//! `ClusterManagementService::update_cluster_conf` is NOT used here; it bypasses the Raft
+//! log and modifies follower membership state directly without calling `notify_config_applied`.
+
+#![cfg(feature = "rocksdb")]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use d_engine_server::{EmbeddedEngine, RocksDBUnifiedEngine};
+use tempfile::TempDir;
+use tokio::time::timeout;
+use tracing_test::traced_test;
+
+use crate::common::get_available_ports;
+
+// ── Timeout constants ─────────────────────────────────────────────────────────
+
+/// How long to wait for the initial leader election before a test assertion.
+const ELECTION_TIMEOUT: Duration = Duration::from_secs(8);
+
+/// How long to wait for a single membership-change notification to arrive.
+const MEMBERSHIP_CHANGE_TIMEOUT: Duration = Duration::from_secs(10);
+
+// ── NodeStatus constants (mirrors d_engine_proto::common::NodeStatus) ─────────
+
+/// `NodeStatus::Active = 3` — alive voter or non-promotable learner.
+const STATUS_ACTIVE: i32 = 3;
+
+/// `NodeStatus::Promotable = 1` — learner eligible for auto-promotion to voter.
+/// When a learner with this status catches up to the leader's commit index,
+/// the leader automatically proposes `BatchPromote` via Raft consensus.
+const STATUS_PROMOTABLE: i32 = 1;
+
+// ── Cluster setup helpers ──────────────────────────────────────────────────────
+
+/// Build a TOML config string for one node in a fixed-topology cluster.
+///
+/// `all_ports[i]` belongs to node `i+1`.
+/// `roles[i]` is the Raft role for node `i+1` (1 = voter, 4 = learner).
+/// `statuses[i]` is the NodeStatus for node `i+1` (1 = Promotable, 3 = Active).
+///
+/// Includes `learner_check_throttle_ms = 100` so auto-promotion fires within
+/// ~100 ms of a learner catching up (default is 1000 ms).
+fn node_toml(
+    node_id: u32,
+    port: u16,
+    all_ports: &[u16],
+    roles: &[i32],
+    statuses: &[i32],
+    db_root: &str,
+    log_dir: &str,
+) -> String {
+    let members = all_ports
+        .iter()
+        .enumerate()
+        .map(|(i, &p)| {
+            let id = i as u32 + 1;
+            let role = roles.get(i).copied().unwrap_or(1);
+            let status = statuses.get(i).copied().unwrap_or(STATUS_ACTIVE);
+            format!(
+                "{{ id = {id}, name = 'n{id}', address = '127.0.0.1:{p}', role = {role}, status = {status} }}"
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",\n    ");
+
+    format!(
+        r#"
+[cluster]
+node_id = {node_id}
+listen_address = '127.0.0.1:{port}'
+initial_cluster = [
+    {members}
+]
+db_root_dir = '{db_root}'
+log_dir = '{log_dir}'
+
+[raft]
+general_raft_timeout_duration_in_ms = 10000
+learner_check_throttle_ms = 100
+
+[raft.election]
+election_timeout_min = 300
+election_timeout_max = 3000
+
+[raft.persistence]
+strategy = "MemFirst"
+
+[retry.election]
+max_retries = 5
+timeout_ms = 2000
+base_delay_ms = 100
+max_delay_ms = 5000
+"#
+    )
+}
+
+/// Append a `[raft.membership.zombie]` override so that a single AppendEntries
+/// failure immediately triggers zombie detection and node removal.
+///
+/// Used only in tests 3 and 7 where we stop a node and wait for `BatchRemove`
+/// to commit via Raft consensus.  Kept separate from `node_toml` to avoid
+/// spurious zombie signals in other tests during startup.
+fn with_fast_zombie(base_toml: &str) -> String {
+    format!(
+        "{base_toml}
+[raft.membership.zombie]
+threshold = 1
+"
+    )
+}
+
+/// Start one `EmbeddedEngine` from a TOML string written to a temp file.
+async fn start_engine(
+    toml: &str,
+    node_id: u32,
+    db_root: &std::path::Path,
+    config_path: &str,
+) -> Result<EmbeddedEngine, Box<dyn std::error::Error>> {
+    tokio::fs::write(config_path, toml).await?;
+    let db_path = db_root.join(format!("node{node_id}/db"));
+    tokio::fs::create_dir_all(&db_path).await?;
+    let (storage, sm) = RocksDBUnifiedEngine::open(&db_path)?;
+    Ok(EmbeddedEngine::start_custom(Arc::new(storage), Arc::new(sm), Some(config_path)).await?)
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+/// Test 1: First `borrow()` on a fresh `watch_membership()` returns the current
+/// membership immediately — no change event required.
+///
+/// This guarantees developers can read the initial cluster state synchronously
+/// right after subscribing, matching the `watch::channel` semantics where the
+/// initial value is always available.
+///
+/// Setup:  single-node cluster (self-elected leader).
+/// Assert: `snapshot.members` contains exactly node 1; `committed_index` is valid.
+#[tokio::test]
+#[traced_test]
+async fn test_watch_membership_returns_initial_snapshot_without_waiting()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp = TempDir::new()?;
+    let mut port_guard = get_available_ports(1).await;
+    port_guard.release_listeners();
+    let port = port_guard.as_slice()[0];
+
+    let engine = start_engine(
+        &node_toml(
+            1,
+            port,
+            &[port],
+            &[1],
+            &[STATUS_ACTIVE],
+            &temp.path().join("db").to_string_lossy(),
+            &temp.path().join("logs").to_string_lossy(),
+        ),
+        1,
+        temp.path(),
+        &temp.path().join("n1.toml").to_string_lossy(),
+    )
+    .await?;
+
+    engine.wait_ready(ELECTION_TIMEOUT).await?;
+
+    // Subscribe and read current state without waiting for any change.
+    let rx = engine.watch_membership();
+    let snapshot = rx.borrow().clone();
+
+    assert!(
+        snapshot.members.contains(&1),
+        "Initial snapshot must contain self (node 1); got: {:?}",
+        snapshot.members
+    );
+    assert!(
+        snapshot.learners.is_empty(),
+        "No learners expected on single-node boot"
+    );
+    // committed_index of 0 is acceptable on a freshly-booted single-node cluster
+    // that has not yet committed any ConfChange entry.
+    let _ = snapshot.committed_index; // presence check; value is implementation-defined
+
+    engine.stop().await?;
+    Ok(())
+}
+
+/// Test 2: `watch_membership()` fires when a new node joins the cluster.
+///
+/// A new node must start with `role = Learner (4)` so it calls `join_cluster()`
+/// RPC on boot.  The leader appends an `AddNode` ConfChange entry; when it
+/// commits all nodes fire the watch channel.
+///
+/// Node 3 uses `status = Active (3)` to avoid triggering auto-promotion; this
+/// test only verifies the join notification, not the promotion path.
+///
+/// Setup:  2-node cluster (nodes 1, 2).  Subscribe on node 1.
+/// Action: start node 3 as Learner (role=4, status=Active) — it sends JoinCluster
+///         RPC to the leader.
+/// Assert: `changed()` fires; `snapshot.learners` contains node 3.
+#[tokio::test]
+#[traced_test]
+async fn test_watch_membership_fires_on_node_join() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = TempDir::new()?;
+    let db_root = temp.path().join("db");
+    let log_dir = temp.path().join("logs");
+
+    let mut port_guard = get_available_ports(3).await;
+    port_guard.release_listeners();
+    let ports = port_guard.as_slice();
+
+    // Start 2-node cluster: nodes 1 and 2 only know about each other.
+    let two_node_ports = &ports[..2];
+    let engine1 = start_engine(
+        &node_toml(
+            1,
+            ports[0],
+            two_node_ports,
+            &[1, 1],
+            &[STATUS_ACTIVE, STATUS_ACTIVE],
+            &db_root.to_string_lossy(),
+            &log_dir.to_string_lossy(),
+        ),
+        1,
+        &db_root,
+        &temp.path().join("n1.toml").to_string_lossy(),
+    )
+    .await?;
+    let engine2 = start_engine(
+        &node_toml(
+            2,
+            ports[1],
+            two_node_ports,
+            &[1, 1],
+            &[STATUS_ACTIVE, STATUS_ACTIVE],
+            &db_root.to_string_lossy(),
+            &log_dir.to_string_lossy(),
+        ),
+        2,
+        &db_root,
+        &temp.path().join("n2.toml").to_string_lossy(),
+    )
+    .await?;
+
+    engine1.wait_ready(ELECTION_TIMEOUT).await?;
+    engine2.wait_ready(ELECTION_TIMEOUT).await?;
+
+    // Subscribe on node 1 before the change happens.
+    let mut rx = engine1.watch_membership();
+
+    // Node 3 starts as Learner (role=4, status=Active).  On boot it calls
+    // join_cluster() RPC, causing the leader to commit an AddNode ConfChange.
+    // Active status prevents auto-promotion so only one watch event fires.
+    let engine3 = start_engine(
+        &node_toml(
+            3,
+            ports[2],
+            ports,
+            &[1, 1, 4],
+            &[STATUS_ACTIVE, STATUS_ACTIVE, STATUS_ACTIVE],
+            &db_root.to_string_lossy(),
+            &log_dir.to_string_lossy(),
+        ),
+        3,
+        &db_root,
+        &temp.path().join("n3.toml").to_string_lossy(),
+    )
+    .await?;
+
+    // Wait for the membership change notification.
+    timeout(MEMBERSHIP_CHANGE_TIMEOUT, rx.changed())
+        .await
+        .expect("timed out waiting for membership change after node join")
+        .expect("watch channel closed unexpectedly");
+
+    let snapshot = rx.borrow_and_update().clone();
+    assert!(
+        snapshot.learners.contains(&3),
+        "Snapshot must include the newly joined learner node 3; got learners: {:?}",
+        snapshot.learners
+    );
+
+    engine1.stop().await?;
+    engine2.stop().await?;
+    engine3.stop().await?;
+    Ok(())
+}
+
+/// Test 3: Zombie detection does NOT auto-remove the node.
+///
+/// ## Design rationale
+///
+/// Auto-removal of unreachable nodes via `BatchRemove` is intentionally absent.
+/// Membership changes are high-risk Raft operations: a node that fails N connection
+/// attempts may simply be restarting, and an incorrect removal would permanently eject
+/// it from the cluster (requiring manual re-add).  Instead, d-engine emits a `warn`
+/// log so that upper-layer tooling or operators can decide whether removal is warranted.
+/// See decision doc: `d-engine-product-design/…/20260418/zombie_detection_decision.md`.
+///
+/// ## What this test verifies
+///
+/// 1. The `watch_membership()` channel does **not** fire after node 3 becomes
+///    unreachable — confirming no `BatchRemove` was submitted to Raft consensus.
+/// 2. Node 3 is still present in the membership snapshot (not auto-removed).
+/// 3. The surviving 2-node cluster remains healthy (leader still accepts requests).
+///
+/// Note: the `warn!("Zombie detected …")` is emitted inside engine Raft tasks that
+/// run on tokio worker threads.  `traced_test` does not capture events from those
+/// threads, so we verify the behavioral invariants instead of the log output.
+///
+/// ## Setup
+///
+/// - 3-node cluster (nodes 1, 2, 3).
+/// - `zombie.threshold = 1`: first AppendEntries failure to node 3 fires the zombie
+///   signal immediately.
+/// - Subscribe watch on node 1 before stopping node 3.
+///
+/// ## Invariant protected
+///
+/// If this test fails because `rx.changed()` fires, it means auto-removal was
+/// accidentally re-introduced somewhere in the zombie detection path.
+#[tokio::test]
+#[traced_test]
+async fn test_watch_membership_zombie_warns_without_removal()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp = TempDir::new()?;
+    let db_root = temp.path().join("db");
+    let log_dir = temp.path().join("logs");
+
+    let mut port_guard = get_available_ports(3).await;
+    port_guard.release_listeners();
+    let ports = port_guard.as_slice();
+
+    // threshold=1: the very first AppendEntries failure fires ZombieDetected(3).
+    // This keeps the wait short while still exercising the full detection pipeline.
+    let make_toml = |id: u32, port: u16| {
+        with_fast_zombie(&node_toml(
+            id,
+            port,
+            ports,
+            &[1, 1, 1],
+            &[STATUS_ACTIVE, STATUS_ACTIVE, STATUS_ACTIVE],
+            &db_root.to_string_lossy(),
+            &log_dir.to_string_lossy(),
+        ))
+    };
+
+    let engine1 = start_engine(
+        &make_toml(1, ports[0]),
+        1,
+        &db_root,
+        &temp.path().join("n1.toml").to_string_lossy(),
+    )
+    .await?;
+    let engine2 = start_engine(
+        &make_toml(2, ports[1]),
+        2,
+        &db_root,
+        &temp.path().join("n2.toml").to_string_lossy(),
+    )
+    .await?;
+    let engine3 = start_engine(
+        &make_toml(3, ports[2]),
+        3,
+        &db_root,
+        &temp.path().join("n3.toml").to_string_lossy(),
+    )
+    .await?;
+
+    engine1.wait_ready(ELECTION_TIMEOUT).await?;
+
+    let rx = engine1.watch_membership();
+
+    // Stop node 3. The currently elected leader (whichever of 1/2/3 it is) will
+    // start failing to replicate to it, triggering the zombie pipeline.
+    // If node 3 happened to be the initial leader, nodes 1 and 2 must first elect
+    // a new leader among themselves before AppendEntries to node 3 can resume.
+    engine3.stop().await?;
+
+    // Wait for a stable leader among nodes 1 and 2 — this is a prerequisite for
+    // AppendEntries being sent to the stopped node 3, which is what feeds the
+    // failure counter and eventually fires the "Zombie detected" warning.
+    let deadline = tokio::time::Instant::now() + ELECTION_TIMEOUT;
+    loop {
+        if engine1.is_leader() || engine2.is_leader() {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "Nodes 1 and 2 failed to elect a leader within the election timeout after node 3 stopped"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // Give the zombie pipeline time to run.  With threshold=1 the signal fires on
+    // the very first AppendEntries failure, which happens within milliseconds of the
+    // new leader sending its first heartbeat to node 3.  2 seconds is generous.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Assert 1: watch channel did NOT fire — no BatchRemove was committed to Raft.
+    // `has_changed()` returns true only if a new value was sent since the last borrow.
+    assert!(
+        !rx.has_changed().unwrap_or(false),
+        "watch_membership must not fire when zombie detection is warn-only (no BatchRemove)"
+    );
+
+    // Assert 2: node 3 is still present in the membership snapshot — not auto-removed.
+    let snapshot = rx.borrow();
+    let node3_present = snapshot.members.contains(&3) || snapshot.learners.contains(&3);
+    assert!(
+        node3_present,
+        "node 3 must still be in membership after zombie detection (no auto-removal)"
+    );
+    drop(snapshot);
+
+    // Assert 3: surviving cluster is still healthy (leader responds).
+    assert!(
+        engine1.is_leader() || engine2.is_leader(),
+        "2-node cluster must still have a leader after node 3 stopped"
+    );
+
+    engine1.stop().await?;
+    engine2.stop().await?;
+    Ok(())
+}
+
+/// Test 4: `watch_membership()` fires when a learner is promoted to voter.
+///
+/// Promotion happens automatically via the `BatchPromote` Raft path:
+/// 1. Learner starts with `status = Promotable (2)` and `role = Learner (4)`.
+/// 2. On boot the learner sends `JoinCluster` RPC → leader commits `AddNode`;
+///    watch fires with node 3 in `learners` (change 1).
+/// 3. The learner replicates the log.  Within `learner_check_throttle_ms = 100 ms`
+///    the leader detects it has caught up and proposes `BatchPromote`; watch fires
+///    with node 3 moved from `learners` to `members` (change 2).
+///
+/// Setup:  2-node voter cluster (nodes 1, 2).  Subscribe on node 1.
+/// Action: start node 3 as Promotable Learner (role=4, status=2).
+/// Assert: second `changed()` shows node 3 in `members`, not in `learners`.
+#[tokio::test]
+#[traced_test]
+async fn test_watch_membership_fires_on_learner_promote() -> Result<(), Box<dyn std::error::Error>>
+{
+    let temp = TempDir::new()?;
+    let db_root = temp.path().join("db");
+    let log_dir = temp.path().join("logs");
+
+    let mut port_guard = get_available_ports(3).await;
+    port_guard.release_listeners();
+    let ports = port_guard.as_slice();
+
+    // Nodes 1 and 2 form a 2-voter cluster; they do NOT know about node 3 initially.
+    // Node 3 will join later via JoinCluster RPC.
+    let two_ports = &ports[..2];
+
+    let engine1 = start_engine(
+        &node_toml(
+            1,
+            ports[0],
+            two_ports,
+            &[1, 1],
+            &[STATUS_ACTIVE, STATUS_ACTIVE],
+            &db_root.to_string_lossy(),
+            &log_dir.to_string_lossy(),
+        ),
+        1,
+        &db_root,
+        &temp.path().join("n1.toml").to_string_lossy(),
+    )
+    .await?;
+    let engine2 = start_engine(
+        &node_toml(
+            2,
+            ports[1],
+            two_ports,
+            &[1, 1],
+            &[STATUS_ACTIVE, STATUS_ACTIVE],
+            &db_root.to_string_lossy(),
+            &log_dir.to_string_lossy(),
+        ),
+        2,
+        &db_root,
+        &temp.path().join("n2.toml").to_string_lossy(),
+    )
+    .await?;
+
+    engine1.wait_ready(ELECTION_TIMEOUT).await?;
+    engine2.wait_ready(ELECTION_TIMEOUT).await?;
+
+    // Subscribe BEFORE starting node 3 so we receive both the AddNode and
+    // the subsequent BatchPromote notifications.
+    let mut rx = engine1.watch_membership();
+
+    // Node 3 starts as a Promotable Learner.  Its status=2 (Promotable) is read from
+    // initial_cluster and sent to the leader in the JoinRequest.  Once it catches up
+    // (gap ≤ learner_catchup_threshold), the leader auto-promotes it via BatchPromote.
+    let engine3 = start_engine(
+        &node_toml(
+            3,
+            ports[2],
+            ports,
+            &[1, 1, 4],
+            &[STATUS_ACTIVE, STATUS_ACTIVE, STATUS_PROMOTABLE],
+            &db_root.to_string_lossy(),
+            &log_dir.to_string_lossy(),
+        ),
+        3,
+        &db_root,
+        &temp.path().join("n3.toml").to_string_lossy(),
+    )
+    .await?;
+
+    // Change 1: AddNode commits — node 3 appears in learners.
+    timeout(MEMBERSHIP_CHANGE_TIMEOUT, rx.changed())
+        .await
+        .expect("timed out waiting for AddNode notification (change 1)")
+        .expect("watch channel closed unexpectedly");
+    let snap1 = rx.borrow_and_update().clone();
+    assert!(
+        snap1.learners.contains(&3),
+        "After joining, node 3 must be in learners; got: {:?}",
+        snap1.learners
+    );
+
+    // Change 2: BatchPromote commits — node 3 moves from learners to members.
+    timeout(MEMBERSHIP_CHANGE_TIMEOUT, rx.changed())
+        .await
+        .expect("timed out waiting for BatchPromote notification (change 2)")
+        .expect("watch channel closed unexpectedly");
+
+    let snap2 = rx.borrow_and_update().clone();
+    assert!(
+        snap2.members.contains(&3),
+        "Promoted node 3 must appear in members; got: {:?}",
+        snap2.members
+    );
+    assert!(
+        !snap2.learners.contains(&3),
+        "Promoted node 3 must not remain in learners; got: {:?}",
+        snap2.learners
+    );
+
+    engine1.stop().await?;
+    engine2.stop().await?;
+    engine3.stop().await?;
+    Ok(())
+}
+
+/// Test 5: All nodes in a cluster receive the membership change notification —
+/// leader, follower, and learner included.
+///
+/// The Raft commit path (`CommitHandler::apply_config_change`) is identical on
+/// every node, so all must fire the watch channel after a ConfChange commits.
+///
+/// Setup sequence:
+/// 1. Start 2-voter cluster (nodes 1, 2).
+/// 2. Start node 3 as Active Learner via JoinCluster RPC; wait for it to join.
+/// 3. Subscribe on all 3 nodes so all hold a "seen" version.
+/// 4. Start node 4 as Active Learner — triggers AddNode ConfChange.
+///
+/// Assert: `changed()` fires on every receiver (leader, follower, learner) within timeout.
+///
+/// Node 3 must NOT be in nodes 1/2's initial_cluster so that `can_rejoin` succeeds.
+/// Both node 3 and node 4 use `status = Active` to suppress auto-promotion (no extra events).
+#[tokio::test]
+#[traced_test]
+async fn test_watch_membership_all_nodes_receive_notification()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp = TempDir::new()?;
+    let db_root = temp.path().join("db");
+    let log_dir = temp.path().join("logs");
+
+    let mut port_guard = get_available_ports(4).await;
+    port_guard.release_listeners();
+    let ports = port_guard.as_slice();
+
+    // Step 1: 2-voter cluster — nodes 1 and 2 do NOT know about nodes 3 or 4 yet.
+    let two_ports = &ports[..2];
+
+    let engine1 = start_engine(
+        &node_toml(
+            1,
+            ports[0],
+            two_ports,
+            &[1, 1],
+            &[STATUS_ACTIVE, STATUS_ACTIVE],
+            &db_root.to_string_lossy(),
+            &log_dir.to_string_lossy(),
+        ),
+        1,
+        &db_root,
+        &temp.path().join("n1.toml").to_string_lossy(),
+    )
+    .await?;
+    let engine2 = start_engine(
+        &node_toml(
+            2,
+            ports[1],
+            two_ports,
+            &[1, 1],
+            &[STATUS_ACTIVE, STATUS_ACTIVE],
+            &db_root.to_string_lossy(),
+            &log_dir.to_string_lossy(),
+        ),
+        2,
+        &db_root,
+        &temp.path().join("n2.toml").to_string_lossy(),
+    )
+    .await?;
+
+    engine1.wait_ready(ELECTION_TIMEOUT).await?;
+
+    // Step 2: Node 3 joins as Active Learner via JoinCluster RPC.
+    // It knows about nodes 1 and 2 (but they don't know about it initially).
+    // Active status prevents auto-promotion.
+    let engine3 = start_engine(
+        &node_toml(
+            3,
+            ports[2],
+            &ports[..3],
+            &[1, 1, 4],
+            &[STATUS_ACTIVE, STATUS_ACTIVE, STATUS_ACTIVE],
+            &db_root.to_string_lossy(),
+            &log_dir.to_string_lossy(),
+        ),
+        3,
+        &db_root,
+        &temp.path().join("n3.toml").to_string_lossy(),
+    )
+    .await?;
+
+    // Wait for node 3's join (AddNode ConfChange) to commit on node 1.
+    {
+        let mut tmp_rx = engine1.watch_membership();
+        timeout(MEMBERSHIP_CHANGE_TIMEOUT, tmp_rx.changed())
+            .await
+            .expect("timed out waiting for node 3 to join")
+            .expect("watch channel closed");
+    }
+
+    // Step 3: Subscribe on all three nodes AFTER node 3 has joined.
+    // Each receiver now holds the "already seen" value; the next change will fire changed().
+    let mut rx1 = engine1.watch_membership();
+    let mut rx2 = engine2.watch_membership();
+    let mut rx3 = engine3.watch_membership();
+
+    // Step 4: Node 4 starts as Active Learner — JoinCluster → AddNode ConfChange commits.
+    // All three nodes (leader, follower, learner) must receive the notification.
+    let engine4 = start_engine(
+        &node_toml(
+            4,
+            ports[3],
+            ports,
+            &[1, 1, 4, 4],
+            &[STATUS_ACTIVE, STATUS_ACTIVE, STATUS_ACTIVE, STATUS_ACTIVE],
+            &db_root.to_string_lossy(),
+            &log_dir.to_string_lossy(),
+        ),
+        4,
+        &db_root,
+        &temp.path().join("n4.toml").to_string_lossy(),
+    )
+    .await?;
+
+    // All three receivers must fire — leader, follower, and learner.
+    let (r1, r2, r3) = tokio::join!(
+        timeout(MEMBERSHIP_CHANGE_TIMEOUT, rx1.changed()),
+        timeout(MEMBERSHIP_CHANGE_TIMEOUT, rx2.changed()),
+        timeout(MEMBERSHIP_CHANGE_TIMEOUT, rx3.changed()),
+    );
+
+    assert!(
+        r1.is_ok(),
+        "Node 1 (voter/leader or follower) did not receive membership notification"
+    );
+    assert!(
+        r2.is_ok(),
+        "Node 2 (voter/follower) did not receive membership notification"
+    );
+    assert!(
+        r3.is_ok(),
+        "Node 3 (learner) did not receive membership notification"
+    );
+
+    // Verify all three nodes agree on the same final membership.
+    let s1 = rx1.borrow_and_update().clone();
+    let s2 = rx2.borrow_and_update().clone();
+    let s3 = rx3.borrow_and_update().clone();
+
+    // Node 4 joined as a learner — all nodes must include it in their view.
+    let has_n4 =
+        |s: &d_engine_server::MembershipSnapshot| s.learners.contains(&4) || s.members.contains(&4);
+    assert!(
+        has_n4(&s1),
+        "Node 1 snapshot missing node 4: members={:?} learners={:?}",
+        s1.members,
+        s1.learners
+    );
+    assert!(
+        has_n4(&s2),
+        "Node 2 snapshot missing node 4: members={:?} learners={:?}",
+        s2.members,
+        s2.learners
+    );
+    assert!(
+        has_n4(&s3),
+        "Node 3 (learner) snapshot missing node 4: members={:?} learners={:?}",
+        s3.members,
+        s3.learners
+    );
+
+    engine1.stop().await?;
+    engine2.stop().await?;
+    engine3.stop().await?;
+    engine4.stop().await?;
+    Ok(())
+}
+
+/// Test 6: Multiple `watch_membership()` calls on the same engine each return
+/// independent receivers that all fire on a single membership change.
+///
+/// `watch::channel` supports multiple subscribers natively.  This test confirms
+/// the implementation does not limit concurrent subscribers.
+///
+/// Setup:  single-node cluster.  Subscribe 3 times before any change.
+/// Action: node 2 joins as Active Learner (no auto-promotion).
+/// Assert: all 3 receivers fire and show consistent snapshots.
+#[tokio::test]
+#[traced_test]
+async fn test_watch_membership_multiple_subscribers_all_notified()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp = TempDir::new()?;
+    let db_root = temp.path().join("db");
+    let log_dir = temp.path().join("logs");
+
+    let mut port_guard = get_available_ports(2).await;
+    port_guard.release_listeners();
+    let ports = port_guard.as_slice();
+
+    let engine1 = start_engine(
+        &node_toml(
+            1,
+            ports[0],
+            &ports[..1],
+            &[1],
+            &[STATUS_ACTIVE],
+            &db_root.to_string_lossy(),
+            &log_dir.to_string_lossy(),
+        ),
+        1,
+        &db_root,
+        &temp.path().join("n1.toml").to_string_lossy(),
+    )
+    .await?;
+    engine1.wait_ready(ELECTION_TIMEOUT).await?;
+
+    // Three independent subscribers on the same engine.
+    let mut rx_a = engine1.watch_membership();
+    let mut rx_b = engine1.watch_membership();
+    let mut rx_c = engine1.watch_membership();
+
+    // Node 2 starts as Active Learner (role=4, status=Active) — triggers one AddNode
+    // ConfChange commit.  Active status prevents auto-promotion (no second event).
+    let engine2 = start_engine(
+        &node_toml(
+            2,
+            ports[1],
+            ports,
+            &[1, 4],
+            &[STATUS_ACTIVE, STATUS_ACTIVE],
+            &db_root.to_string_lossy(),
+            &log_dir.to_string_lossy(),
+        ),
+        2,
+        &db_root,
+        &temp.path().join("n2.toml").to_string_lossy(),
+    )
+    .await?;
+
+    let (ra, rb, rc) = tokio::join!(
+        timeout(MEMBERSHIP_CHANGE_TIMEOUT, rx_a.changed()),
+        timeout(MEMBERSHIP_CHANGE_TIMEOUT, rx_b.changed()),
+        timeout(MEMBERSHIP_CHANGE_TIMEOUT, rx_c.changed()),
+    );
+
+    assert!(
+        ra.is_ok(),
+        "Subscriber A did not receive membership notification"
+    );
+    assert!(
+        rb.is_ok(),
+        "Subscriber B did not receive membership notification"
+    );
+    assert!(
+        rc.is_ok(),
+        "Subscriber C did not receive membership notification"
+    );
+
+    // All subscribers must see the same current state.
+    let sa = rx_a.borrow_and_update().clone();
+    let sb = rx_b.borrow_and_update().clone();
+    let sc = rx_c.borrow_and_update().clone();
+
+    assert_eq!(
+        sa.members, sb.members,
+        "Subscribers A and B disagree on members"
+    );
+    assert_eq!(
+        sb.members, sc.members,
+        "Subscribers B and C disagree on members"
+    );
+    assert!(
+        sa.learners.contains(&2) || sa.members.contains(&2),
+        "Node 2 missing from snapshot: members={:?} learners={:?}",
+        sa.members,
+        sa.learners
+    );
+
+    engine1.stop().await?;
+    engine2.stop().await?;
+    Ok(())
+}
+
+/// Test 7: `committed_index` in consecutive membership snapshots is strictly
+/// monotonically increasing.
+///
+/// ## Why this matters
+///
+/// Callers use `committed_index` as an idempotency key: after a reconnect or restart
+/// they compare the newly received index against the last one they processed, and skip
+/// snapshots they have already handled.  If two distinct membership changes ever produced
+/// the same `committed_index`, a caller could silently miss a change — breaking
+/// correctness.  Monotonicity is therefore a hard invariant.
+///
+/// ## How two membership changes are produced
+///
+/// Both changes are `AddNode` entries committed via the `JoinCluster` RPC path:
+///
+/// - Change 1: node 3 starts and joins the 2-node cluster as an Active Learner.
+/// - Change 2: node 4 starts and joins the (now 3-node) cluster as an Active Learner.
+///
+/// Using two joins avoids relying on zombie-detection auto-removal, which is
+/// intentionally not implemented (see zombie_detection_decision.md).  Each join
+/// produces one Raft `AddNode(Config)` entry that increments the commit index.
+///
+/// ## Assert
+///
+/// `snapshot2.committed_index > snapshot1.committed_index`
+#[tokio::test]
+#[traced_test]
+async fn test_watch_membership_committed_index_monotonically_increasing()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp = TempDir::new()?;
+    let db_root = temp.path().join("db");
+    let log_dir = temp.path().join("logs");
+
+    // 4 ports: 2 initial voters + 2 joining learners.
+    let mut port_guard = get_available_ports(4).await;
+    port_guard.release_listeners();
+    let ports = port_guard.as_slice();
+
+    // Helper: build a node TOML with Active status for all nodes.
+    let make_toml = |id: u32, port: u16, port_slice: &[u16], roles: &[i32]| {
+        let statuses: Vec<i32> = vec![STATUS_ACTIVE; roles.len()];
+        node_toml(
+            id,
+            port,
+            port_slice,
+            roles,
+            &statuses,
+            &db_root.to_string_lossy(),
+            &log_dir.to_string_lossy(),
+        )
+    };
+
+    // Start the initial 2-node cluster (nodes 1 and 2).
+    let engine1 = start_engine(
+        &make_toml(1, ports[0], &ports[..2], &[1, 1]),
+        1,
+        &db_root,
+        &temp.path().join("n1.toml").to_string_lossy(),
+    )
+    .await?;
+    let engine2 = start_engine(
+        &make_toml(2, ports[1], &ports[..2], &[1, 1]),
+        2,
+        &db_root,
+        &temp.path().join("n2.toml").to_string_lossy(),
+    )
+    .await?;
+
+    engine1.wait_ready(ELECTION_TIMEOUT).await?;
+    engine2.wait_ready(ELECTION_TIMEOUT).await?;
+
+    // Subscribe before any join so we don't miss the first notification.
+    let mut rx = engine1.watch_membership();
+
+    // Change 1: node 3 joins as Active Learner.
+    // role=4 (learner), status=Active → no auto-promotion, one clean AddNode commit.
+    let engine3 = start_engine(
+        &make_toml(3, ports[2], &ports[..3], &[1, 1, 4]),
+        3,
+        &db_root,
+        &temp.path().join("n3.toml").to_string_lossy(),
+    )
+    .await?;
+
+    timeout(MEMBERSHIP_CHANGE_TIMEOUT, rx.changed())
+        .await
+        .expect("timed out waiting for first membership change (node 3 join)")
+        .expect("watch channel closed unexpectedly");
+    let snapshot1 = rx.borrow_and_update().clone();
+
+    // Change 2: node 4 joins as Active Learner.
+    // A second distinct AddNode entry is committed, incrementing committed_index again.
+    let engine4 = start_engine(
+        &make_toml(4, ports[3], ports, &[1, 1, 4, 4]),
+        4,
+        &db_root,
+        &temp.path().join("n4.toml").to_string_lossy(),
+    )
+    .await?;
+
+    timeout(MEMBERSHIP_CHANGE_TIMEOUT, rx.changed())
+        .await
+        .expect("timed out waiting for second membership change (node 4 join)")
+        .expect("watch channel closed unexpectedly");
+    let snapshot2 = rx.borrow_and_update().clone();
+
+    assert!(
+        snapshot2.committed_index > snapshot1.committed_index,
+        "committed_index must be strictly increasing across consecutive membership changes: \
+         first={}, second={}",
+        snapshot1.committed_index,
+        snapshot2.committed_index
+    );
+
+    engine1.stop().await?;
+    engine2.stop().await?;
+    engine3.stop().await?;
+    engine4.stop().await?;
+    Ok(())
+}

--- a/d-engine-server/tests/watch_and_subscriptions/watch_membership_standalone.rs
+++ b/d-engine-server/tests/watch_and_subscriptions/watch_membership_standalone.rs
@@ -1,0 +1,189 @@
+//! Integration tests for `GrpcClient::watch_membership()` — Ticket #328
+//!
+//! Verifies that a gRPC client receives `MembershipSnapshot` events via server-side
+//! streaming when cluster membership changes in standalone (gRPC) mode.
+//!
+//! ## What is tested
+//!
+//! | # | Test | Key assertion |
+//! |---|------|---------------|
+//! | 1 | [`test_grpc_watch_membership_receives_snapshot_on_learner_join`] | Stream yields updated snapshot with the new learner after JoinCluster |
+//!
+//! ## Standalone mode specifics
+//!
+//! Unlike the embedded test (`watch_membership_embedded.rs`), this exercises the full
+//! gRPC path:
+//!
+//! ```text
+//! GrpcClient::watch_membership()
+//!   → HTTP/2 server-streaming RPC
+//!   → Node::watch_membership() handler
+//!   → WatchStream::new(membership_rx)  [mark_changed() → immediate initial snapshot]
+//!   → protobuf serialize
+//!   → tonic::Streaming<MembershipSnapshot> on the client side
+//! ```
+//!
+//! ## Stream delivery guarantee
+//!
+//! `Node::watch_membership()` calls `rx.mark_changed()` before creating the stream,
+//! so the first item yielded is always the current cluster state at subscribe time.
+//! Subsequent items arrive for each committed ConfChange (AddNode, Promote, Remove).
+//! The stream terminates with `Err(UNAVAILABLE)` when the server shuts down.
+
+use std::time::Duration;
+
+use d_engine_client::ClientBuilder;
+use futures::StreamExt;
+use tempfile::TempDir;
+use tokio::time::timeout;
+
+use crate::common::TestContext;
+use crate::common::create_node_config;
+use crate::common::create_node_config_with_role;
+use crate::common::get_available_ports;
+use crate::common::node_config;
+use crate::common::start_node;
+
+/// How long to wait for leader election before opening the watch stream.
+const ELECTION_TIMEOUT: Duration = Duration::from_secs(8);
+
+/// How long to wait for a single membership-change snapshot to arrive on the stream.
+const MEMBERSHIP_CHANGE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// `GrpcClient::watch_membership()` receives a `MembershipSnapshot` when a learner joins.
+///
+/// ## Scenario
+///
+/// 1. Start a 2-voter standalone cluster (nodes 1 and 2).
+/// 2. Wait for leader election (8 s).
+/// 3. Open a `watch_membership()` gRPC stream — server delivers the current snapshot
+///    immediately due to `mark_changed()`.
+/// 4. Start node 3 as Learner (role=4, status=Active): it calls `JoinCluster` on boot,
+///    causing the leader to commit an `AddNode` ConfChange via Raft consensus.
+/// 5. Wait for the next snapshot on the stream.
+///
+/// ## Assertions
+///
+/// - Initial snapshot: at least one voter, no learners.
+/// - Change snapshot: node 3 in `learners`; `committed_index > 0`.
+#[tokio::test]
+async fn test_grpc_watch_membership_receives_snapshot_on_learner_join()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = TempDir::new()?;
+    let base_path = temp_dir.path();
+    let db_root = base_path.join("db");
+    let log_dir = base_path.join("logs");
+
+    let mut port_guard = get_available_ports(3).await;
+    port_guard.release_listeners();
+    let ports = port_guard.as_slice();
+
+    // Start a 2-voter cluster. Nodes 1 and 2 do not know about node 3 yet.
+    let two_ports = &ports[..2];
+    let mut graceful_txs = Vec::new();
+    let mut node_handles = Vec::new();
+
+    for (i, &port) in two_ports.iter().enumerate() {
+        let node_id = (i + 1) as u64;
+        let node_dir = db_root.join(node_id.to_string());
+        let node_log = log_dir.join(node_id.to_string());
+        tokio::fs::create_dir_all(&node_dir).await?;
+        tokio::fs::create_dir_all(&node_log).await?;
+
+        let toml = create_node_config(
+            node_id,
+            port,
+            two_ports,
+            node_dir.to_str().unwrap(),
+            node_log.to_str().unwrap(),
+        )
+        .await;
+        let config = node_config(&toml);
+        let (tx, handle) = start_node(config, None, None).await?;
+        graceful_txs.push(tx);
+        node_handles.push(handle);
+    }
+
+    // Allow time for leader election before subscribing.
+    tokio::time::sleep(ELECTION_TIMEOUT).await;
+
+    // Connect the gRPC client to the 2-node cluster.
+    let endpoints: Vec<String> =
+        two_ports.iter().map(|&p| format!("http://127.0.0.1:{p}")).collect();
+    let client = ClientBuilder::new(endpoints)
+        .connect_timeout(Duration::from_secs(10))
+        .request_timeout(Duration::from_secs(30))
+        .build()
+        .await?;
+
+    // Open the watch_membership stream. Server delivers current snapshot immediately.
+    let mut stream = client.watch_membership().await?;
+
+    // Receive the initial snapshot — 2 voters, no learners.
+    let initial = timeout(Duration::from_secs(5), stream.next())
+        .await
+        .expect("timed out waiting for initial snapshot")
+        .expect("stream ended before initial snapshot")?;
+
+    assert!(
+        !initial.members.is_empty(),
+        "Initial snapshot must contain at least one voter; got members={:?}",
+        initial.members
+    );
+    assert!(
+        initial.learners.is_empty(),
+        "No learners expected before node 3 joins; got learners={:?}",
+        initial.learners
+    );
+
+    // Start node 3 as Learner (role=4, status=Active).
+    // On boot it sends JoinCluster RPC to the leader, which commits an AddNode ConfChange.
+    // Active status (3) prevents auto-promotion — exactly one membership event fires.
+    {
+        let node_id = 3u64;
+        let port = ports[2];
+        let node_dir = db_root.join(node_id.to_string());
+        let node_log = log_dir.join(node_id.to_string());
+        tokio::fs::create_dir_all(&node_dir).await?;
+        tokio::fs::create_dir_all(&node_log).await?;
+
+        let toml = create_node_config_with_role(
+            node_id,
+            port,
+            ports, // all 3 ports — node 3 needs to know where to send JoinCluster
+            4,     // role=4 → Learner
+            node_dir.to_str().unwrap(),
+            node_log.to_str().unwrap(),
+        )
+        .await;
+        let config = node_config(&toml);
+        let (tx, handle) = start_node(config, None, None).await?;
+        graceful_txs.push(tx);
+        node_handles.push(handle);
+    }
+
+    // Wait for the AddNode ConfChange to commit and the updated snapshot to arrive.
+    let snapshot = timeout(MEMBERSHIP_CHANGE_TIMEOUT, stream.next())
+        .await
+        .expect("timed out waiting for membership snapshot after learner join")
+        .expect("stream ended before membership change snapshot")?;
+
+    assert!(
+        snapshot.learners.contains(&3),
+        "Snapshot after node 3 joins must include node 3 in learners; got learners={:?}",
+        snapshot.learners
+    );
+    assert!(
+        snapshot.committed_index > 0,
+        "committed_index must be > 0 after an AddNode ConfChange commits; got: {}",
+        snapshot.committed_index
+    );
+
+    TestContext {
+        graceful_txs,
+        node_handles,
+    }
+    .shutdown()
+    .await?;
+    Ok(())
+}

--- a/examples/single-node-expansion/Cargo.lock
+++ b/examples/single-node-expansion/Cargo.lock
@@ -956,8 +956,6 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -966,6 +964,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hdrhistogram"
@@ -1260,11 +1263,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "0e0b564323a0fb6d54b864f625ae139de9612e27edb944dda37c109f05aac531"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]

--- a/examples/three-nodes-embedded/Cargo.lock
+++ b/examples/three-nodes-embedded/Cargo.lock
@@ -1007,20 +1007,14 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hdrhistogram"
@@ -1447,11 +1441,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "0e0b564323a0fb6d54b864f625ae139de9612e27edb944dda37c109f05aac531"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## What Does This PR Do?

Adds real-time cluster membership change notifications for both embedded and standalone (gRPC)
modes. Callers subscribe once and receive a snapshot on every committed ConfChange — no polling.

**Type:**

- [x] Feature (issue #327, #328 approved)

---

## Why Is This Needed?

**For features:** Issues #327 and #328

Operators and upper-layer tooling (service discovery, load balancers, health dashboards) need
to react to cluster topology changes (node join, promotion, removal) without polling
`get_cluster_metadata`. A push-based membership stream enables zero-latency reactions and
eliminates unnecessary RPC traffic.

---

## Checklist

**Required:**

- [x] `make test` passes
- [x] Added tests for new code
- [x] Commits squashed to 1-2 logical units

**If changing APIs:**

- [x] Updated relevant docs (CHANGELOG.md)
- [x] Explained why complexity is justified

---

## Testing

**How tested:**

- **Unit tests (server):** `test_watch_membership_returns_unavailable_when_node_not_ready`,
  `test_watch_membership_yields_current_snapshot_then_sentinel_on_sender_drop`
  — verify the gRPC handler's not-ready guard and the `mark_changed()` + UNAVAILABLE sentinel behavior.

- **Unit tests (client):** `test_watch_membership_returns_err_when_server_rejects`,
  `test_watch_membership_receives_snapshots_in_order`,
  `test_watch_membership_empty_stream_closes_cleanly`
  — verify `GrpcClient::watch_membership()` against a mock gRPC server.

- **Integration tests (embedded):** 7 tests in `watch_membership_embedded.rs` covering
  initial snapshot delivery, node join/promotion, zombie no-op, multi-subscriber fanout,
  and `committed_index` monotonicity.

- **Integration test (standalone/gRPC):** `watch_membership_standalone.rs` — boots a real
  2-node cluster, opens a gRPC stream, joins a 3rd learner node, asserts the stream yields
  a snapshot with `learners=[3]` and `committed_index > 0`.

All 13 `watch_membership` tests pass: `cargo nextest run --all-features -E 'test(watch_membership)'`

---

## Does This Follow d-engine's Principles?

- [x] Solves a real problem for most users (not just my edge case)
- [x] Keeps implementation simple
- [x] Doesn't bloat the API surface

---

## Reviewer Notes

**4 commits, 3 concerns to focus on:**

1. **`mark_changed()` before `WatchStream::new()`** (`grpc_raft_service.rs`): This forces the
   first stream item to be the current snapshot, matching `watch::Receiver::borrow()` semantics.
   Requires tokio ≥ 1.37 (project uses 1.51.1). Alternative would be an extra initial `send()`
   which adds complexity; `mark_changed()` is idiomatic.

2. **UNAVAILABLE sentinel** (`grpc_raft_service.rs`): The stream is chained with a
   `futures::stream::once(Err(Status::unavailable(...)))` so clients get a clean signal instead
   of a silent stream close. Clients should reconnect and resubscribe on receiving this error.

3. **`GrpcClient::watch_membership()` is NOT in `ClientApi` trait**: Membership watch is
   standalone-only (the embedded equivalent uses `EmbeddedEngine::watch_membership()` which
   returns a `watch::Receiver`). Putting both under one trait would force type-system gymnastics;
   keeping them separate preserves simplicity.

**Estimated review complexity:**

- [x] Deep (> 300 lines)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cluster membership streaming: clients can now subscribe to real-time membership snapshots through both embedded and gRPC APIs, with immediate initial snapshot delivery and updates on each committed membership change.

* **Important Fixes**
  * Zombie detection now emits warnings only; unreachable nodes are no longer automatically removed and require deliberate operator action for removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->