### PR TITLE
docs(release) #374: update README and CHANGELOG for v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,18 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- **Unified RocksDB option** (#295): opt-in via `storage.unified_db = true`.
-  Uses a single RocksDB instance with 4 column families instead of two separate instances.
-  - Reduces memory RSS and file descriptor usage
-  - **Experimental**: both paths are supported in v0.2.4; a future release will standardize on one
-  - When enabled: data path changes to `db_root_dir/db/` (⚠️ existing `storage/` data not migrated automatically)
+- **Simplified startup API** (#303): Pass a data directory directly — no config file required for common cases
+  - `EmbeddedEngine::start(data_dir)` replaces the config-file-only constructor
+  - `StandaloneEngine::run(data_dir, shutdown_rx)` for standalone deployments
+  - Config file path still accepted via existing constructors; new API uses sensible defaults
+
+- **Async IO architecture — pipeline replication** (#334, #341, #342, #343, #345, #349, #350, #351):
+  The Raft event loop is now fully non-blocking under write load
+  - `BufferedRaftLog` runs on a dedicated OS thread — WAL writes never steal tokio worker threads
+  - `StateMachineWorker::apply_batch` is fully async — RocksDB apply no longer blocks the event loop
+  - AppendEntries uses a **persistent bidirectional gRPC stream per peer** — eliminates per-batch connection overhead
+  - Replication is pipelined: leader sends to all followers concurrently without stop-and-wait
+  - Truncate and purge are offloaded from the Raft hot path
 
 - **Cluster membership streaming** (#327, #328): Subscribe to real-time membership changes
   - `EmbeddedEngine::watch_membership()` — in-process `watch::Receiver<MembershipSnapshot>` (embedded mode)
@@ -22,17 +29,44 @@ All notable changes to this project will be documented in this file.
   - Stream terminates with `UNAVAILABLE` on server shutdown — callers reconnect and resubscribe
   - `MembershipSnapshot` carries `members`, `learners`, and `committed_index` (idempotency key for deduplication after reconnect)
 
+- **Unified RocksDB option** (#295): opt-in via `storage.unified_db = true`.
+  Uses a single RocksDB instance with 4 column families instead of two separate instances.
+  - Reduces memory RSS and file descriptor usage
+  - **Experimental**: both paths are supported in v0.2.4; a future release will standardize on one
+  - When enabled: data path changes to `db_root_dir/db/` (⚠️ existing `storage/` data not migrated automatically)
+
 ### 🟡 Important Fixes
+
+- **fix(crash-safety) #329**: Leader now commits against durable index, not in-memory index
+  - Previously, entries could be marked committed before being flushed to disk, risking data loss on leader crash
+  - All acknowledged writes are now guaranteed durable before commit advances
 
 - **fix(raft) #340**: Candidate correctly steps down on same-term AppendEntries with log conflict
   - Eliminates election churn when recovering or newly-joined nodes have lagged logs
   - Aligns with Raft §5.2 (term check takes priority over log matching)
 
+- **fix(snapshot) #315**: Snapshot disk I/O isolated from Raft event loop via `spawn_blocking`
+  - Previously, snapshot transfer competed with consensus and caused `ProposeFailed` (4006) under load
+
+- **fix(snapshot) #308**: Snapshot install success is now driven by the follower's apply confirmation, not the transfer ACK
+  - Prevents leader from advancing `match_index` before the follower has actually applied the snapshot
+
+- **fix(snapshot) #253**: Snapshot stale-file corruption on retry eliminated; configurable chunk transfer timeout added
+
+- **fix(snapshot) #290**: Snapshot cooldown reduced from 1 hour to a practical default; adaptive throttling added
+  - WAL log compaction now triggers reliably in long-running deployments
+
+- **fix(cas) #371**: CAS operations in the same `apply_chunk` no longer read stale values
+  - Root cause: batch apply used a plain `ReadOptions` snapshot taken before the batch started; concurrent CAS ops targeting the same key within one chunk would overwrite each other
+  - Fixed with `WriteBatchWithIndex` — each CAS op in a batch reads its own preceding writes
+
+- **fix(client) #323**: `ClientApi` trait is now correctly exposed in embedded mode without the `client` feature flag
+
 ### Changed
 
 - No runtime behavior change for existing deployments — `unified_db` defaults to `false`
 
-- **Zombie detection no longer auto-removes unreachable nodes** (#327):
+- **Zombie detection no longer auto-removes unreachable nodes** (#365):
   Previously, a node that failed to connect N times was automatically removed
   via `BatchRemove`. This was too aggressive and could evict temporarily
   restarting nodes. Detection now emits a `warn` log only — removal remains

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ d-engine = "0.2"
 **Use when**: Building Rust applications that need distributed coordination  
 **Why**: Zero-overhead (<0.1ms), single binary, zero network cost
 
-> **Performance note**: Embedded mode on AWS EC2 3-node cluster achieves **64K writes/sec** and **181K linearizable reads/sec** under high concurrency, with sub-millisecond latency. See [benches/reports/v0.2.4/](https://github.com/deventlab/d-engine/tree/main/benches/reports/v0.2.3) for detailed benchmarks.
+> **Performance note**: Embedded mode on AWS EC2 3-node cluster achieves **64K writes/sec** and **181K linearizable reads/sec** under high concurrency, with sub-millisecond latency. See [benches/reports/v0.2.4/](https://github.com/deventlab/d-engine/tree/main/benches/reports/v0.2.4) for detailed benchmarks.
 
 **→ Examples:**
 
@@ -118,7 +118,7 @@ d-engine = { version = "0.2", features = ["client"], default-features = false }
 **Use when**: Application and d-engine run as separate processes  
 **Why**: Language-agnostic (Go/Python/Java/Rust), independent scaling, easier operations
 
-> **Performance note**: Standalone mode achieves 36K writes/sec and 51K linearizable reads/sec via gRPC, suitable for multi-language environments. For maximum performance, use embedded mode (1.8x faster writes, 3.5x faster reads). See [benches/reports/v0.2.4/](https://github.com/deventlab/d-engine/tree/main/benches/reports/v0.2.3) for benchmarks.
+> **Performance note**: Standalone mode achieves 36K writes/sec and 51K linearizable reads/sec via gRPC, suitable for multi-language environments. For maximum performance, use embedded mode (1.8x faster writes, 3.5x faster reads). See [benches/reports/v0.2.4/](https://github.com/deventlab/d-engine/tree/main/benches/reports/v0.2.4) for benchmarks.
 
 **Note**: Rust apps can use both modes - embedded for performance, standalone for operational flexibility
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,14 @@ and pluggable storage backends. Start with one node, scale to a cluster when nee
 
 ## Features
 
-### New in v0.2.3 🎉
+### New in v0.2.4 🎉
+
+- **Async IO Architecture**: Raft event loop is fully non-blocking — WAL writes, state machine apply, and replication all run off the hot path. AppendEntries uses a persistent bidirectional stream per peer; replication is pipelined across followers.
+- **Cluster Membership Streaming**: `EmbeddedEngine::watch_membership()` / `GrpcClient::watch_membership()` — subscribe to real-time membership changes in both embedded and standalone modes
+- **Simpler Startup**: `EmbeddedEngine::start(data_dir)` and `StandaloneEngine::run(data_dir, shutdown_rx)` — no config file required for common cases
+- **Jepsen Validated**: 5 workloads + 6-hour soak test under combined kill/partition/pause faults — see [Correctness Guarantees](https://github.com/deventlab/d-engine-jepsen/blob/main/GUARANTEES.md)
+
+### Previously in v0.2.3
 
 - **CompareAndSwap (CAS)**: Atomic compare-and-swap for distributed locks, leader election, optimistic updates
 - **Drain-based Batching**: Linearizable read +92%, lease/eventual read +62% vs v0.2.2 (embedded mode)
@@ -46,6 +53,7 @@ and pluggable storage backends. Start with one node, scale to a cluster when nee
 - **Single-Node Start**: Begin with one node, expand to 3-node cluster when needed (zero downtime)
 - **Tunable Persistence**: DiskFirst for durability or MemFirst for lower latency
 - **Pluggable Storage**: Custom backends supported (RocksDB, Sled, Raw File)
+- **Jepsen Validated**: Linearizability, partition tolerance, crash durability, and Watch ordering verified — see [Correctness Guarantees](https://github.com/deventlab/d-engine-jepsen/blob/main/GUARANTEES.md)
 
 ---
 
@@ -92,7 +100,7 @@ d-engine = "0.2"
 **Use when**: Building Rust applications that need distributed coordination  
 **Why**: Zero-overhead (<0.1ms), single binary, zero network cost
 
-> **Performance note**: Embedded mode on AWS EC2 3-node cluster achieves **64K writes/sec** and **181K linearizable reads/sec** under high concurrency, with sub-millisecond latency. See [benches/reports/v0.2.3/](https://github.com/deventlab/d-engine/tree/main/benches/reports/v0.2.3) for detailed benchmarks.
+> **Performance note**: Embedded mode on AWS EC2 3-node cluster achieves **64K writes/sec** and **181K linearizable reads/sec** under high concurrency, with sub-millisecond latency. See [benches/reports/v0.2.4/](https://github.com/deventlab/d-engine/tree/main/benches/reports/v0.2.3) for detailed benchmarks.
 
 **→ Examples:**
 
@@ -110,7 +118,7 @@ d-engine = { version = "0.2", features = ["client"], default-features = false }
 **Use when**: Application and d-engine run as separate processes  
 **Why**: Language-agnostic (Go/Python/Java/Rust), independent scaling, easier operations
 
-> **Performance note**: Standalone mode achieves 36K writes/sec and 51K linearizable reads/sec via gRPC, suitable for multi-language environments. For maximum performance, use embedded mode (1.8x faster writes, 3.5x faster reads). See [benches/reports/v0.2.3/](https://github.com/deventlab/d-engine/tree/main/benches/reports/v0.2.3) for benchmarks.
+> **Performance note**: Standalone mode achieves 36K writes/sec and 51K linearizable reads/sec via gRPC, suitable for multi-language environments. For maximum performance, use embedded mode (1.8x faster writes, 3.5x faster reads). See [benches/reports/v0.2.4/](https://github.com/deventlab/d-engine/tree/main/benches/reports/v0.2.3) for benchmarks.
 
 **Note**: Rust apps can use both modes - embedded for performance, standalone for operational flexibility
 
@@ -228,7 +236,7 @@ Yes. Scale to 3 nodes later with zero downtime (see `examples/single-node-expans
 Implement `StorageEngine` and `StateMachine` traits (see Custom Storage Implementations section).
 
 **Production-ready?**  
-Core Raft engine is production-grade (1000+ tests, Jepsen validated). API is stabilizing toward v1.0. Pre-1.0 versions may introduce breaking changes (documented in [MIGRATION_GUIDE.md](https://github.com/deventlab/d-engine/blob/main/MIGRATION_GUIDE.md)).
+Core Raft engine is production-grade (1000+ tests, [Jepsen validated](https://github.com/deventlab/d-engine-jepsen/blob/main/GUARANTEES.md)). API is stabilizing toward v1.0. Pre-1.0 versions may introduce breaking changes (documented in [MIGRATION_GUIDE.md](https://github.com/deventlab/d-engine/blob/main/MIGRATION_GUIDE.md)).
 
 ## Supported Platforms
 


### PR DESCRIPTION

## What Does This PR Do?

Updates README and CHANGELOG to accurately reflect v0.2.4 — adds the "New in v0.2.4" highlights, fills missing CHANGELOG entries that were never documented, and links the new Jepsen GUARANTEES.md.

**Type:**

- [ ] Bug Fix (with test)
- [ ] Feature (issue #___ approved)
- [x] Documentation
- [ ] Test/Coverage
- [ ] Performance (with benchmark)

---

## Why Is This Needed?

Closes #374. The CHANGELOG was missing the majority of v0.2.4's changes (async IO architecture, simplified startup API, crash-safety fix, 5 snapshot fixes, CAS stale-read fix). The README still showed "New in v0.2.3" and had stale benchmark links. Both need to be correct before the v0.2.4 release tag.

---

## Checklist

**Required:**

- [x] `make test` passes
- [x] Added tests for new code — N/A (docs only)
- [x] Commits squashed to 1-2 logical units

**If changing APIs:**

- [x] Updated relevant docs — N/A (docs only)
- [ ] Explained why complexity is justified

---

## Testing

**How tested:**

- Manual review: verified each CHANGELOG entry against `git log v0.2.3..HEAD`
- Manual review: verified README benchmark links resolve to existing paths

---

## Does This Follow d-engine's Principles?

- [x] Solves a real problem for most users (not just my edge case)
- [x] Keeps implementation simple
- [x] Doesn't bloat the API surface

---

## Reviewer Notes

CHANGELOG additions to review against commits:
- `#303` simplified startup API
- `#329` durable commit index (crash-safety)
- `#334, #341–#345` async IO / pipeline replication
- `#253, #290, #308, #315` snapshot fixes
- `#371` CAS stale-read fix
- `#365` zombie detection ticket ref (was incorrectly #327)

**Estimated review complexity:**

- [x] Quick (< 100 lines)
- [ ] Medium (< 300 lines)
- [ ] Deep (> 300 lines)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * v0.2.4 release notes expanded with async/non-blocking Raft IO architecture, streamed membership watch APIs, and simplified startup APIs
  * Performance benchmark links and Jepsen validation coverage updated; API stabilization toward v1.0 and migration guidance clarified
* **Bug Fixes**
  * Noted important fixes for crash-safety, snapshot install/isolation behavior, candidate step-down, CAS read staleness, and related reliability improvements
* **Changed**
  * `unified_db` default noted as false; zombie-detection behavior changed to warn-only

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deventlab/d-engine/pull/375)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->