### PR TITLE
feat #303: EmbeddedEngine::start(data_dir) and StandaloneEngine::run(data_dir, shutdown_rx)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ use std::time::Duration;
 
 #[tokio::main]
 async fn main() {
-    let engine = EmbeddedEngine::start().await.unwrap();
+    let engine = EmbeddedEngine::start("./data").await.unwrap();
     engine.wait_ready(Duration::from_secs(5)).await.unwrap();
 
     let client = engine.client();
@@ -76,8 +76,6 @@ async fn main() {
     engine.stop().await.unwrap();
 }
 ```
-
-> **Note**: Release builds require explicit `db_root_dir` configuration. Set `CONFIG_PATH` env or use `EmbeddedEngine::with_config(...)`. See [Quick Start Guide](https://docs.rs/d-engine/latest/d_engine/docs/quick_start_5min/index.html).
 
 **→ Full example:** [examples/quick-start-embedded](https://github.com/deventlab/d-engine/tree/main/examples/quick-start-embedded)
 

--- a/d-engine-core/src/config/cluster.rs
+++ b/d-engine-core/src/config/cluster.rs
@@ -7,7 +7,6 @@ use d_engine_proto::common::NodeStatus;
 use d_engine_proto::server::cluster::NodeMeta;
 use serde::Deserialize;
 use serde::Serialize;
-#[cfg(debug_assertions)]
 use tracing::warn;
 
 use super::validate_directory;
@@ -116,25 +115,13 @@ impl ClusterConfig {
             )));
         }
 
-        // Validate storage paths
-        // Check /tmp/db usage: strict in release, permissive in debug
-        if self.db_root_dir == PathBuf::from("/tmp/db") {
-            #[cfg(not(debug_assertions))]
-            {
-                return Err(Error::Config(ConfigError::Message(
-                    "db_root_dir not configured. Using /tmp/db is not allowed in release builds. \
-                     Please set CONFIG_PATH environment variable or configure [cluster.db_root_dir] \
-                     in your config file.".into()
-                )));
-            }
-
-            #[cfg(debug_assertions)]
-            {
-                warn!(
-                    "⚠️  Using default /tmp/db (data will be lost on reboot). \
-                     Set CONFIG_PATH or configure [cluster.db_root_dir] for production."
-                );
-            }
+        // Warn if data path is under /tmp — caller's responsibility to choose a persistent path
+        if self.db_root_dir.starts_with("/tmp") {
+            warn!(
+                "db_root_dir {:?} is a temporary path — data will be lost on reboot. \
+                 Use a persistent path for production.",
+                self.db_root_dir
+            );
         }
 
         validate_directory(&self.db_root_dir, "db_root_dir")?;

--- a/d-engine-server/README.md
+++ b/d-engine-server/README.md
@@ -68,9 +68,8 @@ use tokio::sync::watch;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    std::env::set_var("CONFIG_PATH", "config.toml");
     let (_shutdown_tx, shutdown_rx) = watch::channel(());
-    StandaloneEngine::run(shutdown_rx).await?;
+    StandaloneEngine::run("./data", shutdown_rx).await?;
     Ok(())
 }
 ```

--- a/d-engine-server/src/api/embedded.rs
+++ b/d-engine-server/src/api/embedded.rs
@@ -15,7 +15,7 @@
 //!
 //! ### Using EmbeddedEngine (High-level API)
 //! ```ignore
-//! let engine = EmbeddedEngine::start().await?;
+//! let engine = EmbeddedEngine::start("./data/my-app").await?;
 //! engine.wait_ready(Duration::from_secs(5)).await?;
 //! let client = engine.client();
 //! engine.stop().await?;
@@ -167,7 +167,7 @@ struct Inner {
 /// use d_engine::EmbeddedEngine;
 /// use std::time::Duration;
 ///
-/// let engine = EmbeddedEngine::start().await?;  // Returns Arc<EmbeddedEngine>
+/// let engine = EmbeddedEngine::start("./data/my-app").await?;
 /// engine.wait_ready(Duration::from_secs(5)).await?;
 ///
 /// let client = engine.client();
@@ -181,53 +181,59 @@ pub struct EmbeddedEngine {
 }
 
 impl EmbeddedEngine {
-    /// Start engine with configuration from environment.
+    /// Start engine with an explicit data directory.
     ///
-    /// Reads `CONFIG_PATH` environment variable or uses default configuration.
-    /// Data directory is determined by config's `cluster.db_root_dir` setting.
+    /// `data_dir` has highest priority and always overrides `cluster.db_root_dir` from
+    /// `CONFIG_PATH` or `RAFT__` environment variables. Other configuration (network,
+    /// Raft timeouts, cluster topology) is still read from those sources if set.
+    ///
+    /// The directory is created automatically if it does not exist.
+    /// If it already contains data the engine opens it in place (idempotent).
     ///
     /// # Example
     /// ```ignore
-    /// // Set config path via environment variable
-    /// std::env::set_var("CONFIG_PATH", "/etc/d-engine/production.toml");
-    ///
-    /// let engine = EmbeddedEngine::start().await?;
+    /// // Minimal — just supply a path
+    /// let engine = EmbeddedEngine::start("./data/my-app").await?;
     /// engine.wait_ready(Duration::from_secs(5)).await?;
+    ///
+    /// // Works with any AsRef<Path>
+    /// let engine = EmbeddedEngine::start(std::path::Path::new("/var/lib/my-app")).await?;
     /// ```
     #[cfg(feature = "rocksdb")]
-    pub async fn start() -> Result<Self> {
-        let config = d_engine_core::RaftNodeConfig::new()?.validate()?;
-        let base_dir = &config.cluster.db_root_dir;
-        tokio::fs::create_dir_all(base_dir)
+    pub async fn start(data_dir: impl AsRef<std::path::Path>) -> Result<Self> {
+        let mut config = d_engine_core::RaftNodeConfig::new()?;
+        config.cluster.db_root_dir = data_dir.as_ref().to_path_buf();
+        let config = config.validate()?;
+
+        let base_dir = config.cluster.db_root_dir.clone();
+        tokio::fs::create_dir_all(&base_dir)
             .await
             .map_err(|e| crate::Error::Fatal(format!("Failed to create data directory: {e}")))?;
 
         let (storage, mut sm) = if config.storage.unified_db {
-            let db_path = std::path::PathBuf::from(base_dir).join("db");
+            let db_path = base_dir.join("db");
             info!(
                 "Starting embedded engine with unified RocksDB at {:?}",
                 db_path
             );
             RocksDBUnifiedEngine::open(&db_path)?
         } else {
-            let base = std::path::PathBuf::from(base_dir);
             info!(
                 "Starting embedded engine with separate RocksDB instances at {:?}",
-                base
+                base_dir
             );
-            let storage = RocksDBStorageEngine::new(base.join("storage"))?;
-            let sm = RocksDBStateMachine::new(base.join("state_machine"))?;
+            let storage = RocksDBStorageEngine::new(base_dir.join("storage"))?;
+            let sm = RocksDBStateMachine::new(base_dir.join("state_machine"))?;
             (storage, sm)
         };
 
-        // Inject lease if enabled
         let lease_cfg = &config.raft.state_machine.lease;
         if lease_cfg.enabled {
             let lease = Arc::new(crate::storage::DefaultLease::new(lease_cfg.clone()));
             sm.set_lease(lease);
         }
 
-        Self::start_custom(Arc::new(storage), Arc::new(sm), None).await
+        Self::start_node(config, Arc::new(storage), Arc::new(sm)).await
     }
 
     /// Start engine with explicit configuration file.
@@ -305,12 +311,6 @@ impl EmbeddedEngine {
         SE: StorageEngine + std::fmt::Debug + 'static,
         SM: StateMachine + std::fmt::Debug + 'static,
     {
-        info!("Starting embedded d-engine");
-
-        // Create shutdown channel
-        let (shutdown_tx, shutdown_rx) = watch::channel(());
-
-        // Load config or use default
         let node_config = if let Some(path) = config_path {
             d_engine_core::RaftNodeConfig::default()
                 .with_override_config(path)?
@@ -319,18 +319,32 @@ impl EmbeddedEngine {
             d_engine_core::RaftNodeConfig::new()?.validate()?
         };
 
-        // Build node and start RPC server
+        Self::start_node(node_config, storage_engine, state_machine).await
+    }
+
+    /// Build and launch the node from a validated config and pre-built storage.
+    async fn start_node<SE, SM>(
+        node_config: d_engine_core::RaftNodeConfig,
+        storage_engine: Arc<SE>,
+        state_machine: Arc<SM>,
+    ) -> Result<Self>
+    where
+        SE: StorageEngine + std::fmt::Debug + 'static,
+        SM: StateMachine + std::fmt::Debug + 'static,
+    {
+        info!("Starting embedded d-engine");
+
+        let (shutdown_tx, shutdown_rx) = watch::channel(());
+
         let node = NodeBuilder::init(node_config, shutdown_rx)
             .storage_engine(storage_engine)
             .state_machine(state_machine)
             .start()
             .await?;
 
-        // Get notifiers before node is moved into the background task.
         let leader_elected_rx = node.leader_change_notifier();
         let membership_rx = node.membership_change_notifier();
 
-        // Create client before spawning
         #[cfg(not(feature = "watch"))]
         let client = Arc::new(EmbeddedClient::new_internal(
             node.event_tx.clone(),
@@ -356,7 +370,6 @@ impl EmbeddedEngine {
 
         let node_id = node.node_id();
 
-        // Spawn node.run() in background
         let node_handle = tokio::spawn(async move {
             if let Err(e) = node.run().await {
                 error!("Node run error: {:?}", e);
@@ -411,7 +424,7 @@ impl EmbeddedEngine {
     /// # Example
     /// ```ignore
     /// // Single-node development
-    /// let engine = EmbeddedEngine::start().await?;
+    /// let engine = EmbeddedEngine::start("./data/my-app").await?;
     /// let leader = engine.wait_ready(Duration::from_secs(3)).await?;
     ///
     /// // Multi-node production
@@ -575,7 +588,7 @@ impl EmbeddedEngine {
     ///
     /// # Example
     /// ```ignore
-    /// let engine = EmbeddedEngine::start().await?;
+    /// let engine = EmbeddedEngine::start("./data/my-app").await?;
     /// engine.wait_ready(Duration::from_secs(5)).await?;
     /// let client = engine.client();
     /// client.put(b"key", b"value").await?;

--- a/d-engine-server/src/api/embedded_client.rs
+++ b/d-engine-server/src/api/embedded_client.rs
@@ -10,7 +10,7 @@
 //!
 //! # Usage
 //! ```rust,ignore
-//! let engine = EmbeddedEngine::start().await?;
+//! let engine = EmbeddedEngine::start("./data").await?;
 //! let client = engine.client();
 //! client.put(b"key", b"value").await?;
 //! ```

--- a/d-engine-server/src/api/embedded_env_test.rs
+++ b/d-engine-server/src/api/embedded_env_test.rs
@@ -1,155 +1,113 @@
-//! Sequential tests for EmbeddedEngine that modify global environment variables
+//! Tests for EmbeddedEngine::start(data_dir) behaviour
 //!
-//! These tests must run sequentially (--test-threads=1) to avoid race conditions
-//! from concurrent modifications to process-level CONFIG_PATH environment variable.
+//! Sequential execution required to avoid env-var race conditions.
 
 #[cfg(test)]
 #[cfg(feature = "rocksdb")]
-mod config_env_tests {
+mod start_data_dir_tests {
     use serial_test::serial;
 
     use crate::api::EmbeddedEngine;
 
-    // Tests for start() method with CONFIG_PATH environment variable
-
+    /// data_dir is created automatically when it does not exist.
     #[tokio::test]
-    #[cfg(debug_assertions)]
     #[serial]
-    async fn test_start_with_config_path_env_valid() {
-        let _temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let config_path = _temp_dir.path().join("test_config.toml");
-        let data_dir = _temp_dir.path().join("data");
+    async fn test_start_creates_missing_directory() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let data_dir = temp_dir.path().join("auto-created");
 
-        // Create valid config with custom db_root_dir
-        let config_content = format!(
-            r#"
-[cluster]
-node_id = 1
-db_root_dir = "{}"
-
-[cluster.rpc]
-listen_addr = "127.0.0.1:0"
-"#,
-            data_dir.display()
-        );
-        std::fs::write(&config_path, config_content).expect("Failed to write config");
-
-        // Set CONFIG_PATH env var and test
-        unsafe {
-            std::env::set_var("CONFIG_PATH", config_path.to_str().unwrap());
-        }
-        let result = EmbeddedEngine::start().await;
-        unsafe {
-            std::env::remove_var("CONFIG_PATH");
-        }
-
+        assert!(!data_dir.exists());
+        let result = EmbeddedEngine::start(&data_dir).await;
         assert!(
             result.is_ok(),
-            "start() should succeed with valid CONFIG_PATH"
+            "should create dir automatically: {:?}",
+            result.err()
         );
+        assert!(data_dir.exists());
 
         if let Ok(engine) = result {
             engine.stop().await.ok();
         }
     }
 
+    /// Opening an existing data directory is idempotent (data is preserved).
     #[tokio::test]
-    #[cfg(debug_assertions)]
     #[serial]
-    async fn test_start_with_config_path_env_nonexistent() {
-        // Set CONFIG_PATH to nonexistent file
-        unsafe {
-            std::env::set_var("CONFIG_PATH", "/nonexistent/config.toml");
-        }
-        let result = EmbeddedEngine::start().await;
-        unsafe {
-            std::env::remove_var("CONFIG_PATH");
+    async fn test_start_existing_directory_is_idempotent() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let data_dir = temp_dir.path().join("db");
+
+        // First start: write a key
+        {
+            let engine = EmbeddedEngine::start(&data_dir).await.expect("first start");
+            engine.wait_ready(std::time::Duration::from_secs(5)).await.expect("ready");
+            engine.client().put(b"k".to_vec(), b"v".to_vec()).await.expect("put");
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            engine.stop().await.ok();
         }
 
-        assert!(
-            result.is_err(),
-            "start() should fail with nonexistent CONFIG_PATH"
-        );
+        // Second start: data must still be there
+        {
+            let engine = EmbeddedEngine::start(&data_dir).await.expect("second start");
+            engine.wait_ready(std::time::Duration::from_secs(5)).await.expect("ready");
+            let val = engine.client().get_linearizable(b"k".to_vec()).await.expect("get");
+            assert_eq!(val.as_deref(), Some(b"v".as_ref()), "data must persist");
+            engine.stop().await.ok();
+        }
     }
 
+    /// data_dir overrides cluster.db_root_dir set in CONFIG_PATH.
     #[tokio::test]
-    #[cfg(debug_assertions)]
+    #[serial]
+    async fn test_start_data_dir_overrides_config_path_db_root_dir() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let config_data_dir = temp_dir.path().join("from-config");
+        let explicit_data_dir = temp_dir.path().join("from-arg");
+
+        // Write a config that points at a different directory
+        let config_path = temp_dir.path().join("test.toml");
+        std::fs::write(
+            &config_path,
+            format!(
+                "[cluster]\ndb_root_dir = \"{}\"\n[cluster.rpc]\nlisten_addr = \"127.0.0.1:0\"\n",
+                config_data_dir.display()
+            ),
+        )
+        .expect("write config");
+
+        unsafe { std::env::set_var("CONFIG_PATH", config_path.to_str().unwrap()) };
+
+        let result = EmbeddedEngine::start(&explicit_data_dir).await;
+
+        unsafe { std::env::remove_var("CONFIG_PATH") };
+
+        assert!(result.is_ok(), "should succeed: {:?}", result.err());
+        assert!(explicit_data_dir.exists(), "explicit path must be used");
+        assert!(!config_data_dir.exists(), "config path must be ignored");
+
+        if let Ok(engine) = result {
+            engine.stop().await.ok();
+        }
+    }
+
+    /// /tmp paths emit a warning but are not rejected.
+    #[tokio::test]
     #[serial(tmp_db)]
-    async fn test_start_with_config_path_env_tmp_db_allows_in_debug() {
-        let _temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let config_path = _temp_dir.path().join("test_config.toml");
+    async fn test_start_tmp_path_warns_but_succeeds() {
+        let tmp_path = std::path::PathBuf::from("/tmp/d-engine-env-test");
+        let _ = std::fs::remove_dir_all(&tmp_path);
 
-        // Clean up /tmp/db before test
-        let _ = std::fs::remove_dir_all("/tmp/db");
-
-        // Create config with /tmp/db
-        let config_content = r#"
-[cluster]
-node_id = 1
-db_root_dir = "/tmp/db"
-
-[cluster.rpc]
-listen_addr = "127.0.0.1:0"
-"#;
-        std::fs::write(&config_path, config_content).expect("Failed to write config");
-
-        // In debug mode, should succeed with warning
-        unsafe {
-            std::env::set_var("CONFIG_PATH", config_path.to_str().unwrap());
-        }
-        let result = EmbeddedEngine::start().await;
-        unsafe {
-            std::env::remove_var("CONFIG_PATH");
-        }
+        let result = EmbeddedEngine::start(&tmp_path).await;
 
         assert!(
             result.is_ok(),
-            "start() should allow /tmp/db in debug mode with CONFIG_PATH"
+            "/tmp path should succeed with warn, not error: {:?}",
+            result.err()
         );
 
         if let Ok(engine) = result {
             engine.stop().await.ok();
         }
-
-        // Clean up after test
-        let _ = std::fs::remove_dir_all("/tmp/db");
-    }
-
-    #[tokio::test]
-    #[cfg(not(debug_assertions))]
-    #[serial]
-    async fn test_start_with_config_path_env_tmp_db_rejects_in_release() {
-        let _temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let config_path = _temp_dir.path().join("test_config.toml");
-
-        // Create config with /tmp/db
-        let config_content = r#"
-[cluster]
-node_id = 1
-db_root_dir = "/tmp/db"
-
-[cluster.rpc]
-listen_addr = "127.0.0.1:0"
-"#;
-        std::fs::write(&config_path, config_content).expect("Failed to write config");
-
-        // In release mode, should reject
-        unsafe {
-            std::env::set_var("CONFIG_PATH", config_path.to_str().unwrap());
-        }
-        let result = EmbeddedEngine::start().await;
-        unsafe {
-            std::env::remove_var("CONFIG_PATH");
-        }
-
-        assert!(
-            result.is_err(),
-            "start() should reject /tmp/db in release mode with CONFIG_PATH"
-        );
-
-        if let Err(e) = result {
-            let err_msg = format!("{:?}", e);
-            assert!(err_msg.contains("/tmp/db") || err_msg.contains("db_root_dir"));
-        }
+        let _ = std::fs::remove_dir_all(&tmp_path);
     }
 }

--- a/d-engine-server/src/api/embedded_test.rs
+++ b/d-engine-server/src/api/embedded_test.rs
@@ -346,22 +346,17 @@ mod embedded_engine_tests {
         // to run sequentially and avoid environment variable race conditions
 
         #[tokio::test]
-        #[cfg(debug_assertions)]
         #[serial(tmp_db)]
-        async fn test_start_without_config_path_env_allows_in_debug() {
-            // No CONFIG_PATH env var - uses default config with /tmp/db
-            unsafe {
-                std::env::remove_var("CONFIG_PATH");
-            }
+        async fn test_start_with_tmp_path_warns_but_succeeds() {
+            // /tmp paths warn but are not rejected — caller's choice
+            let tmp_path = std::path::PathBuf::from("/tmp/d-engine-test-start");
+            let _ = std::fs::remove_dir_all(&tmp_path);
 
-            // Clean up /tmp/db before test to avoid corruption from previous runs
-            let _ = std::fs::remove_dir_all("/tmp/db");
-
-            let result = EmbeddedEngine::start().await;
+            let result = EmbeddedEngine::start(&tmp_path).await;
 
             assert!(
                 result.is_ok(),
-                "start() should allow default /tmp/db in debug mode without CONFIG_PATH. Error: {:?}",
+                "start() should succeed with /tmp path (warn only). Error: {:?}",
                 result.as_ref().err()
             );
 
@@ -369,28 +364,31 @@ mod embedded_engine_tests {
                 engine.stop().await.ok();
             }
 
-            // Clean up after test
-            let _ = std::fs::remove_dir_all("/tmp/db");
+            let _ = std::fs::remove_dir_all(&tmp_path);
         }
 
         #[tokio::test]
-        #[cfg(not(debug_assertions))]
         #[serial]
-        async fn test_start_without_config_path_env_rejects_in_release() {
-            // No CONFIG_PATH env var - should reject default /tmp/db in release
-            unsafe {
-                std::env::remove_var("CONFIG_PATH");
-            }
-            let result = EmbeddedEngine::start().await;
+        async fn test_start_creates_directory_if_not_exists() {
+            let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+            let data_dir = temp_dir.path().join("new-subdir").join("db");
 
             assert!(
-                result.is_err(),
-                "start() should reject default /tmp/db in release mode without CONFIG_PATH"
+                !data_dir.exists(),
+                "Directory should not exist before start"
             );
 
-            if let Err(e) = result {
-                let err_msg = format!("{:?}", e);
-                assert!(err_msg.contains("/tmp/db") || err_msg.contains("db_root_dir"));
+            let result = EmbeddedEngine::start(&data_dir).await;
+
+            assert!(
+                result.is_ok(),
+                "start() should auto-create missing directories. Error: {:?}",
+                result.as_ref().err()
+            );
+            assert!(data_dir.exists(), "Directory should be created by start()");
+
+            if let Ok(engine) = result {
+                engine.stop().await.ok();
             }
         }
 

--- a/d-engine-server/src/api/standalone.rs
+++ b/d-engine-server/src/api/standalone.rs
@@ -19,27 +19,33 @@ use crate::node::NodeBuilder;
 pub struct StandaloneEngine;
 
 impl StandaloneEngine {
-    /// Run server with configuration from environment.
+    /// Run server with an explicit data directory.
     ///
-    /// Reads `CONFIG_PATH` environment variable or uses default configuration.
-    /// Data directory is determined by config's `cluster.db_root_dir` setting.
+    /// `data_dir` has highest priority and always overrides `cluster.db_root_dir` from
+    /// `CONFIG_PATH` or `RAFT__` environment variables. Other configuration (network,
+    /// Raft timeouts, cluster topology) is still read from those sources if set.
+    ///
+    /// The directory is created automatically if it does not exist.
     /// Blocks until shutdown signal is received.
     ///
     /// # Arguments
+    /// * `data_dir` - Path to the data directory
     /// * `shutdown_rx` - Shutdown signal receiver
     ///
     /// # Example
     /// ```ignore
-    /// // Set config path via environment variable
-    /// std::env::set_var("CONFIG_PATH", "/etc/d-engine/production.toml");
-    ///
     /// let (shutdown_tx, shutdown_rx) = watch::channel(());
-    /// StandaloneEngine::run(shutdown_rx).await?;
+    /// StandaloneEngine::run("./data/my-node", shutdown_rx).await?;
     /// ```
     #[cfg(feature = "rocksdb")]
-    pub async fn run(shutdown_rx: watch::Receiver<()>) -> Result<()> {
-        let config = d_engine_core::RaftNodeConfig::new()?.validate()?;
-        let base_dir = std::path::PathBuf::from(&config.cluster.db_root_dir);
+    pub async fn run(
+        data_dir: impl AsRef<std::path::Path>,
+        shutdown_rx: watch::Receiver<()>,
+    ) -> Result<()> {
+        let mut config = d_engine_core::RaftNodeConfig::new()?;
+        config.cluster.db_root_dir = data_dir.as_ref().to_path_buf();
+        let config = config.validate()?;
+        let base_dir = config.cluster.db_root_dir.clone();
 
         tokio::fs::create_dir_all(&base_dir)
             .await
@@ -62,14 +68,13 @@ impl StandaloneEngine {
             (storage, sm)
         };
 
-        // Inject lease if enabled
         let lease_cfg = &config.raft.state_machine.lease;
         if lease_cfg.enabled {
             let lease = Arc::new(crate::storage::DefaultLease::new(lease_cfg.clone()));
             sm.set_lease(lease);
         }
 
-        Self::run_custom(Arc::new(storage), Arc::new(sm), shutdown_rx, None).await
+        Self::start_node(config, Arc::new(storage), Arc::new(sm), shutdown_rx).await
     }
 
     /// Run server with explicit configuration file.
@@ -125,13 +130,7 @@ impl StandaloneEngine {
             sm.set_lease(lease);
         }
 
-        Self::run_custom(
-            Arc::new(storage),
-            Arc::new(sm),
-            shutdown_rx,
-            Some(config_path),
-        )
-        .await
+        Self::start_node(config, Arc::new(storage), Arc::new(sm), shutdown_rx).await
     }
 
     /// Run server with custom storage engine and state machine.
@@ -163,20 +162,31 @@ impl StandaloneEngine {
         SE: StorageEngine + std::fmt::Debug + 'static,
         SM: StateMachine + std::fmt::Debug + 'static,
     {
-        let node_config = if let Some(path) = config_path {
+        let config = if let Some(path) = config_path {
             d_engine_core::RaftNodeConfig::default()
                 .with_override_config(path)?
                 .validate()?
         } else {
             d_engine_core::RaftNodeConfig::new()?.validate()?
         };
+        Self::start_node(config, storage_engine, state_machine, shutdown_rx).await
+    }
 
-        let node = NodeBuilder::init(node_config, shutdown_rx)
+    async fn start_node<SE, SM>(
+        config: d_engine_core::RaftNodeConfig,
+        storage_engine: Arc<SE>,
+        state_machine: Arc<SM>,
+        shutdown_rx: watch::Receiver<()>,
+    ) -> Result<()>
+    where
+        SE: StorageEngine + std::fmt::Debug + 'static,
+        SM: StateMachine + std::fmt::Debug + 'static,
+    {
+        let node = NodeBuilder::init(config, shutdown_rx)
             .storage_engine(storage_engine)
             .state_machine(state_machine)
             .start()
             .await?;
-
         node.run().await
     }
 }

--- a/d-engine-server/src/api/standalone_test.rs
+++ b/d-engine-server/src/api/standalone_test.rs
@@ -2,7 +2,6 @@
 
 #[cfg(all(test, feature = "rocksdb"))]
 mod standalone_server_tests {
-    #[cfg(debug_assertions)]
     use std::time::Duration;
 
     use serial_test::serial;
@@ -10,376 +9,150 @@ mod standalone_server_tests {
 
     use crate::api::StandaloneEngine;
 
-    // Tests for run() method (reads CONFIG_PATH env var)
+    // ── run(data_dir, shutdown_rx) tests ─────────────────────────────────────
 
+    /// run() creates the data directory automatically when it does not exist.
     #[tokio::test]
-    #[cfg(debug_assertions)]
     #[serial]
-    async fn test_run_with_config_path_env_valid() {
-        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let config_path = temp_dir.path().join("test_config.toml");
-        let data_dir = temp_dir.path().join("data");
-
-        // Create valid config with custom db_root_dir
-        let config_content = format!(
-            r#"
-[cluster]
-node_id = 1
-db_root_dir = "{}"
-
-[cluster.rpc]
-listen_addr = "127.0.0.1:0"
-"#,
-            data_dir.display()
-        );
-        std::fs::write(&config_path, config_content).expect("Failed to write config");
+    async fn test_run_creates_missing_directory() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let data_dir = temp_dir.path().join("auto-created");
+        assert!(!data_dir.exists());
 
         let (shutdown_tx, shutdown_rx) = watch::channel(());
+        let dir_clone = data_dir.clone();
+        let handle =
+            tokio::spawn(async move { StandaloneEngine::run(&dir_clone, shutdown_rx).await });
 
-        // Set CONFIG_PATH env var
-        unsafe {
-            std::env::set_var("CONFIG_PATH", config_path.to_str().unwrap());
-        }
-
-        // Spawn server in background
-        let server_handle = tokio::spawn(async move { StandaloneEngine::run(shutdown_rx).await });
-
-        // Give it time to start
         tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(data_dir.exists(), "directory must be created automatically");
 
-        // Send shutdown signal
-        let _ = shutdown_tx.send(());
-
-        // Cleanup env var
-        unsafe {
-            std::env::remove_var("CONFIG_PATH");
-        }
-
-        // Wait for server to stop
-        let result = tokio::time::timeout(Duration::from_secs(5), server_handle)
+        shutdown_tx.send(()).ok();
+        let result = tokio::time::timeout(Duration::from_secs(5), handle)
             .await
-            .expect("Server should stop within timeout")
-            .expect("Server task should not panic");
-
-        assert!(
-            result.is_ok(),
-            "run() should succeed with valid CONFIG_PATH"
-        );
+            .expect("server must stop within timeout")
+            .expect("server task must not panic");
+        assert!(result.is_ok(), "run() should succeed: {:?}", result.err());
     }
 
+    /// /tmp data_dir emits a warning but is not rejected.
     #[tokio::test]
-    #[cfg(debug_assertions)]
-    #[serial]
-    async fn test_run_with_config_path_env_nonexistent() {
-        let (_shutdown_tx, shutdown_rx) = watch::channel(());
-
-        // Set CONFIG_PATH to nonexistent file
-        unsafe {
-            std::env::set_var("CONFIG_PATH", "/nonexistent/config.toml");
-        }
-
-        let result = StandaloneEngine::run(shutdown_rx).await;
-
-        unsafe {
-            std::env::remove_var("CONFIG_PATH");
-        }
-
-        assert!(
-            result.is_err(),
-            "run() should fail with nonexistent CONFIG_PATH"
-        );
-    }
-
-    #[tokio::test]
-    #[cfg(debug_assertions)]
     #[serial(tmp_db)]
-    async fn test_run_with_config_path_env_tmp_db_allows_in_debug() {
-        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let config_path = temp_dir.path().join("test_config.toml");
-
-        // Clean up /tmp/db before test
-        let _ = std::fs::remove_dir_all("/tmp/db");
-
-        // Create config with /tmp/db
-        let config_content = r#"
-[cluster]
-node_id = 1
-db_root_dir = "/tmp/db"
-
-[cluster.rpc]
-listen_addr = "127.0.0.1:0"
-"#;
-        std::fs::write(&config_path, config_content).expect("Failed to write config");
+    async fn test_run_tmp_path_warns_but_succeeds() {
+        let tmp_path = std::path::PathBuf::from("/tmp/d-engine-standalone-test");
+        let _ = std::fs::remove_dir_all(&tmp_path);
 
         let (shutdown_tx, shutdown_rx) = watch::channel(());
+        let path_clone = tmp_path.clone();
+        let handle =
+            tokio::spawn(async move { StandaloneEngine::run(&path_clone, shutdown_rx).await });
 
-        unsafe {
-            std::env::set_var("CONFIG_PATH", config_path.to_str().unwrap());
-        }
-
-        // Spawn server in background
-        let server_handle = tokio::spawn(async move { StandaloneEngine::run(shutdown_rx).await });
-
-        // Give it time to start
         tokio::time::sleep(Duration::from_millis(100)).await;
+        shutdown_tx.send(()).ok();
 
-        // Send shutdown signal
-        let _ = shutdown_tx.send(());
-
-        unsafe {
-            std::env::remove_var("CONFIG_PATH");
-        }
-
-        // Wait for server to stop
-        let result = tokio::time::timeout(Duration::from_secs(5), server_handle)
+        let result = tokio::time::timeout(Duration::from_secs(5), handle)
             .await
-            .expect("Server should stop within timeout")
-            .expect("Server task should not panic");
-
-        // In debug mode, should succeed with warning
+            .expect("server must stop within timeout")
+            .expect("server task must not panic");
         assert!(
             result.is_ok(),
-            "run() should allow /tmp/db in debug mode with CONFIG_PATH"
+            "/tmp path should succeed with warning: {:?}",
+            result.err()
         );
 
-        // Clean up after test
-        let _ = std::fs::remove_dir_all("/tmp/db");
+        let _ = std::fs::remove_dir_all(&tmp_path);
     }
 
+    /// data_dir overrides cluster.db_root_dir set in CONFIG_PATH.
     #[tokio::test]
-    #[cfg(not(debug_assertions))]
     #[serial]
-    async fn test_run_with_config_path_env_tmp_db_rejects_in_release() {
-        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let config_path = temp_dir.path().join("test_config.toml");
+    async fn test_run_data_dir_overrides_config_path_db_root_dir() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let config_data_dir = temp_dir.path().join("from-config");
+        let explicit_data_dir = temp_dir.path().join("from-arg");
 
-        // Create config with /tmp/db
-        let config_content = r#"
-[cluster]
-node_id = 1
-db_root_dir = "/tmp/db"
+        let config_path = temp_dir.path().join("test.toml");
+        std::fs::write(
+            &config_path,
+            format!(
+                "[cluster]\ndb_root_dir = \"{}\"\n[cluster.rpc]\nlisten_addr = \"127.0.0.1:0\"\n",
+                config_data_dir.display()
+            ),
+        )
+        .expect("write config");
 
-[cluster.rpc]
-listen_addr = "127.0.0.1:0"
-"#;
-        std::fs::write(&config_path, config_content).expect("Failed to write config");
-
-        let (_shutdown_tx, shutdown_rx) = watch::channel(());
-
-        unsafe {
-            std::env::set_var("CONFIG_PATH", config_path.to_str().unwrap());
-        }
-
-        // In release mode, should reject immediately
-        let result = StandaloneEngine::run(shutdown_rx).await;
-
-        unsafe {
-            std::env::remove_var("CONFIG_PATH");
-        }
-
-        assert!(
-            result.is_err(),
-            "run() should reject /tmp/db in release mode with CONFIG_PATH"
-        );
-
-        if let Err(e) = result {
-            let err_msg = format!("{:?}", e);
-            assert!(err_msg.contains("/tmp/db") || err_msg.contains("db_root_dir"));
-        }
-    }
-
-    #[tokio::test]
-    #[cfg(debug_assertions)]
-    #[serial(tmp_db)]
-    async fn test_run_without_config_path_env_allows_in_debug() {
-        // No CONFIG_PATH env var - uses default config with /tmp/db
-        unsafe {
-            std::env::remove_var("CONFIG_PATH");
-        }
-
-        // Clean up /tmp/db before test
-        let _ = std::fs::remove_dir_all("/tmp/db");
+        unsafe { std::env::set_var("CONFIG_PATH", config_path.to_str().unwrap()) };
 
         let (shutdown_tx, shutdown_rx) = watch::channel(());
+        let dir_clone = explicit_data_dir.clone();
+        let handle =
+            tokio::spawn(async move { StandaloneEngine::run(&dir_clone, shutdown_rx).await });
 
-        // Spawn server in background
-        let server_handle = tokio::spawn(async move { StandaloneEngine::run(shutdown_rx).await });
-
-        // Give it time to start
         tokio::time::sleep(Duration::from_millis(100)).await;
+        shutdown_tx.send(()).ok();
 
-        // Send shutdown signal
-        let _ = shutdown_tx.send(());
+        unsafe { std::env::remove_var("CONFIG_PATH") };
 
-        // Wait for server to stop
-        let result = tokio::time::timeout(Duration::from_secs(5), server_handle)
+        let result = tokio::time::timeout(Duration::from_secs(5), handle)
             .await
-            .expect("Server should stop within timeout")
-            .expect("Server task should not panic");
-
-        assert!(
-            result.is_ok(),
-            "run() should allow default /tmp/db in debug mode without CONFIG_PATH"
-        );
-
-        // Clean up after test
-        let _ = std::fs::remove_dir_all("/tmp/db");
+            .expect("server must stop within timeout")
+            .expect("server task must not panic");
+        assert!(result.is_ok(), "should succeed: {:?}", result.err());
+        assert!(explicit_data_dir.exists(), "explicit path must be used");
+        assert!(!config_data_dir.exists(), "config path must be ignored");
     }
 
+    /// Nonexistent CONFIG_PATH still causes a config-load error.
     #[tokio::test]
-    #[cfg(not(debug_assertions))]
     #[serial]
-    async fn test_run_without_config_path_env_rejects_in_release() {
-        // No CONFIG_PATH env var - should reject default /tmp/db in release
-        unsafe {
-            std::env::remove_var("CONFIG_PATH");
-        }
-
+    async fn test_run_config_path_nonexistent_fails() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let data_dir = temp_dir.path().join("db");
         let (_shutdown_tx, shutdown_rx) = watch::channel(());
 
-        // In release mode, should reject immediately
-        let result = StandaloneEngine::run(shutdown_rx).await;
+        unsafe { std::env::set_var("CONFIG_PATH", "/nonexistent/config.toml") };
+        let result = StandaloneEngine::run(&data_dir, shutdown_rx).await;
+        unsafe { std::env::remove_var("CONFIG_PATH") };
 
-        assert!(
-            result.is_err(),
-            "run() should reject default /tmp/db in release mode without CONFIG_PATH"
-        );
-
-        if let Err(e) = result {
-            let err_msg = format!("{:?}", e);
-            assert!(err_msg.contains("/tmp/db") || err_msg.contains("db_root_dir"));
-        }
+        assert!(result.is_err(), "nonexistent CONFIG_PATH should fail");
     }
 
-    // Tests for run_with() method (explicit config path)
+    // ── run_with(config_path, shutdown_rx) tests ─────────────────────────────
 
     #[tokio::test]
-    #[cfg(debug_assertions)]
-    #[serial]
-    async fn test_run_with_default_db_root_dir_allows_in_debug() {
-        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let config_path = temp_dir.path().join("test_config.toml");
-
-        // Clean up /tmp/db before test
-        let _ = std::fs::remove_dir_all("/tmp/db");
-
-        // Create config without db_root_dir (will use default /tmp/db)
-        let config_content = r#"
-[cluster]
-node_id = 1
-
-[cluster.rpc]
-listen_addr = "127.0.0.1:0"
-"#;
-        std::fs::write(&config_path, config_content).expect("Failed to write config");
-
-        let (shutdown_tx, shutdown_rx) = watch::channel(());
-
-        // Spawn server in background
-        let server_handle = tokio::spawn(async move {
-            StandaloneEngine::run_with(config_path.to_str().unwrap(), shutdown_rx).await
-        });
-
-        // Give it time to start
-        tokio::time::sleep(Duration::from_millis(100)).await;
-
-        // Send shutdown signal
-        let _ = shutdown_tx.send(());
-
-        // Wait for server to stop
-        let result = tokio::time::timeout(Duration::from_secs(5), server_handle)
-            .await
-            .expect("Server should stop within timeout")
-            .expect("Server task should not panic");
-
-        // In debug mode, should succeed (allows /tmp/db with warning)
-        assert!(
-            result.is_ok(),
-            "run_with() should succeed in debug mode with default /tmp/db"
-        );
-
-        // Clean up after test
-        let _ = std::fs::remove_dir_all("/tmp/db");
-    }
-
-    #[tokio::test]
-    #[cfg(not(debug_assertions))]
-    #[serial]
-    async fn test_run_with_default_db_root_dir_rejects_in_release() {
-        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let config_path = temp_dir.path().join("test_config.toml");
-
-        // Create config without db_root_dir (will use default /tmp/db)
-        let config_content = r#"
-[cluster]
-node_id = 1
-
-[cluster.rpc]
-listen_addr = "127.0.0.1:0"
-"#;
-        std::fs::write(&config_path, config_content).expect("Failed to write config");
-
-        let (_shutdown_tx, shutdown_rx) = watch::channel(());
-
-        // In release mode, should reject /tmp/db immediately
-        let result = StandaloneEngine::run_with(config_path.to_str().unwrap(), shutdown_rx).await;
-
-        assert!(
-            result.is_err(),
-            "run_with() should reject /tmp/db in release mode"
-        );
-
-        if let Err(e) = result {
-            let err_msg = format!("{:?}", e);
-            assert!(err_msg.contains("/tmp/db") || err_msg.contains("db_root_dir"));
-        }
-    }
-
-    #[tokio::test]
-    #[cfg(debug_assertions)]
     async fn test_run_with_valid_config() {
-        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let config_path = temp_dir.path().join("test_config.toml");
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let config_path = temp_dir.path().join("config.toml");
         let data_dir = temp_dir.path().join("data");
 
-        // Create valid config with custom db_root_dir
-        let config_content = format!(
-            r#"
-[cluster]
-node_id = 1
-db_root_dir = "{}"
-
-[cluster.rpc]
-listen_addr = "127.0.0.1:0"
-
-[raft]
-heartbeat_idle_flush_interval_ms = 500
-election_timeout_min_ms = 1500
-election_timeout_max_ms = 3000
-"#,
-            data_dir.display()
-        );
-        std::fs::write(&config_path, config_content).expect("Failed to write config");
+        std::fs::write(
+            &config_path,
+            format!(
+                concat!(
+                    "[cluster]\nnode_id = 1\ndb_root_dir = \"{}\"\n\n",
+                    "[cluster.rpc]\nlisten_addr = \"127.0.0.1:0\"\n\n",
+                    "[raft]\nheartbeat_idle_flush_interval_ms = 500\n",
+                    "election_timeout_min_ms = 1500\nelection_timeout_max_ms = 3000\n"
+                ),
+                data_dir.display()
+            ),
+        )
+        .expect("write config");
 
         let (shutdown_tx, shutdown_rx) = watch::channel(());
+        let config_path_str = config_path.to_str().unwrap().to_string();
+        let handle =
+            tokio::spawn(
+                async move { StandaloneEngine::run_with(&config_path_str, shutdown_rx).await },
+            );
 
-        // Spawn server in background
-        let server_handle = tokio::spawn(async move {
-            StandaloneEngine::run_with(config_path.to_str().unwrap(), shutdown_rx).await
-        });
-
-        // Give it time to start
         tokio::time::sleep(Duration::from_millis(100)).await;
+        shutdown_tx.send(()).ok();
 
-        // Send shutdown signal
-        let _ = shutdown_tx.send(());
-
-        // Wait for server to stop
-        let result = tokio::time::timeout(Duration::from_secs(5), server_handle)
+        let result = tokio::time::timeout(Duration::from_secs(5), handle)
             .await
-            .expect("Server should stop within timeout")
-            .expect("Server task should not panic");
-
+            .expect("server must stop within timeout")
+            .expect("server task must not panic");
         assert!(
             result.is_ok(),
             "run_with() should succeed with valid config"
@@ -389,139 +162,82 @@ election_timeout_max_ms = 3000
     #[tokio::test]
     async fn test_run_with_nonexistent_config() {
         let (_shutdown_tx, shutdown_rx) = watch::channel(());
-
         let result = StandaloneEngine::run_with("/nonexistent/config.toml", shutdown_rx).await;
-
         assert!(
             result.is_err(),
             "run_with() should fail with nonexistent config"
         );
     }
 
+    /// run_with() with a /tmp db_root_dir emits a warning but is not rejected.
     #[tokio::test]
-    #[cfg(debug_assertions)]
     #[serial(tmp_db)]
-    async fn test_run_with_tmp_db_allows_in_debug() {
-        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let config_path = temp_dir.path().join("test_config.toml");
+    async fn test_run_with_tmp_db_warns_but_succeeds() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let config_path = temp_dir.path().join("config.toml");
+        let tmp_db = "/tmp/d-engine-standalone-runwith-test";
+        let _ = std::fs::remove_dir_all(tmp_db);
 
-        // Clean up /tmp/db before test
-        let _ = std::fs::remove_dir_all("/tmp/db");
-
-        // Create config with /tmp/db
-        let config_content = r#"
-[cluster]
-node_id = 1
-db_root_dir = "/tmp/db"
-
-[cluster.rpc]
-listen_addr = "127.0.0.1:0"
-"#;
-        std::fs::write(&config_path, config_content).expect("Failed to write config");
+        std::fs::write(
+            &config_path,
+            format!(
+                "[cluster]\nnode_id = 1\ndb_root_dir = \"{tmp_db}\"\n\n[cluster.rpc]\nlisten_addr = \"127.0.0.1:0\"\n"
+            ),
+        )
+        .expect("write config");
 
         let (shutdown_tx, shutdown_rx) = watch::channel(());
+        let config_path_str = config_path.to_str().unwrap().to_string();
+        let handle =
+            tokio::spawn(
+                async move { StandaloneEngine::run_with(&config_path_str, shutdown_rx).await },
+            );
 
-        // Spawn server in background
-        let server_handle = tokio::spawn(async move {
-            StandaloneEngine::run_with(config_path.to_str().unwrap(), shutdown_rx).await
-        });
-
-        // Give it time to start
         tokio::time::sleep(Duration::from_millis(100)).await;
+        shutdown_tx.send(()).ok();
 
-        // Send shutdown signal
-        let _ = shutdown_tx.send(());
-
-        // Wait for server to stop
-        let result = tokio::time::timeout(Duration::from_secs(5), server_handle)
+        let result = tokio::time::timeout(Duration::from_secs(5), handle)
             .await
-            .expect("Server should stop within timeout")
-            .expect("Server task should not panic");
-
-        // In debug mode, should succeed with warning
+            .expect("server must stop within timeout")
+            .expect("server task must not panic");
         assert!(
             result.is_ok(),
-            "run_with() should allow /tmp/db in debug mode"
+            "/tmp path should succeed with warning: {:?}",
+            result.err()
         );
 
-        // Clean up after test
-        let _ = std::fs::remove_dir_all("/tmp/db");
+        let _ = std::fs::remove_dir_all(tmp_db);
     }
 
     #[tokio::test]
-    #[cfg(not(debug_assertions))]
-    #[serial]
-    async fn test_run_with_tmp_db_rejects_in_release() {
-        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let config_path = temp_dir.path().join("test_config.toml");
-
-        // Create config with /tmp/db
-        let config_content = r#"
-[cluster]
-node_id = 1
-db_root_dir = "/tmp/db"
-
-[cluster.rpc]
-listen_addr = "127.0.0.1:0"
-"#;
-        std::fs::write(&config_path, config_content).expect("Failed to write config");
-
-        let (_shutdown_tx, shutdown_rx) = watch::channel(());
-
-        // In release mode, should reject immediately
-        let result = StandaloneEngine::run_with(config_path.to_str().unwrap(), shutdown_rx).await;
-
-        assert!(
-            result.is_err(),
-            "run_with() should reject /tmp/db in release mode"
-        );
-
-        if let Err(e) = result {
-            let err_msg = format!("{:?}", e);
-            assert!(err_msg.contains("/tmp/db") || err_msg.contains("db_root_dir"));
-        }
-    }
-
-    #[tokio::test]
-    #[cfg(debug_assertions)]
-    #[serial]
     async fn test_shutdown_signal_stops_server() {
-        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let config_path = temp_dir.path().join("test_config.toml");
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let config_path = temp_dir.path().join("config.toml");
         let data_dir = temp_dir.path().join("data");
 
-        let config_content = format!(
-            r#"
-[cluster]
-node_id = 1
-db_root_dir = "{}"
-
-[cluster.rpc]
-listen_addr = "127.0.0.1:0"
-"#,
-            data_dir.display()
-        );
-        std::fs::write(&config_path, config_content).expect("Failed to write config");
+        std::fs::write(
+            &config_path,
+            format!(
+                "[cluster]\nnode_id = 1\ndb_root_dir = \"{}\"\n\n[cluster.rpc]\nlisten_addr = \"127.0.0.1:0\"\n",
+                data_dir.display()
+            ),
+        )
+        .expect("write config");
 
         let (shutdown_tx, shutdown_rx) = watch::channel(());
+        let config_path_str = config_path.to_str().unwrap().to_string();
+        let handle =
+            tokio::spawn(
+                async move { StandaloneEngine::run_with(&config_path_str, shutdown_rx).await },
+            );
 
-        let server_handle = tokio::spawn(async move {
-            StandaloneEngine::run_with(config_path.to_str().unwrap(), shutdown_rx).await
-        });
-
-        // Let server start
         tokio::time::sleep(Duration::from_millis(100)).await;
+        shutdown_tx.send(()).expect("send shutdown");
 
-        // Send shutdown signal
-        let send_result = shutdown_tx.send(());
-        assert!(send_result.is_ok(), "Should send shutdown signal");
-
-        // Server should stop gracefully
-        let result = tokio::time::timeout(Duration::from_secs(5), server_handle)
+        let result = tokio::time::timeout(Duration::from_secs(5), handle)
             .await
-            .expect("Server should stop within timeout");
-
-        assert!(result.is_ok(), "Server task should not panic");
+            .expect("server must stop within timeout");
+        assert!(result.is_ok(), "server task should not panic");
     }
 }
 

--- a/d-engine-server/src/api/standalone_test.rs
+++ b/d-engine-server/src/api/standalone_test.rs
@@ -91,12 +91,13 @@ mod standalone_server_tests {
         tokio::time::sleep(Duration::from_millis(100)).await;
         shutdown_tx.send(()).ok();
 
-        unsafe { std::env::remove_var("CONFIG_PATH") };
-
         let result = tokio::time::timeout(Duration::from_secs(5), handle)
             .await
             .expect("server must stop within timeout")
             .expect("server task must not panic");
+
+        unsafe { std::env::remove_var("CONFIG_PATH") };
+
         assert!(result.is_ok(), "should succeed: {:?}", result.err());
         assert!(explicit_data_dir.exists(), "explicit path must be used");
         assert!(!config_data_dir.exists(), "config path must be ignored");

--- a/d-engine-server/src/lib.rs
+++ b/d-engine-server/src/lib.rs
@@ -49,9 +49,8 @@
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     std::env::set_var("CONFIG_PATH", "config.toml");
 //!     let (_shutdown_tx, shutdown_rx) = watch::channel(());
-//!     StandaloneEngine::run(shutdown_rx).await?;
+//!     StandaloneEngine::run("./data", shutdown_rx).await?;
 //!     Ok(())
 //! }
 //! ```

--- a/d-engine-server/tests/cluster_lifecycle/single_node_bootstrap_embedded.rs
+++ b/d-engine-server/tests/cluster_lifecycle/single_node_bootstrap_embedded.rs
@@ -13,17 +13,15 @@ async fn test_single_node_lifecycle() -> Result<(), Box<dyn std::error::Error>> 
     unsafe {
         std::env::set_var("RAFT__CLUSTER__NODE_ID", "1");
         std::env::set_var("RAFT__CLUSTER__LISTEN_ADDRESS", "127.0.0.1:9001");
-        std::env::set_var("RAFT__CLUSTER__DB_ROOT_DIR", data_dir.to_str().unwrap());
     }
 
-    // Start embedded engine with RocksDB
-    let engine = EmbeddedEngine::start().await?;
+    // Start embedded engine — data_dir takes highest priority
+    let engine = EmbeddedEngine::start(&data_dir).await?;
 
     // Clean up environment variables immediately
     unsafe {
         std::env::remove_var("RAFT__CLUSTER__NODE_ID");
         std::env::remove_var("RAFT__CLUSTER__LISTEN_ADDRESS");
-        std::env::remove_var("RAFT__CLUSTER__DB_ROOT_DIR");
     }
 
     // Single-node should elect itself as leader
@@ -80,15 +78,13 @@ async fn test_leader_notification() -> Result<(), Box<dyn std::error::Error>> {
     unsafe {
         std::env::set_var("RAFT__CLUSTER__NODE_ID", "1");
         std::env::set_var("RAFT__CLUSTER__LISTEN_ADDRESS", "127.0.0.1:9002");
-        std::env::set_var("RAFT__CLUSTER__DB_ROOT_DIR", data_dir.to_str().unwrap());
     }
 
-    let engine = EmbeddedEngine::start().await?;
+    let engine = EmbeddedEngine::start(&data_dir).await?;
 
     unsafe {
         std::env::remove_var("RAFT__CLUSTER__NODE_ID");
         std::env::remove_var("RAFT__CLUSTER__LISTEN_ADDRESS");
-        std::env::remove_var("RAFT__CLUSTER__DB_ROOT_DIR");
     }
 
     // Wait for leader election
@@ -125,28 +121,24 @@ async fn test_data_persistence() -> Result<(), Box<dyn std::error::Error>> {
     unsafe {
         std::env::set_var("RAFT__CLUSTER__NODE_ID", "1");
         std::env::set_var("RAFT__CLUSTER__LISTEN_ADDRESS", "127.0.0.1:9003");
-        std::env::set_var("RAFT__CLUSTER__DB_ROOT_DIR", data_dir.to_str().unwrap());
     }
 
     // First session: write data
     {
-        let engine = EmbeddedEngine::start().await?;
+        let engine = EmbeddedEngine::start(&data_dir).await?;
         engine.wait_ready(Duration::from_secs(5)).await?;
 
         engine.client().put(b"persist-key".to_vec(), b"persist-value".to_vec()).await?;
 
-        // Small delay to ensure data is committed before shutdown
         tokio::time::sleep(Duration::from_millis(100)).await;
-
         engine.stop().await?;
     }
 
-    // Small delay between sessions
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     // Second session: verify data still exists
     {
-        let engine = EmbeddedEngine::start().await?;
+        let engine = EmbeddedEngine::start(&data_dir).await?;
         engine.wait_ready(Duration::from_secs(5)).await?;
 
         let value = engine.client().get_linearizable(b"persist-key".to_vec()).await?;
@@ -163,7 +155,6 @@ async fn test_data_persistence() -> Result<(), Box<dyn std::error::Error>> {
     unsafe {
         std::env::remove_var("RAFT__CLUSTER__NODE_ID");
         std::env::remove_var("RAFT__CLUSTER__LISTEN_ADDRESS");
-        std::env::remove_var("RAFT__CLUSTER__DB_ROOT_DIR");
     }
 
     Ok(())

--- a/d-engine/src/docs/quick-start-5min.md
+++ b/d-engine/src/docs/quick-start-5min.md
@@ -196,8 +196,8 @@ No manual `tokio::spawn()`, no leaked tasks.
 ### EmbeddedEngine
 
 ```rust,ignore
-// Use CONFIG_PATH environment variable
-EmbeddedEngine::start() -> Result<Self>
+// Explicit data directory (highest priority)
+EmbeddedEngine::start(data_dir: impl AsRef<Path>) -> Result<Self>
 
 // Use explicit config file
 EmbeddedEngine::start_with(config_path: &str) -> Result<Self>
@@ -252,11 +252,11 @@ See [complete API documentation](https://docs.rs/d-engine/latest/d_engine/prelud
 
 ## Common Patterns
 
-### Pattern 1: Production (environment variable)
+### Pattern 1: Production (explicit data directory)
 
 ```rust,ignore
-// Reads config path from CONFIG_PATH env var
-let engine = EmbeddedEngine::start().await?;
+// Pass the data directory directly — works in debug and release
+let engine = EmbeddedEngine::start("./data").await?;
 ```
 
 ### Pattern 2: Development (explicit config)


### PR DESCRIPTION
Both APIs now require an explicit data directory as their first argument, matching the ergonomics of sled/RocksDB/SQLite ("just pass a path"). This eliminates the release-build failure caused by the default /tmp/db path being rejected by validate().

## What Does This PR Do?

Makes embedded and standalone engines as easy to start as sled or RocksDB: pass a path, get a running engine. Removes the release-build failure where the default `/tmp/db` path was hard-rejected by `validate()`.

**Type:**
- [x] Bug Fix (with test)
- [x] Feature (issue #303 approved)

---

## Why Is This Needed?

Fixes #303. `EmbeddedEngine::start().await` failed in release builds because the implicit default path `/tmp/db` was rejected by config validation. Users had to set `CONFIG_PATH` or `RAFT__CLUSTER__DB_ROOT_DIR` just to get started — a significant friction point that competitors (sled, RocksDB, SQLite) avoid by simply accepting a path as an argument.

---

## Checklist

- [x] `make test` passes (1435/1436; 1 pre-existing flaky throughput benchmark unrelated to this PR)
- [x] Added tests for new code
- [x] Commits squashed to 1-2 logical units
- [x] Updated relevant docs

---

## Testing

- Unit tests: `embedded_env_test.rs` — 4 new TDD tests covering dir auto-creation, idempotency, `data_dir` overrides `CONFIG_PATH` db_root_dir, `/tmp` warns but succeeds
- Unit tests: `standalone_test.rs` — fully rewritten; 4 tests for `run(data_dir)`, 4 tests for `run_with()`; all debug/release cfg splits removed
- Integration tests: `single_node_bootstrap_embedded.rs` — updated call sites, existing lifecycle/persistence/leader-notification tests pass
- [x] Added test that fails without this fix

---

## Does This Follow d-engine's Principles?

- [x] Solves a real problem for most users
- [x] Keeps implementation simple
- [x] Doesn't bloat the API surface — net −331 lines

---

## Reviewer Notes

Both `EmbeddedEngine` and `StandaloneEngine` now follow the same funnel pattern — all public entry points converge on a private `start_node()` that holds the single `NodeBuilder` call. This also fixed a latent bug in `StandaloneEngine::run_with()` → `run_custom()` where the config file was being parsed twice.

**Breaking change:** `EmbeddedEngine::start()` and `StandaloneEngine::run()` signatures changed. Callers must pass `data_dir` explicitly.

**Estimated review complexity:**
- [x] Deep (> 300 lines)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Engine startup now requires explicit data directory specification for better control over data persistence.
  * Data directories are automatically created if missing during initialization.

* **Improvements**
  * Enhanced validation for temporary storage paths with informative warnings instead of startup failures.

* **Documentation**
  * Updated quick-start guides and examples to reflect new engine initialization requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deventlab/d-engine/pull/373)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->