### PR TITLE
fix #371: use WriteBatchWithIndex to prevent CAS stale-read in apply_chunk

### DIFF
--- a/d-engine-server/src/storage/adaptors/rocksdb/rocksdb_state_machine.rs
+++ b/d-engine-server/src/storage/adaptors/rocksdb/rocksdb_state_machine.rs
@@ -165,7 +165,10 @@ impl RocksDBStateMachine {
     /// Replaces the underlying DB with `new_db`. Only available in `#[cfg(test)]`.
     /// Used to inject a read-only or otherwise broken DB to exercise error paths.
     #[cfg(test)]
-    pub(super) fn swap_db_for_test(&self, new_db: DB) {
+    pub(super) fn swap_db_for_test(
+        &self,
+        new_db: DB,
+    ) {
         self.db.store(Arc::new(new_db));
     }
 
@@ -734,7 +737,9 @@ impl StateMachine for RocksDBStateMachine {
                             // same batch are visible, preventing stale-read linearizability violations.
                             let current_value = batch
                                 .get_from_batch_and_db_cf(&*db, &cf, &key, &ReadOptions::default())
-                                .map_err(|e| StorageError::DbError(format!("CAS read failed: {e}")))?;
+                                .map_err(|e| {
+                                    StorageError::DbError(format!("CAS read failed: {e}"))
+                                })?;
 
                             let cas_success = match (current_value, &expected_value) {
                                 (Some(current), Some(expected)) => current == expected.as_ref(),

--- a/d-engine-server/src/storage/adaptors/rocksdb/rocksdb_state_machine.rs
+++ b/d-engine-server/src/storage/adaptors/rocksdb/rocksdb_state_machine.rs
@@ -33,7 +33,9 @@ use rocksdb::ImportColumnFamilyOptions;
 use rocksdb::IteratorMode;
 use rocksdb::LiveFile;
 use rocksdb::Options;
+use rocksdb::ReadOptions;
 use rocksdb::WriteBatch;
+use rocksdb::WriteBatchWithIndex;
 use serde::Deserialize;
 use serde::Serialize;
 use tracing::debug;
@@ -651,7 +653,7 @@ impl StateMachine for RocksDBStateMachine {
             .cf_handle(STATE_MACHINE_CF)
             .ok_or_else(|| StorageError::DbError("State machine CF not found".to_string()))?;
 
-        let mut batch = WriteBatch::default();
+        let mut batch = WriteBatchWithIndex::new(0, true);
         let mut highest_index_entry: Option<LogId> = None;
         let mut results = Vec::with_capacity(chunk.len());
 
@@ -720,11 +722,14 @@ impl StateMachine for RocksDBStateMachine {
                             expected_value,
                             new_value,
                         })) => {
-                            // RocksDB doesn't have native CAS, implement via read-compare-write
-                            // This is safe because apply_chunk is called sequentially per Raft log order
-                            let current_value = db.get_cf(&cf, &key).map_err(|e| {
-                                StorageError::DbError(format!("CAS read failed: {e}"))
-                            })?;
+                            // RocksDB doesn't have native CAS, implement via read-compare-write.
+                            // Read through WriteBatchWithIndex so that earlier CAS writes in the
+                            // same batch are visible, preventing stale-read linearizability violations.
+                            let current_value = batch
+                                .get_from_batch_and_db_cf(&*db, &cf, &key, &ReadOptions::default())
+                                .map_err(|e| {
+                                    StorageError::DbError(format!("CAS read failed: {e}"))
+                                })?;
 
                             let cas_success = match (current_value, &expected_value) {
                                 (Some(current), Some(expected)) => current == expected.as_ref(),
@@ -769,7 +774,10 @@ impl StateMachine for RocksDBStateMachine {
             }
         }
 
-        self.apply_batch(batch)?;
+        self.db
+            .load()
+            .write_wbwi(&batch)
+            .map_err(|e| StorageError::DbError(e.to_string()))?;
 
         // Note: Lease cleanup is now handled by:
         // - Lazy strategy: cleanup in get() method

--- a/d-engine-server/src/storage/adaptors/rocksdb/rocksdb_state_machine.rs
+++ b/d-engine-server/src/storage/adaptors/rocksdb/rocksdb_state_machine.rs
@@ -162,6 +162,13 @@ impl RocksDBStateMachine {
         self.lease = Some(lease);
     }
 
+    /// Replaces the underlying DB with `new_db`. Only available in `#[cfg(test)]`.
+    /// Used to inject a read-only or otherwise broken DB to exercise error paths.
+    #[cfg(test)]
+    pub(super) fn swap_db_for_test(&self, new_db: DB) {
+        self.db.store(Arc::new(new_db));
+    }
+
     // Injects lease configuration into this state machine.
     //
     // Framework-internal method: called by NodeBuilder::build() during initialization.
@@ -727,9 +734,7 @@ impl StateMachine for RocksDBStateMachine {
                             // same batch are visible, preventing stale-read linearizability violations.
                             let current_value = batch
                                 .get_from_batch_and_db_cf(&*db, &cf, &key, &ReadOptions::default())
-                                .map_err(|e| {
-                                    StorageError::DbError(format!("CAS read failed: {e}"))
-                                })?;
+                                .map_err(|e| StorageError::DbError(format!("CAS read failed: {e}")))?;
 
                             let cas_success = match (current_value, &expected_value) {
                                 (Some(current), Some(expected)) => current == expected.as_ref(),

--- a/d-engine-server/src/storage/adaptors/rocksdb/rocksdb_state_machine_test.rs
+++ b/d-engine-server/src/storage/adaptors/rocksdb/rocksdb_state_machine_test.rs
@@ -341,6 +341,37 @@ async fn test_apply_chunk_delete_removes_key() {
     assert_eq!(sm.get(b"to_delete").unwrap(), None);
 }
 
+/// apply_chunk returns Err when the underlying DB is replaced with a read-only instance.
+///
+/// This covers the write_wbwi error path that is only reachable when RocksDB itself fails.
+/// Deleting the directory does not work (Unix keeps open FDs valid), so we inject a
+/// read-only DB via swap_db_for_test to reliably trigger the error.
+#[tokio::test]
+async fn test_apply_chunk_returns_error_on_read_only_db() {
+    use rocksdb::{Options, DB};
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("rocksdb");
+    let (_storage, sm) = RocksDBUnifiedEngine::open(&db_path).unwrap();
+
+    // Confirm the state machine works normally first
+    sm.apply_chunk(vec![encode_insert(b"k", b"v", 0)]).await.unwrap();
+
+    // Open the same DB as read-only and inject it — writes will now return NotSupported
+    let ro_db = DB::open_cf_for_read_only(
+        &Options::default(),
+        &db_path,
+        &[super::STATE_MACHINE_CF, super::STATE_MACHINE_META_CF],
+        false,
+    )
+    .unwrap();
+    sm.swap_db_for_test(ro_db);
+
+    // Write to a read-only DB must fail
+    let result = sm.apply_chunk(vec![encode_insert(b"k2", b"v2", 0)]).await;
+    assert!(result.is_err(), "apply_chunk should return Err when DB is read-only");
+}
+
 /// map_snapshot_join_error produces "panicked" message when the blocking task panics.
 #[tokio::test]
 async fn test_snapshot_join_error_reports_panic() {

--- a/d-engine-server/src/storage/adaptors/rocksdb/rocksdb_state_machine_test.rs
+++ b/d-engine-server/src/storage/adaptors/rocksdb/rocksdb_state_machine_test.rs
@@ -294,6 +294,41 @@ async fn test_apply_chunk_cas_none_expected_on_existing_key_fails() {
     assert_eq!(sm.get(b"k").unwrap(), Some(Bytes::from("exists")));
 }
 
+/// Two CAS ops targeting the same key in a single apply_chunk must be applied
+/// sequentially: the second CAS must see the first CAS's write, not the stale DB value.
+///
+/// Failure mode without fix: db.get_cf() returns the pre-batch value for both reads,
+/// both report succeeded=true, and CAS2's write silently overwrites CAS1's value,
+/// causing a linearizability violation (acknowledged write disappears).
+#[tokio::test]
+async fn test_apply_chunk_two_cas_same_key_second_must_see_first_write() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let (_storage, sm) = RocksDBUnifiedEngine::open(dir.path()).unwrap();
+
+    sm.apply_chunk(vec![encode_insert(b"k", b"v0", 0)]).await.unwrap();
+
+    // CAS1: v0 → v1  (should succeed)
+    // CAS2: v0 → v2  (must fail — CAS1 already changed value to v1)
+    let results = sm
+        .apply_chunk(vec![
+            encode_cas(b"k", Some(b"v0"), b"v1", 2),
+            encode_cas(b"k", Some(b"v0"), b"v2", 3),
+        ])
+        .await
+        .unwrap();
+
+    assert!(results[0].succeeded, "CAS1 (v0→v1) must succeed");
+    assert!(
+        !results[1].succeeded,
+        "CAS2 (v0→v2) must fail: CAS1 already wrote v1, so expected=v0 no longer matches"
+    );
+    assert_eq!(
+        sm.get(b"k").unwrap(),
+        Some(Bytes::from("v1")),
+        "final value must be v1; CAS2 must not overwrite CAS1's committed write"
+    );
+}
+
 /// delete() removes a key successfully; subsequent get returns None.
 #[tokio::test]
 async fn test_apply_chunk_delete_removes_key() {

--- a/d-engine-server/src/storage/adaptors/rocksdb/rocksdb_state_machine_test.rs
+++ b/d-engine-server/src/storage/adaptors/rocksdb/rocksdb_state_machine_test.rs
@@ -348,7 +348,7 @@ async fn test_apply_chunk_delete_removes_key() {
 /// read-only DB via swap_db_for_test to reliably trigger the error.
 #[tokio::test]
 async fn test_apply_chunk_returns_error_on_read_only_db() {
-    use rocksdb::{Options, DB};
+    use rocksdb::{DB, Options};
 
     let dir = tempfile::TempDir::new().unwrap();
     let db_path = dir.path().join("rocksdb");
@@ -361,7 +361,7 @@ async fn test_apply_chunk_returns_error_on_read_only_db() {
     let ro_db = DB::open_cf_for_read_only(
         &Options::default(),
         &db_path,
-        &[super::STATE_MACHINE_CF, super::STATE_MACHINE_META_CF],
+        [super::STATE_MACHINE_CF, super::STATE_MACHINE_META_CF],
         false,
     )
     .unwrap();
@@ -369,7 +369,10 @@ async fn test_apply_chunk_returns_error_on_read_only_db() {
 
     // Write to a read-only DB must fail
     let result = sm.apply_chunk(vec![encode_insert(b"k2", b"v2", 0)]).await;
-    assert!(result.is_err(), "apply_chunk should return Err when DB is read-only");
+    assert!(
+        result.is_err(),
+        "apply_chunk should return Err when DB is read-only"
+    );
 }
 
 /// map_snapshot_join_error produces "panicked" message when the blocking task panics.


### PR DESCRIPTION
## What Does This PR Do?

Fixes a linearizability violation in `rocksdb_state_machine.rs` where multiple
CAS operations targeting the same key in a single `apply_chunk` batch could all
report `succeeded=true` but only the last write survived.

**Type:**
- [x] Bug Fix (with test)

---

## Why Is This Needed?

`apply_chunk` builds a `WriteBatch` and commits it atomically at the end.
Each CAS reads the current value via `db.get_cf()`, which reads committed RocksDB
state — the pending `WriteBatch` writes are invisible to it.

When two CAS ops target the same key in the same batch:
- CAS1 reads old value → match → writes v1 into WriteBatch
- CAS2 reads old value → still matches (WriteBatch not yet committed) → writes v2,
  silently overwriting CAS1
- Both get `succeeded=true`; v1 is never persisted

This is a linearizability violation: an acknowledged write disappears.
Confirmed by Jepsen `set` workload under `FAULTS=partition` (lost-count 11, 37%
loss rate).

Fix: replace `WriteBatch` with `WriteBatchWithIndex` and read via
`get_from_batch_and_db_cf()`, so each CAS sees prior writes from the same batch.

---

## Checklist

- [x] `make test` passes
- [x] Added tests for new code
- [x] Commits squashed to 1-2 logical units

---

## Testing

**How tested:**

- Unit: `test_apply_chunk_two_cas_same_key_second_must_see_first_write` — fails
  without this fix, passes after
- Unit: full RocksDB test suite (28 tests, 0 failures)
- Integration: Jepsen `set` and `bank` workloads pass under `FAULTS=partition`
- Integration: Jepsen `register` workload passes under `FAULTS=partition`

- [x] Added test that fails without this fix

---

## Does This Follow d-engine's Principles?

- [x] Solves a real problem for most users (not just my edge case)
- [x] Keeps implementation simple
- [x] Doesn't bloat the API surface

---

## Reviewer Notes

`WriteBatchWithIndex` is a RocksDB built-in. The only changes are:
1. `WriteBatch::default()` → `WriteBatchWithIndex::new(0, true)`
2. `db.get_cf()` → `batch.get_from_batch_and_db_cf()`
3. `db.write(&batch)` → `db.write_wbwi(&batch)`

`apply_batch()` (used elsewhere) is unchanged — it still takes a plain `WriteBatch`.

File SM and Sled SM are not affected: File SM applies ops sequentially to an
in-memory HashMap (writes immediately visible); Sled SM flushes before each CAS.

**Estimated review complexity:**
- [x] Quick (< 100 lines)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure multiple operations on the same key within a single transaction batch are properly sequenced so later operations see earlier writes.

* **Tests**
  * Added tests validating sequential processing of multiple operations on the same key within a batch.
  * Added tests confirming errors are returned when the database becomes read-only/unavailable during batch processing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deventlab/d-engine/pull/372)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->