### PR TITLE
refactor #384: StateMachine::apply_chunk receives &[ApplyEntry] instead of Vec<Entry>

### DIFF
--- a/d-engine-core/src/command.rs
+++ b/d-engine-core/src/command.rs
@@ -1,0 +1,259 @@
+/// # Why this module exists
+///
+/// `EntryPayload.command` is stored as raw `bytes` in the Raft log — intentionally.
+/// The replication path (Leader → Followers → WAL) must be zero-copy: Followers store
+/// and forward bytes without ever decoding them.  Only the *apply* step needs to know
+/// what the command means.
+///
+/// Before this module, every `StateMachine` implementor called
+/// `WriteCommand::decode(&data[..])` themselves, duplicating the same proto decode
+/// logic and forcing a `d-engine-proto` dependency on anyone writing a custom SM.
+///
+/// This module moves the decode to one place — `DefaultStateMachineHandler` — and
+/// exposes a clean Rust-native type (`Command`) at the `StateMachine::apply_chunk`
+/// boundary.  `WriteCommand` (proto, wire format) and `Command` (Rust enum, execution
+/// interface) are intentionally two separate types — anti-corruption layer — so that
+/// proto schema changes never break the SM trait.
+use bytes::Bytes;
+use d_engine_proto::client::WriteCommand;
+use d_engine_proto::client::write_command::Operation;
+use d_engine_proto::common::Entry;
+use d_engine_proto::common::entry_payload::Payload;
+use prost::Message;
+
+use crate::Error;
+use crate::StorageError;
+
+/// Decoded KV operation — the unit of work delivered to a `StateMachine`.
+///
+/// Replaces raw proto `Entry` at the `StateMachine::apply_chunk` boundary.
+/// The framework decodes wire bytes exactly once (in `DefaultStateMachineHandler`)
+/// before dispatching; implementors never touch prost or proto types.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Command {
+    /// Raft-internal no-op written by a newly elected leader.
+    /// SM must return `ApplyResult::success(entry.index)` and otherwise ignore it.
+    /// Cannot be filtered before reaching SM: omitting it would create gaps in
+    /// `last_applied`, breaking the index-tracking invariant in `StateMachineWorker`.
+    Noop,
+
+    Insert {
+        key: Bytes,
+        value: Bytes,
+        /// `None` = no expiration.  Proto encodes this as `ttl_secs = 0`; we convert
+        /// to `Option` here so SM implementors use idiomatic Rust instead of magic zeros.
+        ttl_secs: Option<u64>,
+    },
+
+    Delete {
+        key: Bytes,
+    },
+
+    CompareAndSwap {
+        key: Bytes,
+        /// `None` means the key must not exist for the swap to succeed.
+        expected: Option<Bytes>,
+        value: Bytes,
+    },
+}
+
+/// A decoded Raft log entry ready for state machine application.
+///
+/// Pairs `index` / `term` with the decoded `Command` so that state machines can
+/// produce `ApplyResult { index, .. }` without re-reading the original `Entry`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ApplyEntry {
+    pub index: u64,
+    pub term: u64,
+    pub command: Command,
+}
+
+/// Single coupling point between the proto schema and the SM trait.
+///
+/// When a new operation variant is added to `WriteCommand`, the compiler forces
+/// an update here (non-exhaustive `match`), preventing silent omissions downstream.
+impl TryFrom<WriteCommand> for Command {
+    type Error = Error;
+
+    fn try_from(wc: WriteCommand) -> Result<Self, Error> {
+        match wc.operation {
+            Some(Operation::Insert(i)) => Ok(Command::Insert {
+                key: i.key,
+                value: i.value,
+                ttl_secs: if i.ttl_secs == 0 {
+                    None
+                } else {
+                    Some(i.ttl_secs)
+                },
+            }),
+            Some(Operation::Delete(d)) => Ok(Command::Delete { key: d.key }),
+            Some(Operation::CompareAndSwap(c)) => Ok(Command::CompareAndSwap {
+                key: c.key,
+                expected: c.expected_value,
+                value: c.new_value,
+            }),
+            None => {
+                Err(StorageError::StateMachineError("WriteCommand has no operation".into()).into())
+            }
+        }
+    }
+}
+
+/// Decode a batch of raw Raft `Entry` values into `ApplyEntry` values.
+///
+/// - `Config` entries become `Command::Noop` — membership is handled by the Raft layer, but
+///   the index must still reach SM so `last_applied` stays contiguous; dropping them would
+///   leave `last_applied` stuck below the config index, breaking ReadIndex drain.
+/// - `Noop` entries become `Command::Noop`.
+/// - `Command` bytes are decoded via `TryFrom<WriteCommand>`.
+/// - Any decode failure returns `Err` immediately.
+pub fn decode_entries(entries: Vec<Entry>) -> Result<Vec<ApplyEntry>, Error> {
+    let mut result = Vec::with_capacity(entries.len());
+
+    for entry in entries {
+        let index = entry.index;
+        let term = entry.term;
+
+        let payload = entry.payload.and_then(|p| p.payload).ok_or_else(|| {
+            StorageError::StateMachineError(format!("Entry at index {index} has no payload"))
+        })?;
+
+        match payload {
+            Payload::Noop(_) => {
+                result.push(ApplyEntry {
+                    index,
+                    term,
+                    command: Command::Noop,
+                });
+            }
+            Payload::Config(_) => {
+                // Membership changes are handled by the membership layer.
+                // Convert to Noop so sm.last_applied advances through this index —
+                // dropping the entry would leave last_applied stuck, breaking ReadIndex.
+                result.push(ApplyEntry {
+                    index,
+                    term,
+                    command: Command::Noop,
+                });
+            }
+            Payload::Command(data) => {
+                let wc = WriteCommand::decode(&data[..]).map_err(|e| {
+                    StorageError::SerializationError(format!(
+                        "Failed to decode WriteCommand at index {index}: {e}"
+                    ))
+                })?;
+                result.push(ApplyEntry {
+                    index,
+                    term,
+                    command: Command::try_from(wc)?,
+                });
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use d_engine_proto::common::EntryPayload;
+    use d_engine_proto::common::MembershipChange;
+    use d_engine_proto::common::Noop;
+    use d_engine_proto::common::entry_payload::Payload;
+
+    use super::*;
+
+    fn noop_entry(index: u64) -> Entry {
+        Entry {
+            index,
+            term: 1,
+            payload: Some(EntryPayload {
+                payload: Some(Payload::Noop(Noop {})),
+            }),
+        }
+    }
+
+    fn config_entry(index: u64) -> Entry {
+        Entry {
+            index,
+            term: 1,
+            payload: Some(EntryPayload {
+                payload: Some(Payload::Config(MembershipChange { change: None })),
+            }),
+        }
+    }
+
+    fn insert_entry(
+        index: u64,
+        key: &str,
+        value: &str,
+    ) -> Entry {
+        use d_engine_proto::client::WriteCommand;
+        use d_engine_proto::client::write_command::{Insert, Operation};
+        use prost::Message;
+
+        let wc = WriteCommand {
+            operation: Some(Operation::Insert(Insert {
+                key: Bytes::from(key.to_owned()),
+                value: Bytes::from(value.to_owned()),
+                ttl_secs: 0,
+            })),
+        };
+        let mut buf = Vec::new();
+        wc.encode(&mut buf).unwrap();
+        Entry {
+            index,
+            term: 1,
+            payload: Some(EntryPayload {
+                payload: Some(Payload::Command(Bytes::from(buf))),
+            }),
+        }
+    }
+
+    /// Config entries must produce Command::Noop, not be dropped.
+    /// Dropping them leaves sm.last_applied stuck, breaking ReadIndex drain.
+    #[test]
+    fn config_entry_becomes_noop() {
+        let entries = vec![config_entry(5)];
+        let result = decode_entries(entries).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].index, 5);
+        assert_eq!(result[0].command, Command::Noop);
+    }
+
+    /// last_applied continuity: a mixed batch of Insert→Config→Insert must yield
+    /// three ApplyEntry values with no index gaps.
+    #[test]
+    fn config_entry_preserves_index_continuity() {
+        let entries = vec![
+            insert_entry(10, "k1", "v1"),
+            config_entry(11), // membership change
+            insert_entry(12, "k2", "v2"),
+        ];
+        let result = decode_entries(entries).unwrap();
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].index, 10);
+        assert_eq!(result[1].index, 11);
+        assert!(matches!(result[1].command, Command::Noop));
+        assert_eq!(result[2].index, 12);
+    }
+
+    /// A chunk that is entirely Config entries must still produce one Noop per entry,
+    /// so the SM can advance last_applied to the highest config index.
+    #[test]
+    fn all_config_chunk_produces_noops() {
+        let entries = vec![config_entry(3), config_entry(4), config_entry(5)];
+        let result = decode_entries(entries).unwrap();
+        assert_eq!(result.len(), 3);
+        assert!(result.iter().all(|e| e.command == Command::Noop));
+        assert_eq!(result.last().unwrap().index, 5);
+    }
+
+    #[test]
+    fn noop_entry_produces_noop() {
+        let result = decode_entries(vec![noop_entry(1)]).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].command, Command::Noop);
+    }
+}

--- a/d-engine-core/src/command_test.rs
+++ b/d-engine-core/src/command_test.rs
@@ -1,0 +1,278 @@
+use bytes::Bytes;
+use d_engine_proto::client::WriteCommand;
+use d_engine_proto::client::write_command::{CompareAndSwap, Delete, Insert, Operation};
+use d_engine_proto::common::AddNode;
+use d_engine_proto::common::Entry;
+use d_engine_proto::common::EntryPayload;
+use d_engine_proto::common::membership_change::Change;
+use prost::Message;
+
+use crate::command::{ApplyEntry, Command, decode_entries};
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+fn noop_entry(
+    index: u64,
+    term: u64,
+) -> Entry {
+    Entry {
+        index,
+        term,
+        payload: Some(EntryPayload::noop()),
+    }
+}
+
+fn config_entry(
+    index: u64,
+    term: u64,
+) -> Entry {
+    Entry {
+        index,
+        term,
+        payload: Some(EntryPayload::config(Change::AddNode(AddNode {
+            node_id: 1,
+            address: "127.0.0.1:4000".to_string(),
+            status: 0,
+        }))),
+    }
+}
+
+fn encode_write_cmd(op: Operation) -> Bytes {
+    let cmd = WriteCommand {
+        operation: Some(op),
+    };
+    let mut buf = Vec::new();
+    cmd.encode(&mut buf).unwrap();
+    Bytes::from(buf)
+}
+
+fn insert_entry(
+    index: u64,
+    term: u64,
+    key: &[u8],
+    value: &[u8],
+    ttl_secs: u64,
+) -> Entry {
+    Entry {
+        index,
+        term,
+        payload: Some(EntryPayload::command(encode_write_cmd(Operation::Insert(
+            Insert {
+                key: Bytes::copy_from_slice(key),
+                value: Bytes::copy_from_slice(value),
+                ttl_secs,
+            },
+        )))),
+    }
+}
+
+fn delete_entry(
+    index: u64,
+    term: u64,
+    key: &[u8],
+) -> Entry {
+    Entry {
+        index,
+        term,
+        payload: Some(EntryPayload::command(encode_write_cmd(Operation::Delete(
+            Delete {
+                key: Bytes::copy_from_slice(key),
+            },
+        )))),
+    }
+}
+
+fn cas_entry(
+    index: u64,
+    term: u64,
+    key: &[u8],
+    expected: Option<&[u8]>,
+    new_value: &[u8],
+) -> Entry {
+    Entry {
+        index,
+        term,
+        payload: Some(EntryPayload::command(encode_write_cmd(
+            Operation::CompareAndSwap(CompareAndSwap {
+                key: Bytes::copy_from_slice(key),
+                expected_value: expected.map(Bytes::copy_from_slice),
+                new_value: Bytes::copy_from_slice(new_value),
+            }),
+        ))),
+    }
+}
+
+// ── decode: single-variant tests ───────────────────────────────────────────
+
+#[test]
+fn test_decode_empty_batch_returns_empty_vec() {
+    let result = decode_entries(vec![]).unwrap();
+    assert!(result.is_empty());
+}
+
+#[test]
+fn test_decode_noop_entry_produces_noop_command() {
+    let entries = vec![noop_entry(1, 1)];
+    let result = decode_entries(entries).unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(
+        result[0],
+        ApplyEntry {
+            index: 1,
+            term: 1,
+            command: Command::Noop
+        }
+    );
+}
+
+#[test]
+fn test_decode_config_entry_becomes_noop() {
+    // Config entries must become Command::Noop, not be dropped.
+    // Dropping them leaves sm.last_applied stuck, breaking ReadIndex drain.
+    let entries = vec![config_entry(1, 1)];
+    let result = decode_entries(entries).unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].index, 1);
+    assert!(matches!(result[0].command, Command::Noop));
+}
+
+#[test]
+fn test_decode_insert_without_ttl() {
+    let entries = vec![insert_entry(2, 1, b"k", b"v", 0)];
+    let result = decode_entries(entries).unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(
+        result[0].command,
+        Command::Insert {
+            key: Bytes::from_static(b"k"),
+            value: Bytes::from_static(b"v"),
+            ttl_secs: None,
+        }
+    );
+}
+
+#[test]
+fn test_decode_insert_with_ttl_converts_to_some() {
+    let entries = vec![insert_entry(3, 1, b"key", b"val", 60)];
+    let result = decode_entries(entries).unwrap();
+    assert_eq!(
+        result[0].command,
+        Command::Insert {
+            key: Bytes::from_static(b"key"),
+            value: Bytes::from_static(b"val"),
+            ttl_secs: Some(60),
+        }
+    );
+}
+
+#[test]
+fn test_decode_delete_entry() {
+    let entries = vec![delete_entry(4, 2, b"gone")];
+    let result = decode_entries(entries).unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(
+        result[0].command,
+        Command::Delete {
+            key: Bytes::from_static(b"gone")
+        }
+    );
+}
+
+#[test]
+fn test_decode_cas_with_expected_value() {
+    let entries = vec![cas_entry(5, 1, b"k", Some(b"old"), b"new")];
+    let result = decode_entries(entries).unwrap();
+    assert_eq!(
+        result[0].command,
+        Command::CompareAndSwap {
+            key: Bytes::from_static(b"k"),
+            expected: Some(Bytes::from_static(b"old")),
+            value: Bytes::from_static(b"new"),
+        }
+    );
+}
+
+#[test]
+fn test_decode_cas_with_no_expected_value_means_key_must_not_exist() {
+    let entries = vec![cas_entry(6, 1, b"k", None, b"new")];
+    let result = decode_entries(entries).unwrap();
+    assert_eq!(
+        result[0].command,
+        Command::CompareAndSwap {
+            key: Bytes::from_static(b"k"),
+            expected: None,
+            value: Bytes::from_static(b"new"),
+        }
+    );
+}
+
+// ── decode: index and term preservation ────────────────────────────────────
+
+#[test]
+fn test_decode_preserves_index_and_term() {
+    let entries = vec![
+        insert_entry(10, 3, b"a", b"1", 0),
+        delete_entry(11, 3, b"b"),
+    ];
+    let result = decode_entries(entries).unwrap();
+    assert_eq!(result[0].index, 10);
+    assert_eq!(result[0].term, 3);
+    assert_eq!(result[1].index, 11);
+    assert_eq!(result[1].term, 3);
+}
+
+// ── decode: mixed batch ─────────────────────────────────────────────────────
+
+#[test]
+fn test_decode_mixed_batch_config_becomes_noop_keeps_order() {
+    // index: 1=Noop, 2=Config(→Noop), 3=Insert, 4=Delete — all 4 entries preserved
+    let entries = vec![
+        noop_entry(1, 1),
+        config_entry(2, 1),
+        insert_entry(3, 1, b"x", b"y", 0),
+        delete_entry(4, 1, b"x"),
+    ];
+    let result = decode_entries(entries).unwrap();
+    assert_eq!(result.len(), 4); // Config becomes Noop, index continuity preserved
+    assert_eq!(result[0].index, 1);
+    assert!(matches!(result[0].command, Command::Noop));
+    assert_eq!(result[1].index, 2);
+    assert!(matches!(result[1].command, Command::Noop)); // config → noop
+    assert_eq!(result[2].index, 3);
+    assert!(matches!(result[2].command, Command::Insert { .. }));
+    assert_eq!(result[3].index, 4);
+    assert!(matches!(result[3].command, Command::Delete { .. }));
+}
+
+// ── decode: error cases ─────────────────────────────────────────────────────
+
+#[test]
+fn test_decode_invalid_command_bytes_returns_error() {
+    let entry = Entry {
+        index: 1,
+        term: 1,
+        payload: Some(EntryPayload::command(Bytes::from_static(
+            b"\xff\xff\xff\xff",
+        ))),
+    };
+    let result = decode_entries(vec![entry]);
+    assert!(result.is_err(), "Corrupt command bytes must return Err");
+}
+
+#[test]
+fn test_decode_write_command_with_no_operation_returns_error() {
+    // WriteCommand with operation = None
+    let empty_cmd = WriteCommand { operation: None };
+    let mut buf = Vec::new();
+    empty_cmd.encode(&mut buf).unwrap();
+    let entry = Entry {
+        index: 2,
+        term: 1,
+        payload: Some(EntryPayload::command(Bytes::from(buf))),
+    };
+    let result = decode_entries(vec![entry]);
+    assert!(
+        result.is_err(),
+        "WriteCommand without operation must return Err"
+    );
+}

--- a/d-engine-core/src/lib.rs
+++ b/d-engine-core/src/lib.rs
@@ -54,6 +54,7 @@
 //! - [Customize State Machine](https://docs.rs/d-engine/latest/d_engine/docs/server_guide/customize_state_machine/index.html)
 
 pub mod client;
+pub mod command;
 mod commit_handler;
 pub mod config;
 mod election;
@@ -79,6 +80,7 @@ pub mod watch;
 
 // ── User-facing public API ──────────────────────────────────────────────────
 pub use client::*;
+pub use command::*;
 pub use config::*;
 pub use errors::*;
 pub use storage::*;
@@ -126,6 +128,8 @@ pub use utils::*;
 
 pub(crate) use timer::*;
 
+#[cfg(test)]
+mod command_test;
 #[cfg(test)]
 mod maybe_clone_oneshot_test;
 

--- a/d-engine-core/src/state_machine_handler/default_state_machine_handler.rs
+++ b/d-engine-core/src/state_machine_handler/default_state_machine_handler.rs
@@ -47,7 +47,11 @@ use super::SnapshotAssembler;
 use super::SnapshotContext;
 use super::SnapshotPolicy;
 use super::StateMachineHandler;
+#[cfg(feature = "watch")]
+use crate::ApplyEntry;
 use crate::ApplyResult;
+#[cfg(feature = "watch")]
+use crate::Command;
 use crate::NewCommitData;
 use crate::Result;
 use crate::SnapshotConfig;
@@ -60,6 +64,7 @@ use crate::TypeConfig;
 use crate::alias::SMOF;
 use crate::alias::SNP;
 use crate::convert::classify_error;
+use crate::decode_entries;
 use crate::file_io::validate_checksum;
 use crate::file_io::validate_compressed_format;
 use crate::scoped_timer::ScopedTimer;
@@ -214,6 +219,8 @@ where
         )
         .increment(1);
 
+        // Capture last_index before decode: Config entries are dropped by decode_entries,
+        // but last_applied must still advance to the original commit index.
         let last_index = chunk.last().map(|entry| entry.index);
         trace!(
             "[node-{}] apply_chunk::entry={:?} last_index: {:?}",
@@ -222,26 +229,30 @@ where
 
         let sm = self.state_machine.clone();
 
+        // Decode proto bytes → ApplyEntry exactly once here.
+        // State machine receives clean Rust types; never touches proto or wire format.
+        let apply_entries = decode_entries(chunk)?;
+
         // Read prev values before applying if any watcher requested prev_kv.
         // Must happen BEFORE apply_chunk so old values are still in the state machine.
         #[cfg(feature = "watch")]
         let prev_values: Option<Vec<Option<bytes::Bytes>>> = if self.watch_event_tx.is_some()
             && self.prev_kv_watcher_count.load(std::sync::atomic::Ordering::Relaxed) > 0
         {
-            Some(Self::read_prev_values(&*sm, &chunk))
+            Some(Self::read_prev_values(&*sm, &apply_entries))
         } else {
             None
         };
 
         // Apply the chunk and track errors
-        let apply_result = sm.apply_chunk(chunk.clone()).await;
+        let apply_result = sm.apply_chunk(&apply_entries).await;
 
         // Fire-and-forget watch events on success (non-blocking)
         #[cfg(feature = "watch")]
         if let Ok(ref results) = apply_result
             && let Some(ref tx) = self.watch_event_tx
         {
-            self.broadcast_watch_events(&chunk, results, tx, prev_values.as_deref());
+            self.broadcast_watch_events(&apply_entries, results, tx, prev_values.as_deref());
         }
 
         // Record latency and chunk size histogram *after* the operation
@@ -644,75 +655,52 @@ where
     ///
     /// Returns one `Option<Bytes>` per entry in the same order:
     /// - `Some(value)` for Insert / Delete / CAS entries (empty Bytes if key didn't exist)
-    /// - `None` for Noop / Config entries (no prev_value needed)
+    /// - `None` for Noop entries (no prev_value needed)
+    ///
+    /// Uses a per-batch overlay so two writes to the same key within one chunk produce
+    /// correct prev_values: the second write sees the first write's value, not the
+    /// pre-batch SM state.
     #[cfg(feature = "watch")]
     fn read_prev_values(
         sm: &dyn crate::StateMachine,
-        chunk: &[Entry],
+        chunk: &[ApplyEntry],
     ) -> Vec<Option<bytes::Bytes>> {
         use std::collections::HashMap;
 
-        use d_engine_proto::client::WriteCommand;
-        use d_engine_proto::client::write_command::Operation;
-        use d_engine_proto::common::entry_payload::Payload;
-        use prost::Message;
-
-        // Tracks the value each key would hold after each processed entry.
-        // None = key was deleted by an earlier entry in this batch.
-        // Ensures that two writes to the same key in one chunk produce correct
-        // prev_values: the second write sees the first write's value, not the
-        // pre-batch SM state.
         let mut overlay: HashMap<bytes::Bytes, Option<bytes::Bytes>> = HashMap::new();
         let mut result = Vec::with_capacity(chunk.len());
 
         for entry in chunk {
-            let prev = (|| -> Option<bytes::Bytes> {
-                let payload = entry.payload.as_ref()?;
-                let Some(Payload::Command(cmd_bytes)) = &payload.payload else {
-                    return None;
-                };
-                let Ok(write_cmd) = WriteCommand::decode(cmd_bytes.as_ref()) else {
-                    return None;
-                };
-                let op = write_cmd.operation?;
-
-                let key: bytes::Bytes = match &op {
-                    Operation::Insert(ins) => ins.key.clone(),
-                    Operation::Delete(del) => del.key.clone(),
-                    Operation::CompareAndSwap(cas) => cas.key.clone(),
-                };
-
-                // Check overlay first (reflects mutations earlier in this batch),
-                // then fall back to the SM's pre-batch state.
-                let prev = if let Some(v) = overlay.get(&key) {
-                    v.clone()
-                } else {
-                    sm.get(&key).ok().flatten()
-                };
-
-                // Update overlay so later entries in this batch see the updated state.
-                // CAS outcome is unknown before apply, so we conservatively skip it;
-                // same-key CAS-pairs in one batch are rare and semantically ambiguous.
-                match op {
-                    Operation::Insert(ins) => {
-                        overlay.insert(key, Some(ins.value));
-                    }
-                    Operation::Delete(_) => {
-                        overlay.insert(key, None);
-                    }
-                    Operation::CompareAndSwap(_) => {}
+            let prev = match &entry.command {
+                Command::Insert { key, value, .. } => {
+                    let prev =
+                        overlay.get(key).cloned().unwrap_or_else(|| sm.get(key).ok().flatten());
+                    overlay.insert(key.clone(), Some(value.clone()));
+                    Some(prev.unwrap_or_default())
                 }
-
-                Some(prev.unwrap_or_default())
-            })();
+                Command::Delete { key } => {
+                    let prev =
+                        overlay.get(key).cloned().unwrap_or_else(|| sm.get(key).ok().flatten());
+                    overlay.insert(key.clone(), None);
+                    Some(prev.unwrap_or_default())
+                }
+                Command::CompareAndSwap { key, .. } => {
+                    let prev =
+                        overlay.get(key).cloned().unwrap_or_else(|| sm.get(key).ok().flatten());
+                    // CAS outcome is unknown before apply; skip overlay update.
+                    // Same-key CAS pairs in one batch are rare and semantically ambiguous.
+                    Some(prev.unwrap_or_default())
+                }
+                Command::Noop => None,
+            };
             result.push(prev);
         }
         result
     }
 
-    /// Broadcast watch events for applied chunk entries (fire-and-forget)
+    /// Broadcast watch events for applied chunk entries (fire-and-forget).
     ///
-    /// Parses chunk entries and broadcasts WatchResponse via tokio::broadcast channel.
+    /// Receives already-decoded `&[ApplyEntry]` — no proto decode happens here.
     /// Non-blocking: if channel is full, oldest events are dropped (lagging receivers).
     ///
     /// `results` must have the same length as `chunk` (enforced by StateMachineHandler contract).
@@ -722,68 +710,57 @@ where
     #[inline]
     pub(super) fn broadcast_watch_events(
         &self,
-        chunk: &[Entry],
+        chunk: &[ApplyEntry],
         results: &[ApplyResult],
         tx: &tokio::sync::broadcast::Sender<d_engine_proto::client::WatchResponse>,
         prev_values: Option<&[Option<bytes::Bytes>]>,
     ) {
         use d_engine_proto::client::WatchEventType;
         use d_engine_proto::client::WatchResponse;
-        use d_engine_proto::client::WriteCommand;
-        use d_engine_proto::client::write_command::Operation;
-        use d_engine_proto::common::entry_payload::Payload;
-        use prost::Message;
 
         for (i, entry) in chunk.iter().enumerate() {
-            if let Some(ref payload) = entry.payload
-                && let Some(Payload::Command(bytes)) = &payload.payload
-                && let Ok(write_cmd) = WriteCommand::decode(bytes.as_ref())
-            {
-                let prev_value = prev_values
-                    .and_then(|pv| pv.get(i))
-                    .and_then(|v| v.clone())
-                    .unwrap_or_default();
+            let prev_value =
+                prev_values.and_then(|pv| pv.get(i)).and_then(|v| v.clone()).unwrap_or_default();
 
-                let event = match write_cmd.operation {
-                    Some(Operation::Insert(insert)) => Some(WatchResponse {
-                        key: insert.key,
-                        value: insert.value,
-                        prev_value,
-                        event_type: WatchEventType::Put as i32,
-                        error: 0,
-                        revision: entry.index,
-                    }),
-                    Some(Operation::Delete(delete)) => Some(WatchResponse {
-                        key: delete.key,
-                        value: bytes::Bytes::new(),
-                        prev_value,
-                        event_type: WatchEventType::Delete as i32,
-                        error: 0,
-                        revision: entry.index,
-                    }),
-                    Some(Operation::CompareAndSwap(cas)) => {
-                        // Only broadcast if CAS actually mutated the value.
-                        // A failed CAS leaves the key unchanged — no watch event.
-                        if results.get(i).is_some_and(|r| r.succeeded) {
-                            Some(WatchResponse {
-                                key: cas.key,
-                                value: cas.new_value,
-                                prev_value,
-                                event_type: WatchEventType::Put as i32,
-                                error: 0,
-                                revision: entry.index,
-                            })
-                        } else {
-                            None
-                        }
+            let event = match &entry.command {
+                Command::Insert { key, value, .. } => Some(WatchResponse {
+                    key: key.clone(),
+                    value: value.clone(),
+                    prev_value,
+                    event_type: WatchEventType::Put as i32,
+                    error: 0,
+                    revision: entry.index,
+                }),
+                Command::Delete { key } => Some(WatchResponse {
+                    key: key.clone(),
+                    value: bytes::Bytes::new(),
+                    prev_value,
+                    event_type: WatchEventType::Delete as i32,
+                    error: 0,
+                    revision: entry.index,
+                }),
+                Command::CompareAndSwap { key, value, .. } => {
+                    // Only broadcast if CAS actually mutated the value.
+                    // A failed CAS leaves the key unchanged — no watch event.
+                    if results.get(i).is_some_and(|r| r.succeeded) {
+                        Some(WatchResponse {
+                            key: key.clone(),
+                            value: value.clone(),
+                            prev_value,
+                            event_type: WatchEventType::Put as i32,
+                            error: 0,
+                            revision: entry.index,
+                        })
+                    } else {
+                        None
                     }
-                    None => None,
-                };
-
-                if let Some(ev) = event {
-                    // Fire-and-forget: ignore send errors (no receivers or lagging)
-                    let _ = tx.send(ev);
                 }
+                Command::Noop => None,
+            };
+
+            if let Some(ev) = event {
+                // Fire-and-forget: ignore send errors (no receivers or lagging)
+                let _ = tx.send(ev);
             }
         }
     }

--- a/d-engine-core/src/state_machine_handler/default_state_machine_handler_test.rs
+++ b/d-engine-core/src/state_machine_handler/default_state_machine_handler_test.rs
@@ -153,7 +153,17 @@ fn test_pending_range_case3() {
 #[cfg(test)]
 mod apply_chunk_test {
 
+    use d_engine_proto::common::EntryPayload;
+
     use super::*;
+
+    fn noop_entry(index: u64) -> Entry {
+        Entry {
+            index,
+            term: 1,
+            payload: Some(EntryPayload::noop()),
+        }
+    }
 
     fn create_test_handler(
         path: &str,
@@ -185,27 +195,11 @@ mod apply_chunk_test {
             None,
         );
 
-        // Initial last_applied value
         assert_eq!(handler.last_applied(), 0);
 
-        // Create a test chunk with index 100
-        let chunk: Vec<Entry> = vec![
-            Entry {
-                index: 90,
-                term: 1,
-                payload: None,
-            },
-            Entry {
-                index: 100,
-                term: 1,
-                payload: None,
-            },
-        ];
-
-        // Apply the chunk
+        let chunk = vec![noop_entry(90), noop_entry(100)];
         let result = handler.apply_chunk(chunk).await;
 
-        // Verify last_applied was updated
         assert!(result.is_ok());
         assert_eq!(handler.last_applied(), 100);
     }
@@ -218,59 +212,27 @@ mod apply_chunk_test {
             None,
         );
 
-        // Initial last_applied value
         assert_eq!(handler.last_applied(), 0);
 
-        // Create a test chunk with index 50
-        let chunk = vec![
-            Entry {
-                index: 50,
-                term: 1,
-                payload: None,
-            },
-            Entry {
-                index: 70,
-                term: 1,
-                payload: None,
-            },
-        ];
-
-        // Apply the chunk
+        let chunk = vec![noop_entry(50), noop_entry(70)];
         let result = handler.apply_chunk(chunk).await;
 
-        // Verify last_applied was updated to the higher index
         assert!(result.is_ok());
         assert_eq!(handler.last_applied(), 70);
     }
+
     #[tokio::test]
     async fn test_apply_chunk_handles_empty_chunk() {
         let handler =
             create_test_handler("/tmp/test_apply_chunk_handles_empty_chunk", false, Some(2));
 
-        // Initial last_applied value
-        let chunk = vec![
-            Entry {
-                index: 1,
-                term: 1,
-                payload: None,
-            },
-            Entry {
-                index: 2,
-                term: 1,
-                payload: None,
-            },
-        ];
+        let chunk = vec![noop_entry(1), noop_entry(2)];
         let result = handler.apply_chunk(chunk).await;
         assert!(result.is_ok());
         assert_eq!(handler.last_applied(), 2);
 
-        // Create an empty chunk
-        let chunk = vec![];
-
-        // Apply the empty chunk
-        let result = handler.apply_chunk(chunk).await;
-
-        // Verify last_applied was updated
+        // Empty chunk: last_applied must not regress
+        let result = handler.apply_chunk(vec![]).await;
         assert!(result.is_ok());
         assert_eq!(handler.last_applied(), 2);
     }
@@ -283,20 +245,178 @@ mod apply_chunk_test {
             None,
         );
 
-        // Initial last_applied value
         assert_eq!(handler.last_applied(), 0);
 
-        // Create first chunk with index 50
-        let chunk1 = vec![Entry {
-            index: 50,
+        let result = handler.apply_chunk(vec![noop_entry(50)]).await;
+        assert!(result.is_err());
+        assert_eq!(handler.last_applied(), 0);
+    }
+}
+
+/// Verifies the decode boundary: raw proto `Entry` → `ApplyEntry` transition happens inside
+/// `DefaultStateMachineHandler::apply_chunk`, not inside the state machine.
+///
+/// The state machine mock's `apply_chunk` receives `&[ApplyEntry]` with fully decoded `Command`
+/// variants. It never sees raw proto bytes.
+#[cfg(test)]
+mod decode_boundary_tests {
+    use bytes::Bytes;
+    use d_engine_proto::client::WriteCommand;
+    use d_engine_proto::client::write_command::{Insert, Operation};
+    use d_engine_proto::common::EntryPayload;
+    use d_engine_proto::common::entry_payload::Payload;
+    use prost::Message;
+
+    use super::*;
+    use crate::test_utils::snapshot_config;
+    use crate::{ApplyResult, Command, MockSnapshotPolicy, MockStateMachine, MockTypeConfig};
+
+    fn noop_entry(index: u64) -> Entry {
+        Entry {
+            index,
             term: 1,
-            payload: None,
-        }];
+            payload: Some(EntryPayload::noop()),
+        }
+    }
 
-        // Apply first chunk
-        let result1 = handler.apply_chunk(chunk1).await;
-        assert!(result1.is_err());
-        assert_eq!(handler.last_applied(), 0);
+    fn insert_entry(
+        index: u64,
+        key: &[u8],
+        value: &[u8],
+    ) -> Entry {
+        let cmd = WriteCommand {
+            operation: Some(Operation::Insert(Insert {
+                key: Bytes::copy_from_slice(key),
+                value: Bytes::copy_from_slice(value),
+                ttl_secs: 0,
+            })),
+        };
+        let mut buf = Vec::new();
+        cmd.encode(&mut buf).unwrap();
+        Entry {
+            index,
+            term: 1,
+            payload: Some(EntryPayload {
+                payload: Some(Payload::Command(Bytes::from(buf))),
+            }),
+        }
+    }
+
+    fn config_entry(index: u64) -> Entry {
+        use d_engine_proto::common::AddNode;
+        use d_engine_proto::common::membership_change::Change;
+        Entry {
+            index,
+            term: 1,
+            payload: Some(EntryPayload::config(Change::AddNode(AddNode {
+                node_id: 1,
+                address: "127.0.0.1:4000".to_string(),
+                status: 0,
+            }))),
+        }
+    }
+
+    /// SM receives `ApplyEntry` with `Command::Insert` — the handler decoded the proto bytes.
+    #[tokio::test]
+    async fn test_handler_decodes_insert_before_sm_receives_it() {
+        let mut sm = MockStateMachine::new();
+        sm.expect_apply_chunk()
+            .withf(|entries| {
+                entries.len() == 1
+                    && matches!(
+                        &entries[0].command,
+                        Command::Insert { key, .. } if key == &Bytes::from_static(b"mykey")
+                    )
+            })
+            .returning(|chunk| Ok(vec![ApplyResult::success(chunk[0].index)]));
+
+        let handler = DefaultStateMachineHandler::<MockTypeConfig>::new_without_watch(
+            1,
+            0,
+            Arc::new(sm),
+            snapshot_config(std::path::PathBuf::from("/tmp/test_decode_insert_boundary")),
+            MockSnapshotPolicy::new(),
+        );
+
+        let result = handler.apply_chunk(vec![insert_entry(5, b"mykey", b"myval")]).await;
+        assert!(result.is_ok());
+        assert_eq!(handler.last_applied(), 5);
+    }
+
+    /// Noop entries reach the SM as `Command::Noop` — index continuity is preserved.
+    #[tokio::test]
+    async fn test_handler_noop_reaches_sm_as_command_noop() {
+        let mut sm = MockStateMachine::new();
+        sm.expect_apply_chunk()
+            .withf(|entries| entries.len() == 1 && matches!(entries[0].command, Command::Noop))
+            .returning(|chunk| Ok(vec![ApplyResult::success(chunk[0].index)]));
+
+        let handler = DefaultStateMachineHandler::<MockTypeConfig>::new_without_watch(
+            1,
+            0,
+            Arc::new(sm),
+            snapshot_config(std::path::PathBuf::from("/tmp/test_decode_noop_boundary")),
+            MockSnapshotPolicy::new(),
+        );
+
+        let result = handler.apply_chunk(vec![noop_entry(3)]).await;
+        assert!(result.is_ok());
+        assert_eq!(handler.last_applied(), 3);
+    }
+
+    /// Config entries become Command::Noop — SM receives a Noop at the config index.
+    /// This ensures sm.last_applied advances to the config index, so ReadIndex drain works.
+    #[tokio::test]
+    async fn test_handler_config_entry_becomes_noop_last_applied_advances() {
+        let mut sm = MockStateMachine::new();
+        sm.expect_apply_chunk()
+            .withf(|entries| entries.len() == 1 && matches!(entries[0].command, Command::Noop))
+            .returning(|chunk| Ok(chunk.iter().map(|e| ApplyResult::success(e.index)).collect()));
+
+        let handler = DefaultStateMachineHandler::<MockTypeConfig>::new_without_watch(
+            1,
+            0,
+            Arc::new(sm),
+            snapshot_config(std::path::PathBuf::from("/tmp/test_decode_config_boundary")),
+            MockSnapshotPolicy::new(),
+        );
+
+        let result = handler.apply_chunk(vec![config_entry(7)]).await;
+        assert!(result.is_ok());
+        // last_applied must reach 7 — Config was at commit index 7.
+        assert_eq!(handler.last_applied(), 7);
+    }
+
+    /// Mixed batch: noop + config + insert. Config becomes Noop; SM receives 3 entries in order.
+    #[tokio::test]
+    async fn test_handler_mixed_batch_config_becomes_noop_order_preserved() {
+        let mut sm = MockStateMachine::new();
+        sm.expect_apply_chunk()
+            .withf(|entries| {
+                entries.len() == 3
+                    && matches!(entries[0].command, Command::Noop)
+                    && matches!(entries[1].command, Command::Noop) // config → noop
+                    && matches!(&entries[2].command, Command::Insert { .. })
+            })
+            .returning(|chunk| Ok(chunk.iter().map(|e| ApplyResult::success(e.index)).collect()));
+
+        let handler = DefaultStateMachineHandler::<MockTypeConfig>::new_without_watch(
+            1,
+            0,
+            Arc::new(sm),
+            snapshot_config(std::path::PathBuf::from("/tmp/test_decode_mixed_boundary")),
+            MockSnapshotPolicy::new(),
+        );
+
+        // indices: 10=noop, 11=config(→noop), 12=insert — all 3 forwarded to SM
+        let chunk = vec![
+            noop_entry(10),
+            config_entry(11),
+            insert_entry(12, b"k", b"v"),
+        ];
+        let result = handler.apply_chunk(chunk).await;
+        assert!(result.is_ok());
+        assert_eq!(handler.last_applied(), 12);
     }
 }
 
@@ -1688,35 +1808,22 @@ mod mmap_tests {
 
 #[cfg(feature = "watch")]
 mod broadcast_watch_events_tests {
+    use bytes::Bytes;
+    use d_engine_proto::client::WatchEventType;
+
     use super::*;
+    use crate::{ApplyEntry, ApplyResult, Command};
 
-    use d_engine_proto::{
-        client::{
-            WatchEventType, WriteCommand,
-            write_command::{CompareAndSwap, Delete, Insert, Operation},
-        },
-        common::{EntryPayload, entry_payload::Payload},
-    };
-    use prost::Message;
-
-    use crate::ApplyResult;
-
-    fn create_entry(
+    /// Build an `ApplyEntry` directly from a `Command` — no proto encoding needed.
+    /// `broadcast_watch_events` receives already-decoded entries; tests mirror that reality.
+    fn apply_entry(
         index: u64,
-        operation: Operation,
-    ) -> Entry {
-        let write_cmd = WriteCommand {
-            operation: Some(operation),
-        };
-        let mut buf = Vec::new();
-        write_cmd.encode(&mut buf).unwrap();
-
-        Entry {
+        command: Command,
+    ) -> ApplyEntry {
+        ApplyEntry {
             index,
             term: 1,
-            payload: Some(EntryPayload {
-                payload: Some(Payload::Command(Bytes::from(buf))),
-            }),
+            command,
         }
     }
 
@@ -1739,20 +1846,20 @@ mod broadcast_watch_events_tests {
         let (tx, mut rx) = tokio::sync::broadcast::channel(10);
         let handler = create_test_handler(Path::new("/tmp/test_watch"), Some(0));
 
-        let entry = create_entry(
+        let entry = apply_entry(
             1,
-            Operation::Insert(Insert {
-                key: b"key1".to_vec().into(),
-                value: b"value1".to_vec().into(),
-                ttl_secs: 0,
-            }),
+            Command::Insert {
+                key: Bytes::from_static(b"key1"),
+                value: Bytes::from_static(b"value1"),
+                ttl_secs: None,
+            },
         );
 
         handler.broadcast_watch_events(&[entry], &[succeeded(1)], &tx, None);
 
         let event = rx.recv().await.unwrap();
-        assert_eq!(event.key, Bytes::from(&b"key1"[..]));
-        assert_eq!(event.value, Bytes::from(&b"value1"[..]));
+        assert_eq!(event.key, Bytes::from_static(b"key1"));
+        assert_eq!(event.value, Bytes::from_static(b"value1"));
         assert_eq!(event.event_type, WatchEventType::Put as i32);
     }
 
@@ -1761,17 +1868,17 @@ mod broadcast_watch_events_tests {
         let (tx, mut rx) = tokio::sync::broadcast::channel(10);
         let handler = create_test_handler(Path::new("/tmp/test_watch"), Some(0));
 
-        let entry = create_entry(
+        let entry = apply_entry(
             1,
-            Operation::Delete(Delete {
-                key: b"key1".to_vec().into(),
-            }),
+            Command::Delete {
+                key: Bytes::from_static(b"key1"),
+            },
         );
 
         handler.broadcast_watch_events(&[entry], &[succeeded(1)], &tx, None);
 
         let event = rx.recv().await.unwrap();
-        assert_eq!(event.key, Bytes::from(&b"key1"[..]));
+        assert_eq!(event.key, Bytes::from_static(b"key1"));
         assert_eq!(event.value, Bytes::new());
         assert_eq!(event.event_type, WatchEventType::Delete as i32);
     }
@@ -1782,20 +1889,20 @@ mod broadcast_watch_events_tests {
         let (tx, mut rx) = tokio::sync::broadcast::channel(10);
         let handler = create_test_handler(Path::new("/tmp/test_watch"), Some(0));
 
-        let entry = create_entry(
+        let entry = apply_entry(
             1,
-            Operation::CompareAndSwap(CompareAndSwap {
-                key: b"lock".to_vec().into(),
-                expected_value: Some(b"owner1".to_vec().into()),
-                new_value: b"owner2".to_vec().into(),
-            }),
+            Command::CompareAndSwap {
+                key: Bytes::from_static(b"lock"),
+                expected: Some(Bytes::from_static(b"owner1")),
+                value: Bytes::from_static(b"owner2"),
+            },
         );
 
         handler.broadcast_watch_events(&[entry], &[succeeded(1)], &tx, None);
 
         let event = rx.recv().await.unwrap();
-        assert_eq!(event.key, Bytes::from(&b"lock"[..]));
-        assert_eq!(event.value, Bytes::from(&b"owner2"[..]));
+        assert_eq!(event.key, Bytes::from_static(b"lock"));
+        assert_eq!(event.value, Bytes::from_static(b"owner2"));
         assert_eq!(event.event_type, WatchEventType::Put as i32);
     }
 
@@ -1805,18 +1912,17 @@ mod broadcast_watch_events_tests {
         let (tx, mut rx) = tokio::sync::broadcast::channel(10);
         let handler = create_test_handler(Path::new("/tmp/test_watch"), Some(0));
 
-        let entry = create_entry(
+        let entry = apply_entry(
             1,
-            Operation::CompareAndSwap(CompareAndSwap {
-                key: b"lock".to_vec().into(),
-                expected_value: Some(b"wrong_owner".to_vec().into()),
-                new_value: b"owner2".to_vec().into(),
-            }),
+            Command::CompareAndSwap {
+                key: Bytes::from_static(b"lock"),
+                expected: Some(Bytes::from_static(b"wrong_owner")),
+                value: Bytes::from_static(b"owner2"),
+            },
         );
 
         handler.broadcast_watch_events(&[entry], &[failed(1)], &tx, None);
 
-        // Channel must be empty — no event should have been sent
         assert!(
             rx.try_recv().is_err(),
             "Expected no watch event for failed CAS"
@@ -1830,29 +1936,29 @@ mod broadcast_watch_events_tests {
         let handler = create_test_handler(Path::new("/tmp/test_watch"), Some(0));
 
         let entries = vec![
-            create_entry(
+            apply_entry(
                 1,
-                Operation::CompareAndSwap(CompareAndSwap {
-                    key: b"k1".to_vec().into(),
-                    expected_value: Some(b"v0".to_vec().into()),
-                    new_value: b"v1".to_vec().into(),
-                }),
+                Command::CompareAndSwap {
+                    key: Bytes::from_static(b"k1"),
+                    expected: Some(Bytes::from_static(b"v0")),
+                    value: Bytes::from_static(b"v1"),
+                },
             ),
-            create_entry(
+            apply_entry(
                 2,
-                Operation::CompareAndSwap(CompareAndSwap {
-                    key: b"k2".to_vec().into(),
-                    expected_value: Some(b"wrong".to_vec().into()),
-                    new_value: b"v2".to_vec().into(),
-                }),
+                Command::CompareAndSwap {
+                    key: Bytes::from_static(b"k2"),
+                    expected: Some(Bytes::from_static(b"wrong")),
+                    value: Bytes::from_static(b"v2"),
+                },
             ),
-            create_entry(
+            apply_entry(
                 3,
-                Operation::CompareAndSwap(CompareAndSwap {
-                    key: b"k3".to_vec().into(),
-                    expected_value: None,
-                    new_value: b"v3".to_vec().into(),
-                }),
+                Command::CompareAndSwap {
+                    key: Bytes::from_static(b"k3"),
+                    expected: None,
+                    value: Bytes::from_static(b"v3"),
+                },
             ),
         ];
         let results = vec![succeeded(1), failed(2), succeeded(3)];
@@ -1861,17 +1967,16 @@ mod broadcast_watch_events_tests {
 
         // k1 succeeded → Put event
         let event1 = rx.recv().await.unwrap();
-        assert_eq!(event1.key, Bytes::from(&b"k1"[..]));
-        assert_eq!(event1.value, Bytes::from(&b"v1"[..]));
+        assert_eq!(event1.key, Bytes::from_static(b"k1"));
+        assert_eq!(event1.value, Bytes::from_static(b"v1"));
         assert_eq!(event1.event_type, WatchEventType::Put as i32);
 
         // k3 succeeded → Put event (k2 failed, skipped)
         let event2 = rx.recv().await.unwrap();
-        assert_eq!(event2.key, Bytes::from(&b"k3"[..]));
-        assert_eq!(event2.value, Bytes::from(&b"v3"[..]));
+        assert_eq!(event2.key, Bytes::from_static(b"k3"));
+        assert_eq!(event2.value, Bytes::from_static(b"v3"));
         assert_eq!(event2.event_type, WatchEventType::Put as i32);
 
-        // No more events
         assert!(rx.try_recv().is_err(), "Expected no further events");
     }
 
@@ -1882,106 +1987,90 @@ mod broadcast_watch_events_tests {
         let handler = create_test_handler(Path::new("/tmp/test_watch"), Some(0));
 
         let entries = vec![
-            create_entry(
+            apply_entry(
                 1,
-                Operation::Insert(Insert {
-                    key: b"k1".to_vec().into(),
-                    value: b"v1".to_vec().into(),
-                    ttl_secs: 0,
-                }),
+                Command::Insert {
+                    key: Bytes::from_static(b"k1"),
+                    value: Bytes::from_static(b"v1"),
+                    ttl_secs: None,
+                },
             ),
-            create_entry(
+            apply_entry(
                 2,
-                Operation::CompareAndSwap(CompareAndSwap {
-                    key: b"k2".to_vec().into(),
-                    expected_value: Some(b"wrong".to_vec().into()),
-                    new_value: b"v2".to_vec().into(),
-                }),
+                Command::CompareAndSwap {
+                    key: Bytes::from_static(b"k2"),
+                    expected: Some(Bytes::from_static(b"wrong")),
+                    value: Bytes::from_static(b"v2"),
+                },
             ),
-            create_entry(
+            apply_entry(
                 3,
-                Operation::Delete(Delete {
-                    key: b"k3".to_vec().into(),
-                }),
+                Command::Delete {
+                    key: Bytes::from_static(b"k3"),
+                },
             ),
         ];
         let results = vec![succeeded(1), failed(2), succeeded(3)];
 
         handler.broadcast_watch_events(&entries, &results, &tx, None);
 
-        // Insert event
         let event1 = rx.recv().await.unwrap();
-        assert_eq!(event1.key, Bytes::from(&b"k1"[..]));
+        assert_eq!(event1.key, Bytes::from_static(b"k1"));
         assert_eq!(event1.event_type, WatchEventType::Put as i32);
 
-        // Delete event (failed CAS at index 1 was skipped)
         let event2 = rx.recv().await.unwrap();
-        assert_eq!(event2.key, Bytes::from(&b"k3"[..]));
+        assert_eq!(event2.key, Bytes::from_static(b"k3"));
         assert_eq!(event2.event_type, WatchEventType::Delete as i32);
 
-        // No more events
         assert!(rx.try_recv().is_err(), "Expected no further events");
     }
 
-    // Verifies results[i] aligns with chunk[i] by index position, not by ApplyResult.index
+    // results[i] aligns with chunk[i] by position, not by ApplyResult.index
     #[tokio::test]
     async fn test_broadcast_cas_results_index_alignment() {
         let (tx, mut rx) = tokio::sync::broadcast::channel(10);
         let handler = create_test_handler(Path::new("/tmp/test_watch"), Some(0));
 
-        // chunk[0] = CAS failed, chunk[1] = CAS succeeded
         let entries = vec![
-            create_entry(
+            apply_entry(
                 10,
-                Operation::CompareAndSwap(CompareAndSwap {
-                    key: b"key-a".to_vec().into(),
-                    expected_value: Some(b"old".to_vec().into()),
-                    new_value: b"new-a".to_vec().into(),
-                }),
+                Command::CompareAndSwap {
+                    key: Bytes::from_static(b"key-a"),
+                    expected: Some(Bytes::from_static(b"old")),
+                    value: Bytes::from_static(b"new-a"),
+                },
             ),
-            create_entry(
+            apply_entry(
                 11,
-                Operation::CompareAndSwap(CompareAndSwap {
-                    key: b"key-b".to_vec().into(),
-                    expected_value: Some(b"old".to_vec().into()),
-                    new_value: b"new-b".to_vec().into(),
-                }),
+                Command::CompareAndSwap {
+                    key: Bytes::from_static(b"key-b"),
+                    expected: Some(Bytes::from_static(b"old")),
+                    value: Bytes::from_static(b"new-b"),
+                },
             ),
         ];
-        // results[0] = failed (aligns with chunk[0] = key-a)
-        // results[1] = succeeded (aligns with chunk[1] = key-b)
         let results = vec![failed(10), succeeded(11)];
 
         handler.broadcast_watch_events(&entries, &results, &tx, None);
 
-        // Only key-b event should arrive
         let event = rx.recv().await.unwrap();
-        assert_eq!(event.key, Bytes::from(&b"key-b"[..]));
-        assert_eq!(event.value, Bytes::from(&b"new-b"[..]));
+        assert_eq!(event.key, Bytes::from_static(b"key-b"));
+        assert_eq!(event.value, Bytes::from_static(b"new-b"));
         assert_eq!(event.event_type, WatchEventType::Put as i32);
 
         assert!(rx.try_recv().is_err(), "key-a should not emit an event");
     }
 
+    // Noop entries in chunk produce no watch events
     #[tokio::test]
-    async fn test_broadcast_ignores_invalid_entries() {
+    async fn test_broadcast_noop_produces_no_event() {
         let (tx, mut rx) = tokio::sync::broadcast::channel(10);
-        let handler = create_test_handler(Path::new("/tmp/test_watch"), Some(0));
+        let handler = create_test_handler(Path::new("/tmp/test_watch_noop"), Some(0));
 
-        let entry = create_entry(
-            1,
-            Operation::Insert(Insert {
-                key: b"key1".to_vec().into(),
-                value: b"value1".to_vec().into(),
-                ttl_secs: 0,
-            }),
-        );
-
+        let entry = apply_entry(1, Command::Noop);
         handler.broadcast_watch_events(&[entry], &[succeeded(1)], &tx, None);
 
-        // Should still receive valid event
-        let event = rx.recv().await.unwrap();
-        assert_eq!(event.key, Bytes::from(&b"key1"[..]));
+        assert!(rx.try_recv().is_err(), "Noop must not emit a watch event");
     }
 }
 

--- a/d-engine-core/src/storage/state_machine.rs
+++ b/d-engine-core/src/storage/state_machine.rs
@@ -4,9 +4,10 @@
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use d_engine_proto::common::Entry;
 use d_engine_proto::common::LogId;
 use d_engine_proto::server::storage::SnapshotMetadata;
+
+use crate::ApplyEntry;
 #[cfg(any(test, feature = "__test_support"))]
 use mockall::automock;
 
@@ -102,17 +103,17 @@ pub trait StateMachine: Send + Sync + 'static {
         entry_id: u64,
     ) -> Option<u64>;
 
-    /// Applies a chunk of log entries to the state machine.
+    /// Applies a batch of decoded log entries to the state machine.
     ///
-    /// Returns a result for each entry in the same order as the input chunk.
-    /// The returned vector MUST have the same length as the input chunk.
+    /// Receives `&[ApplyEntry]` (already decoded by the framework) instead of raw
+    /// proto `Entry`.  The framework decodes `bytes → Command` exactly once in
+    /// `DefaultStateMachineHandler`; implementors never touch proto or wire format.
     ///
-    /// # Performance Note
-    /// This is a hot path - implementations should minimize allocations.
-    /// Pre-allocate the result vector with `Vec::with_capacity(chunk.len())`.
+    /// The returned `Vec` MUST have the same length as `chunk` and preserve order.
+    /// Pre-allocate with `Vec::with_capacity(chunk.len())` on the hot path.
     async fn apply_chunk(
         &self,
-        chunk: Vec<Entry>,
+        chunk: &[ApplyEntry],
     ) -> Result<Vec<ApplyResult>, Error>;
 
     /// Returns the number of entries in the state machine.

--- a/d-engine-core/src/storage/state_machine_test.rs
+++ b/d-engine-core/src/storage/state_machine_test.rs
@@ -4,19 +4,12 @@ use std::time::Instant;
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use d_engine_proto::client::WriteCommand;
-use d_engine_proto::client::write_command::CompareAndSwap;
-use d_engine_proto::client::write_command::Delete;
-use d_engine_proto::client::write_command::Insert;
-use d_engine_proto::client::write_command::Operation;
-use d_engine_proto::common::Entry;
-use d_engine_proto::common::EntryPayload;
 use d_engine_proto::common::LogId;
-use d_engine_proto::common::entry_payload::Payload;
 use d_engine_proto::server::storage::SnapshotMetadata;
-use prost::Message;
 use tempfile::TempDir;
 
+use crate::ApplyEntry;
+use crate::Command;
 use crate::Error;
 use crate::storage::StateMachine;
 
@@ -97,7 +90,7 @@ impl StateMachineTestSuite {
             Bytes::from(test_key.to_vec()),
             test_value.clone(),
         )];
-        state_machine.apply_chunk(entries).await?;
+        state_machine.apply_chunk(&entries).await?;
 
         // Verify the value was inserted
         match state_machine.get(test_key)? {
@@ -107,7 +100,7 @@ impl StateMachineTestSuite {
 
         // Create a delete entry
         let entries = vec![create_delete_entry(2, Bytes::from(test_key.to_vec()))];
-        state_machine.apply_chunk(entries).await?;
+        state_machine.apply_chunk(&entries).await?;
 
         // Verify the value was deleted
         assert!(state_machine.get(test_key)?.is_none());
@@ -121,7 +114,7 @@ impl StateMachineTestSuite {
 
         // Test 1: CAS on non-existent key (expected None)
         let entry1 = create_cas_entry(1, b"lock".to_vec().into(), None, b"owner1".to_vec().into());
-        sm.apply_chunk(vec![entry1]).await?;
+        sm.apply_chunk(&[entry1]).await?;
         assert_eq!(sm.get(b"lock")?, Some(b"owner1".to_vec().into()));
 
         // Test 2: CAS success (expected matches)
@@ -131,7 +124,7 @@ impl StateMachineTestSuite {
             Some(b"owner1".to_vec().into()),
             b"owner2".to_vec().into(),
         );
-        sm.apply_chunk(vec![entry2]).await?;
+        sm.apply_chunk(&[entry2]).await?;
         assert_eq!(sm.get(b"lock")?, Some(b"owner2".to_vec().into()));
 
         // Test 3: CAS failure (expected mismatch) - value should not change
@@ -141,7 +134,7 @@ impl StateMachineTestSuite {
             Some(b"wrong".to_vec().into()),
             b"owner3".to_vec().into(),
         );
-        sm.apply_chunk(vec![entry3]).await?;
+        sm.apply_chunk(&[entry3]).await?;
         assert_eq!(sm.get(b"lock")?, Some(b"owner2".to_vec().into())); // Still owner2
 
         sm.stop()?;
@@ -172,7 +165,7 @@ impl StateMachineTestSuite {
             ),
         ];
 
-        state_machine.apply_chunk(entries).await?;
+        state_machine.apply_chunk(&entries).await?;
 
         // Verify the final state
         assert!(state_machine.get(b"key1")?.is_none());
@@ -216,7 +209,7 @@ impl StateMachineTestSuite {
             ),
         ];
 
-        state_machine.apply_chunk(entries).await?;
+        state_machine.apply_chunk(&entries).await?;
         assert_eq!(state_machine.last_applied(), LogId { index: 3, term: 1 });
 
         Ok(())
@@ -244,7 +237,7 @@ impl StateMachineTestSuite {
                 Bytes::from(b"value3".to_vec()),
             ),
         ];
-        state_machine.apply_chunk(entries).await?;
+        state_machine.apply_chunk(&entries).await?;
 
         // Create a temporary directory for the snapshot
         let temp_dir = TempDir::new()?;
@@ -294,7 +287,7 @@ impl StateMachineTestSuite {
                 Bytes::from(b"old_value3".to_vec()),
             ),
         ];
-        state_machine.apply_chunk(entries).await?;
+        state_machine.apply_chunk(&entries).await?;
 
         state_machine.apply_snapshot_from_file(&metadata, snapshot_dir).await?;
 
@@ -333,7 +326,7 @@ impl StateMachineTestSuite {
                 Bytes::from(b"value2".to_vec()),
             ),
         ];
-        state_machine.apply_chunk(entries).await?;
+        state_machine.apply_chunk(&entries).await?;
 
         // Update last applied
         let last_applied = LogId { index: 2, term: 1 };
@@ -370,7 +363,7 @@ impl StateMachineTestSuite {
             .collect();
 
         let start = Instant::now();
-        state_machine.apply_chunk(entries).await?;
+        state_machine.apply_chunk(&entries).await?;
         let elapsed = start.elapsed();
 
         assert!(
@@ -400,7 +393,7 @@ impl StateMachineTestSuite {
             .collect();
 
         let start_small = Instant::now();
-        state_machine.apply_chunk(small_entries).await?;
+        state_machine.apply_chunk(&small_entries).await?;
         let elapsed_small = start_small.elapsed();
 
         // Large batch: 1000 entries
@@ -415,7 +408,7 @@ impl StateMachineTestSuite {
             .collect();
 
         let start_large = Instant::now();
-        state_machine.apply_chunk(large_entries).await?;
+        state_machine.apply_chunk(&large_entries).await?;
         let elapsed_large = start_large.elapsed();
 
         // Verify linear scalability: 1000 entries should be 5x-15x slower (not 100x)
@@ -470,7 +463,7 @@ impl StateMachineTestSuite {
                 Bytes::from(b"drop_test_value2".to_vec()),
             ),
         ];
-        sm.apply_chunk(entries).await?;
+        sm.apply_chunk(&entries).await?;
 
         // Verify data exists in memory
         assert_eq!(
@@ -545,7 +538,7 @@ impl StateMachineTestSuite {
                     Bytes::from(b"drop_meta_value3".to_vec()),
                 ),
             ];
-            sm.apply_chunk(entries).await?;
+            sm.apply_chunk(&entries).await?;
 
             // Verify last_applied in memory
             assert_eq!(
@@ -624,7 +617,7 @@ impl StateMachineTestSuite {
                     Bytes::from(b"reopen_value3".to_vec()),
                 ),
             ];
-            sm.apply_chunk(entries).await?;
+            sm.apply_chunk(&entries).await?;
 
             last_applied_before = sm.last_applied();
             assert_eq!(last_applied_before.index, 3);
@@ -703,7 +696,7 @@ impl StateMachineTestSuite {
                 Bytes::from(b"crash_value2".to_vec()),
             ),
         ];
-        sm.apply_chunk(entries).await?;
+        sm.apply_chunk(&entries).await?;
 
         // Verify data exists in memory
         assert!(sm.get(b"crash_key1")?.is_some());
@@ -776,7 +769,7 @@ impl StateMachineTestSuite {
                 Bytes::from(b"value3".to_vec()),
             ),
         ];
-        state_machine.apply_chunk(entries).await?;
+        state_machine.apply_chunk(&entries).await?;
 
         // Verify data exists
         assert_eq!(
@@ -826,7 +819,7 @@ impl StateMachineTestSuite {
                 Bytes::from(b"new_value2".to_vec()),
             ),
         ];
-        state_machine.apply_chunk(new_entries).await?;
+        state_machine.apply_chunk(&new_entries).await?;
 
         // Verify new data exists
         assert_eq!(
@@ -843,92 +836,50 @@ impl StateMachineTestSuite {
     }
 }
 
-/// Helper function to create an insert entry
+/// Helper function to create an Insert ApplyEntry
 fn create_insert_entry(
     index: u64,
     key: Bytes,
     value: Bytes,
-) -> Entry {
-    // 1. Build the WriteCommand
-    let insert = Insert {
-        key,
-        value,
-        ttl_secs: 0,
-    };
-    let operation = Operation::Insert(insert);
-    let write_cmd = WriteCommand {
-        operation: Some(operation),
-    };
-
-    // 2. Serialize WriteCommand to Bytes
-    let mut buf = Vec::new();
-    write_cmd.encode(&mut buf).expect("Failed to encode WriteCommand");
-    let cmd_bytes = Bytes::from(buf); // convert Vec<u8> to Bytes
-
-    // 3. Wrap in Payload::Command
-    let payload = EntryPayload {
-        payload: Some(Payload::Command(cmd_bytes)),
-    };
-
-    // 4. Build the Entry
-    Entry {
+) -> ApplyEntry {
+    ApplyEntry {
         index,
         term: 1,
-        payload: Some(payload),
+        command: Command::Insert {
+            key,
+            value,
+            ttl_secs: None,
+        },
     }
 }
 
-/// Helper function to create a delete entry
+/// Helper function to create a Delete ApplyEntry
 fn create_delete_entry(
     index: u64,
     key: Bytes,
-) -> Entry {
-    let delete = Delete { key };
-    let operation = Operation::Delete(delete);
-    let write_cmd = WriteCommand {
-        operation: Some(operation),
-    };
-
-    let mut buf = Vec::new();
-    write_cmd.encode(&mut buf).expect("Failed to encode WriteCommand");
-    let cmd_bytes = Bytes::from(buf);
-
-    Entry {
+) -> ApplyEntry {
+    ApplyEntry {
         index,
         term: 1,
-        payload: Some(EntryPayload {
-            payload: Some(Payload::Command(cmd_bytes)),
-        }),
+        command: Command::Delete { key },
     }
 }
 
-/// Helper function to create a CAS entry
+/// Helper function to create a CAS ApplyEntry
 fn create_cas_entry(
     index: u64,
     key: Bytes,
-    expected_value: Option<Bytes>,
-    new_value: Bytes,
-) -> Entry {
-    let cas = CompareAndSwap {
-        key,
-        expected_value,
-        new_value,
-    };
-    let operation = Operation::CompareAndSwap(cas);
-    let write_cmd = WriteCommand {
-        operation: Some(operation),
-    };
-
-    let mut buf = Vec::new();
-    write_cmd.encode(&mut buf).expect("Failed to encode WriteCommand");
-    let cmd_bytes = Bytes::from(buf);
-
-    Entry {
+    expected: Option<Bytes>,
+    value: Bytes,
+) -> ApplyEntry {
+    ApplyEntry {
         index,
         term: 1,
-        payload: Some(EntryPayload {
-            payload: Some(Payload::Command(cmd_bytes)),
-        }),
+        command: Command::CompareAndSwap {
+            key,
+            expected,
+            value,
+        },
     }
 }
 
@@ -946,11 +897,11 @@ mod default_scan_prefix_tests {
 
     use async_trait::async_trait;
     use bytes::Bytes;
-    use d_engine_proto::common::{Entry, LogId};
+    use d_engine_proto::common::LogId;
     use d_engine_proto::server::storage::SnapshotMetadata;
 
-    use crate::Error;
     use crate::storage::state_machine::{ApplyResult, StateMachine};
+    use crate::{ApplyEntry, Error};
 
     struct MinimalSm {
         running: AtomicBool,
@@ -988,7 +939,7 @@ mod default_scan_prefix_tests {
 
         async fn apply_chunk(
             &self,
-            _chunk: Vec<Entry>,
+            _chunk: &[ApplyEntry],
         ) -> Result<Vec<ApplyResult>, Error> {
             Ok(vec![])
         }

--- a/d-engine-server/benches/lease_performance.rs
+++ b/d-engine-server/benches/lease_performance.rs
@@ -10,6 +10,7 @@
 //! 3. Batch operations with TTL
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use bytes::Bytes;
 use criterion::BenchmarkId;
@@ -124,9 +125,11 @@ fn bench_ttl_registration(c: &mut Criterion) {
     // Scenario 1: No TTL (baseline)
     let (sm_no_ttl, _temp1) = rt.block_on(create_sm_background());
 
+    let idx1 = AtomicU64::new(1);
     group.bench_function("no_ttl_baseline", |b| {
         b.to_async(&rt).iter(|| async {
-            let entry = create_entry_with_ttl(1, 1, b"key", b"value", 0);
+            let i = idx1.fetch_add(1, Ordering::Relaxed);
+            let entry = create_entry_with_ttl(i, 1, b"key", b"value", 0);
             sm_no_ttl.apply_chunk(&[entry]).await.unwrap();
         });
     });
@@ -137,9 +140,11 @@ fn bench_ttl_registration(c: &mut Criterion) {
     // Scenario 2: With TTL (lease enabled)
     let (sm_ttl, _temp2) = rt.block_on(create_sm_background());
 
+    let idx2 = AtomicU64::new(1);
     group.bench_function("with_ttl_background", |b| {
         b.to_async(&rt).iter(|| async {
-            let entry = create_entry_with_ttl(1, 1, b"key", b"value", 3600);
+            let i = idx2.fetch_add(1, Ordering::Relaxed);
+            let entry = create_entry_with_ttl(i, 1, b"key", b"value", 3600);
             sm_ttl.apply_chunk(&[entry]).await.unwrap();
         });
     });
@@ -159,16 +164,18 @@ fn bench_batch_ttl_operations(c: &mut Criterion) {
     for batch_size in [10, 100, 1000].iter() {
         // Create fresh StateMachine for each batch size to avoid state pollution
         let (sm_bg, _temp_bg) = rt.block_on(create_sm_background());
+        let idx = AtomicU64::new(1);
 
         group.bench_with_input(
             BenchmarkId::new("background", batch_size),
             batch_size,
             |b, &size| {
                 b.to_async(&rt).iter(|| async {
+                    let start = idx.fetch_add(size as u64, Ordering::Relaxed);
                     let entries: Vec<ApplyEntry> = (0..size)
                         .map(|i| {
                             create_entry_with_ttl(
-                                1 + i as u64,
+                                start + i as u64,
                                 1,
                                 format!("key_{i}").as_bytes(),
                                 b"value",

--- a/d-engine-server/benches/lease_performance.rs
+++ b/d-engine-server/benches/lease_performance.rs
@@ -17,15 +17,9 @@ use criterion::Criterion;
 use criterion::black_box;
 use criterion::criterion_group;
 use criterion::criterion_main;
-use d_engine_core::StateMachine;
-use d_engine_proto::client::WriteCommand;
-use d_engine_proto::client::write_command::Operation;
-use d_engine_proto::common::Entry;
-use d_engine_proto::common::EntryPayload;
-use d_engine_proto::common::entry_payload::Payload;
+use d_engine_core::{ApplyEntry, Command, StateMachine};
 use d_engine_server::storage::DefaultLease;
 use d_engine_server::storage::FileStateMachine;
-use prost::Message;
 use tempfile::TempDir;
 
 /// Create FileStateMachine with Background strategy (lease enabled)
@@ -64,26 +58,15 @@ fn create_entry_with_ttl(
     key: &[u8],
     value: &[u8],
     ttl_secs: u64,
-) -> Entry {
-    let insert = d_engine_proto::client::write_command::Insert {
-        key: Bytes::copy_from_slice(key),
-        value: Bytes::copy_from_slice(value),
-        ttl_secs,
-    };
-
-    let write_cmd = WriteCommand {
-        operation: Some(Operation::Insert(insert)),
-    };
-
-    let mut buf = Vec::new();
-    write_cmd.encode(&mut buf).unwrap();
-
-    Entry {
+) -> ApplyEntry {
+    ApplyEntry {
         index,
         term,
-        payload: Some(EntryPayload {
-            payload: Some(Payload::Command(Bytes::from(buf))),
-        }),
+        command: Command::Insert {
+            key: Bytes::copy_from_slice(key),
+            value: Bytes::copy_from_slice(value),
+            ttl_secs: if ttl_secs > 0 { Some(ttl_secs) } else { None },
+        },
     }
 }
 
@@ -98,7 +81,7 @@ fn bench_get_performance(c: &mut Criterion) {
     // Insert key without TTL
     rt.block_on(async {
         let entry = create_entry_with_ttl(1, 1, b"bench_key", b"bench_value", 0);
-        sm.apply_chunk(vec![entry]).await.unwrap();
+        sm.apply_chunk(&[entry]).await.unwrap();
     });
 
     group.bench_function("no_lease_baseline", |b| {
@@ -116,7 +99,7 @@ fn bench_get_performance(c: &mut Criterion) {
 
     rt.block_on(async {
         let entry = create_entry_with_ttl(1, 1, b"bg_key", b"bg_value", 3600);
-        sm_bg.apply_chunk(vec![entry]).await.unwrap();
+        sm_bg.apply_chunk(&[entry]).await.unwrap();
     });
 
     group.bench_function("background_strategy", |b| {
@@ -144,7 +127,7 @@ fn bench_ttl_registration(c: &mut Criterion) {
     group.bench_function("no_ttl_baseline", |b| {
         b.to_async(&rt).iter(|| async {
             let entry = create_entry_with_ttl(1, 1, b"key", b"value", 0);
-            sm_no_ttl.apply_chunk(vec![entry]).await.unwrap();
+            sm_no_ttl.apply_chunk(&[entry]).await.unwrap();
         });
     });
 
@@ -157,7 +140,7 @@ fn bench_ttl_registration(c: &mut Criterion) {
     group.bench_function("with_ttl_background", |b| {
         b.to_async(&rt).iter(|| async {
             let entry = create_entry_with_ttl(1, 1, b"key", b"value", 3600);
-            sm_ttl.apply_chunk(vec![entry]).await.unwrap();
+            sm_ttl.apply_chunk(&[entry]).await.unwrap();
         });
     });
 
@@ -182,7 +165,7 @@ fn bench_batch_ttl_operations(c: &mut Criterion) {
             batch_size,
             |b, &size| {
                 b.to_async(&rt).iter(|| async {
-                    let entries: Vec<Entry> = (0..size)
+                    let entries: Vec<ApplyEntry> = (0..size)
                         .map(|i| {
                             create_entry_with_ttl(
                                 1 + i as u64,
@@ -193,7 +176,7 @@ fn bench_batch_ttl_operations(c: &mut Criterion) {
                             )
                         })
                         .collect();
-                    sm_bg.apply_chunk(entries).await.unwrap();
+                    sm_bg.apply_chunk(&entries).await.unwrap();
                 });
             },
         );

--- a/d-engine-server/benches/state_machine.rs
+++ b/d-engine-server/benches/state_machine.rs
@@ -16,18 +16,11 @@ use criterion::Criterion;
 use criterion::black_box;
 use criterion::criterion_group;
 use criterion::criterion_main;
-use d_engine_core::StateMachine;
 use d_engine_core::watch::WatchDispatcher;
 use d_engine_core::watch::WatchRegistry;
 use d_engine_core::watch::WatcherHandle;
-use d_engine_proto::client::WriteCommand;
-use d_engine_proto::client::write_command::Insert;
-use d_engine_proto::client::write_command::Operation;
-use d_engine_proto::common::Entry;
-use d_engine_proto::common::EntryPayload;
-use d_engine_proto::common::entry_payload::Payload;
+use d_engine_core::{ApplyEntry, Command, StateMachine};
 use d_engine_server::storage::FileStateMachine;
-use prost::Message;
 use std::sync::Arc;
 use std::time::Duration;
 use tempfile::TempDir;
@@ -103,28 +96,19 @@ fn register_watchers(
 fn create_entries_without_ttl(
     count: usize,
     start_index: u64,
-) -> Vec<Entry> {
+) -> Vec<ApplyEntry> {
     (0..count)
         .map(|i| {
             let key = format!("key_{}", start_index + i as u64);
             let value = format!("value_{}", start_index + i as u64);
-
-            let insert = Insert {
-                key: Bytes::from(key),
-                value: Bytes::from(value),
-                ttl_secs: 0,
-            };
-            let write_cmd = WriteCommand {
-                operation: Some(Operation::Insert(insert)),
-            };
-            let payload = Payload::Command(write_cmd.encode_to_vec().into());
-
-            Entry {
+            ApplyEntry {
                 index: start_index + i as u64,
                 term: 1,
-                payload: Some(EntryPayload {
-                    payload: Some(payload),
-                }),
+                command: Command::Insert {
+                    key: Bytes::from(key),
+                    value: Bytes::from(value),
+                    ttl_secs: None,
+                },
             }
         })
         .collect()
@@ -135,28 +119,19 @@ fn create_entries_with_ttl(
     count: usize,
     start_index: u64,
     ttl_secs: u64,
-) -> Vec<Entry> {
+) -> Vec<ApplyEntry> {
     (0..count)
         .map(|i| {
             let key = format!("key_ttl_{}", start_index + i as u64);
             let value = format!("value_ttl_{}", start_index + i as u64);
-
-            let insert = Insert {
-                key: Bytes::from(key),
-                value: Bytes::from(value),
-                ttl_secs,
-            };
-            let write_cmd = WriteCommand {
-                operation: Some(Operation::Insert(insert)),
-            };
-            let payload = Payload::Command(write_cmd.encode_to_vec().into());
-
-            Entry {
+            ApplyEntry {
                 index: start_index + i as u64,
                 term: 1,
-                payload: Some(EntryPayload {
-                    payload: Some(payload),
-                }),
+                command: Command::Insert {
+                    key: Bytes::from(key),
+                    value: Bytes::from(value),
+                    ttl_secs: if ttl_secs > 0 { Some(ttl_secs) } else { None },
+                },
             }
         })
         .collect()
@@ -172,9 +147,7 @@ fn bench_apply_without_ttl(c: &mut Criterion) {
     c.bench_function("apply_without_ttl", |b| {
         b.to_async(&runtime).iter(|| async {
             let entries = create_entries_without_ttl(1, 1);
-
-            // Measure pure apply performance
-            sm.apply_chunk(entries).await.unwrap();
+            sm.apply_chunk(&entries).await.unwrap();
             black_box(());
         });
     });
@@ -190,9 +163,7 @@ fn bench_apply_with_ttl(c: &mut Criterion) {
     c.bench_function("apply_with_ttl", |b| {
         b.to_async(&runtime).iter(|| async {
             let entries = create_entries_with_ttl(1, 1, 3600); // 1 hour TTL
-
-            // Measure apply with TTL registration
-            sm.apply_chunk(entries).await.unwrap();
+            sm.apply_chunk(&entries).await.unwrap();
             black_box(());
         });
     });
@@ -207,7 +178,7 @@ fn bench_get_without_ttl(c: &mut Criterion) {
     let (sm, _temp_dir) = runtime.block_on(async {
         let (sm, temp_dir) = create_test_state_machine().await;
         let entries = create_entries_without_ttl(100, 1);
-        sm.apply_chunk(entries).await.unwrap();
+        sm.apply_chunk(&entries).await.unwrap();
         (sm, temp_dir)
     });
 
@@ -229,7 +200,7 @@ fn bench_get_with_ttl_check(c: &mut Criterion) {
     let (sm, _temp_dir) = runtime.block_on(async {
         let (sm, temp_dir) = create_test_state_machine().await;
         let entries = create_entries_with_ttl(100, 1, 3600); // Long TTL
-        sm.apply_chunk(entries).await.unwrap();
+        sm.apply_chunk(&entries).await.unwrap();
         (sm, temp_dir)
     });
 
@@ -251,7 +222,7 @@ fn bench_get_expired_ttl(c: &mut Criterion) {
     let (sm, _temp_dir) = runtime.block_on(async {
         let (sm, temp_dir) = create_test_state_machine().await;
         let entries = create_entries_with_ttl(100, 1, 1); // 1 second TTL
-        sm.apply_chunk(entries).await.unwrap();
+        sm.apply_chunk(&entries).await.unwrap();
 
         // Wait for expiration
         tokio::time::sleep(Duration::from_secs(2)).await;
@@ -280,8 +251,7 @@ fn bench_batch_apply(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
             b.to_async(&runtime).iter(|| async {
                 let entries = create_entries_without_ttl(size, 1);
-
-                sm.apply_chunk(entries).await.unwrap();
+                sm.apply_chunk(&entries).await.unwrap();
                 black_box(());
             });
         });
@@ -301,8 +271,7 @@ fn bench_batch_apply_with_ttl(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
             b.to_async(&runtime).iter(|| async {
                 let entries = create_entries_with_ttl(size, 1, 3600);
-
-                sm.apply_chunk(entries).await.unwrap();
+                sm.apply_chunk(&entries).await.unwrap();
                 black_box(());
             });
         });
@@ -322,9 +291,7 @@ fn bench_apply_without_watch(c: &mut Criterion) {
     c.bench_function("apply_without_watch", |b| {
         b.to_async(&runtime).iter(|| async {
             let entries = create_entries_without_ttl(100, 1);
-
-            // Measure pure apply performance without watch
-            sm.apply_chunk(entries).await.unwrap();
+            sm.apply_chunk(&entries).await.unwrap();
             black_box(());
         });
     });
@@ -346,52 +313,43 @@ fn bench_apply_with_1_watcher(c: &mut Criterion) {
 
             let entries = create_entries_without_ttl(100, 1);
 
-            // Simulate notify_watchers call for each entry
             for entry in &entries {
-                if let Some(payload) = &entry.payload
-                    && let Some(Payload::Command(cmd_bytes)) = &payload.payload
-                    && let Ok(write_cmd) = WriteCommand::decode(cmd_bytes.as_ref())
-                    && let Some(op) = write_cmd.operation
-                {
-                    match op {
-                        Operation::Insert(insert) => {
-                            let event = d_engine_proto::client::WatchResponse {
-                                key: insert.key.clone(),
-                                value: insert.value.clone(),
-                                event_type: d_engine_proto::client::WatchEventType::Put as i32,
-                                prev_value: bytes::Bytes::new(),
-                                error: 0,
-                                revision: 0,
-                            };
-                            let _ = broadcast_tx.send(event);
-                        }
-                        Operation::Delete(delete) => {
-                            let event = d_engine_proto::client::WatchResponse {
-                                key: delete.key.clone(),
-                                value: bytes::Bytes::new(),
-                                event_type: d_engine_proto::client::WatchEventType::Delete as i32,
-                                prev_value: bytes::Bytes::new(),
-                                error: 0,
-                                revision: 0,
-                            };
-                            let _ = broadcast_tx.send(event);
-                        }
-                        Operation::CompareAndSwap(cas) => {
-                            let event = d_engine_proto::client::WatchResponse {
-                                key: cas.key.clone(),
-                                value: cas.new_value.clone(),
-                                event_type: d_engine_proto::client::WatchEventType::Put as i32,
-                                prev_value: bytes::Bytes::new(),
-                                error: 0,
-                                revision: 0,
-                            };
-                            let _ = broadcast_tx.send(event);
-                        }
+                match &entry.command {
+                    Command::Insert { key, value, .. } => {
+                        let _ = broadcast_tx.send(d_engine_proto::client::WatchResponse {
+                            key: key.clone(),
+                            value: value.clone(),
+                            event_type: d_engine_proto::client::WatchEventType::Put as i32,
+                            prev_value: bytes::Bytes::new(),
+                            error: 0,
+                            revision: 0,
+                        });
                     }
+                    Command::Delete { key } => {
+                        let _ = broadcast_tx.send(d_engine_proto::client::WatchResponse {
+                            key: key.clone(),
+                            value: bytes::Bytes::new(),
+                            event_type: d_engine_proto::client::WatchEventType::Delete as i32,
+                            prev_value: bytes::Bytes::new(),
+                            error: 0,
+                            revision: 0,
+                        });
+                    }
+                    Command::CompareAndSwap { key, value, .. } => {
+                        let _ = broadcast_tx.send(d_engine_proto::client::WatchResponse {
+                            key: key.clone(),
+                            value: value.clone(),
+                            event_type: d_engine_proto::client::WatchEventType::Put as i32,
+                            prev_value: bytes::Bytes::new(),
+                            error: 0,
+                            revision: 0,
+                        });
+                    }
+                    Command::Noop => {}
                 }
             }
 
-            sm.apply_chunk(entries).await.unwrap();
+            sm.apply_chunk(&entries).await.unwrap();
             black_box(());
         });
     });
@@ -413,52 +371,43 @@ fn bench_apply_with_10_watchers(c: &mut Criterion) {
 
             let entries = create_entries_without_ttl(100, 1);
 
-            // Simulate notify_watchers call for each entry
             for entry in &entries {
-                if let Some(payload) = &entry.payload
-                    && let Some(Payload::Command(cmd_bytes)) = &payload.payload
-                    && let Ok(write_cmd) = WriteCommand::decode(cmd_bytes.as_ref())
-                    && let Some(op) = write_cmd.operation
-                {
-                    match op {
-                        Operation::Insert(insert) => {
-                            let event = d_engine_proto::client::WatchResponse {
-                                key: insert.key.clone(),
-                                value: insert.value.clone(),
-                                event_type: d_engine_proto::client::WatchEventType::Put as i32,
-                                prev_value: bytes::Bytes::new(),
-                                error: 0,
-                                revision: 0,
-                            };
-                            let _ = broadcast_tx.send(event);
-                        }
-                        Operation::Delete(delete) => {
-                            let event = d_engine_proto::client::WatchResponse {
-                                key: delete.key.clone(),
-                                value: bytes::Bytes::new(),
-                                event_type: d_engine_proto::client::WatchEventType::Delete as i32,
-                                prev_value: bytes::Bytes::new(),
-                                error: 0,
-                                revision: 0,
-                            };
-                            let _ = broadcast_tx.send(event);
-                        }
-                        Operation::CompareAndSwap(cas) => {
-                            let event = d_engine_proto::client::WatchResponse {
-                                key: cas.key.clone(),
-                                value: cas.new_value.clone(),
-                                event_type: d_engine_proto::client::WatchEventType::Put as i32,
-                                prev_value: bytes::Bytes::new(),
-                                error: 0,
-                                revision: 0,
-                            };
-                            let _ = broadcast_tx.send(event);
-                        }
+                match &entry.command {
+                    Command::Insert { key, value, .. } => {
+                        let _ = broadcast_tx.send(d_engine_proto::client::WatchResponse {
+                            key: key.clone(),
+                            value: value.clone(),
+                            event_type: d_engine_proto::client::WatchEventType::Put as i32,
+                            prev_value: bytes::Bytes::new(),
+                            error: 0,
+                            revision: 0,
+                        });
                     }
+                    Command::Delete { key } => {
+                        let _ = broadcast_tx.send(d_engine_proto::client::WatchResponse {
+                            key: key.clone(),
+                            value: bytes::Bytes::new(),
+                            event_type: d_engine_proto::client::WatchEventType::Delete as i32,
+                            prev_value: bytes::Bytes::new(),
+                            error: 0,
+                            revision: 0,
+                        });
+                    }
+                    Command::CompareAndSwap { key, value, .. } => {
+                        let _ = broadcast_tx.send(d_engine_proto::client::WatchResponse {
+                            key: key.clone(),
+                            value: value.clone(),
+                            event_type: d_engine_proto::client::WatchEventType::Put as i32,
+                            prev_value: bytes::Bytes::new(),
+                            error: 0,
+                            revision: 0,
+                        });
+                    }
+                    Command::Noop => {}
                 }
             }
 
-            sm.apply_chunk(entries).await.unwrap();
+            sm.apply_chunk(&entries).await.unwrap();
             black_box(());
         });
     });
@@ -480,52 +429,43 @@ fn bench_apply_with_100_watchers(c: &mut Criterion) {
 
             let entries = create_entries_without_ttl(100, 1);
 
-            // Simulate notify_watchers call for each entry
             for entry in &entries {
-                if let Some(payload) = &entry.payload
-                    && let Some(Payload::Command(cmd_bytes)) = &payload.payload
-                    && let Ok(write_cmd) = WriteCommand::decode(cmd_bytes.as_ref())
-                    && let Some(op) = write_cmd.operation
-                {
-                    match op {
-                        Operation::Insert(insert) => {
-                            let event = d_engine_proto::client::WatchResponse {
-                                key: insert.key.clone(),
-                                value: insert.value.clone(),
-                                event_type: d_engine_proto::client::WatchEventType::Put as i32,
-                                prev_value: bytes::Bytes::new(),
-                                error: 0,
-                                revision: 0,
-                            };
-                            let _ = broadcast_tx.send(event);
-                        }
-                        Operation::Delete(delete) => {
-                            let event = d_engine_proto::client::WatchResponse {
-                                key: delete.key.clone(),
-                                value: bytes::Bytes::new(),
-                                event_type: d_engine_proto::client::WatchEventType::Delete as i32,
-                                prev_value: bytes::Bytes::new(),
-                                error: 0,
-                                revision: 0,
-                            };
-                            let _ = broadcast_tx.send(event);
-                        }
-                        Operation::CompareAndSwap(cas) => {
-                            let event = d_engine_proto::client::WatchResponse {
-                                key: cas.key.clone(),
-                                value: cas.new_value.clone(),
-                                event_type: d_engine_proto::client::WatchEventType::Put as i32,
-                                prev_value: bytes::Bytes::new(),
-                                error: 0,
-                                revision: 0,
-                            };
-                            let _ = broadcast_tx.send(event);
-                        }
+                match &entry.command {
+                    Command::Insert { key, value, .. } => {
+                        let _ = broadcast_tx.send(d_engine_proto::client::WatchResponse {
+                            key: key.clone(),
+                            value: value.clone(),
+                            event_type: d_engine_proto::client::WatchEventType::Put as i32,
+                            prev_value: bytes::Bytes::new(),
+                            error: 0,
+                            revision: 0,
+                        });
                     }
+                    Command::Delete { key } => {
+                        let _ = broadcast_tx.send(d_engine_proto::client::WatchResponse {
+                            key: key.clone(),
+                            value: bytes::Bytes::new(),
+                            event_type: d_engine_proto::client::WatchEventType::Delete as i32,
+                            prev_value: bytes::Bytes::new(),
+                            error: 0,
+                            revision: 0,
+                        });
+                    }
+                    Command::CompareAndSwap { key, value, .. } => {
+                        let _ = broadcast_tx.send(d_engine_proto::client::WatchResponse {
+                            key: key.clone(),
+                            value: value.clone(),
+                            event_type: d_engine_proto::client::WatchEventType::Put as i32,
+                            prev_value: bytes::Bytes::new(),
+                            error: 0,
+                            revision: 0,
+                        });
+                    }
+                    Command::Noop => {}
                 }
             }
 
-            sm.apply_chunk(entries).await.unwrap();
+            sm.apply_chunk(&entries).await.unwrap();
             black_box(());
         });
     });

--- a/d-engine-server/benches/state_machine.rs
+++ b/d-engine-server/benches/state_machine.rs
@@ -22,6 +22,7 @@ use d_engine_core::watch::WatcherHandle;
 use d_engine_core::{ApplyEntry, Command, StateMachine};
 use d_engine_server::storage::FileStateMachine;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use tempfile::TempDir;
 use tokio::sync::broadcast;
@@ -143,10 +144,12 @@ fn bench_apply_without_ttl(c: &mut Criterion) {
     let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
 
     let (sm, _temp_dir) = runtime.block_on(async { create_test_state_machine().await });
+    let idx = AtomicU64::new(1);
 
     c.bench_function("apply_without_ttl", |b| {
         b.to_async(&runtime).iter(|| async {
-            let entries = create_entries_without_ttl(1, 1);
+            let start = idx.fetch_add(1, Ordering::Relaxed);
+            let entries = create_entries_without_ttl(1, start);
             sm.apply_chunk(&entries).await.unwrap();
             black_box(());
         });
@@ -159,10 +162,12 @@ fn bench_apply_with_ttl(c: &mut Criterion) {
     let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
 
     let (sm, _temp_dir) = runtime.block_on(async { create_test_state_machine().await });
+    let idx = AtomicU64::new(1);
 
     c.bench_function("apply_with_ttl", |b| {
         b.to_async(&runtime).iter(|| async {
-            let entries = create_entries_with_ttl(1, 1, 3600); // 1 hour TTL
+            let start = idx.fetch_add(1, Ordering::Relaxed);
+            let entries = create_entries_with_ttl(1, start, 3600); // 1 hour TTL
             sm.apply_chunk(&entries).await.unwrap();
             black_box(());
         });
@@ -246,11 +251,13 @@ fn bench_batch_apply(c: &mut Criterion) {
     let mut group = c.benchmark_group("batch_apply");
 
     let (sm, _temp_dir) = runtime.block_on(async { create_test_state_machine().await });
+    let idx = AtomicU64::new(1);
 
     for size in [10, 100, 1000].iter() {
         group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
             b.to_async(&runtime).iter(|| async {
-                let entries = create_entries_without_ttl(size, 1);
+                let start = idx.fetch_add(size as u64, Ordering::Relaxed);
+                let entries = create_entries_without_ttl(size, start);
                 sm.apply_chunk(&entries).await.unwrap();
                 black_box(());
             });
@@ -266,11 +273,13 @@ fn bench_batch_apply_with_ttl(c: &mut Criterion) {
     let mut group = c.benchmark_group("batch_apply_with_ttl");
 
     let (sm, _temp_dir) = runtime.block_on(async { create_test_state_machine().await });
+    let idx = AtomicU64::new(1);
 
     for size in [10, 100, 1000].iter() {
         group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
             b.to_async(&runtime).iter(|| async {
-                let entries = create_entries_with_ttl(size, 1, 3600);
+                let start = idx.fetch_add(size as u64, Ordering::Relaxed);
+                let entries = create_entries_with_ttl(size, start, 3600);
                 sm.apply_chunk(&entries).await.unwrap();
                 black_box(());
             });
@@ -287,10 +296,12 @@ fn bench_apply_without_watch(c: &mut Criterion) {
 
     // Initialize state machine once outside the iteration loop
     let (sm, _temp_dir) = runtime.block_on(async { create_test_state_machine().await });
+    let idx = AtomicU64::new(1);
 
     c.bench_function("apply_without_watch", |b| {
         b.to_async(&runtime).iter(|| async {
-            let entries = create_entries_without_ttl(100, 1);
+            let start = idx.fetch_add(100, Ordering::Relaxed);
+            let entries = create_entries_without_ttl(100, start);
             sm.apply_chunk(&entries).await.unwrap();
             black_box(());
         });
@@ -303,6 +314,7 @@ fn bench_apply_with_1_watcher(c: &mut Criterion) {
     let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
 
     let (sm, _temp_dir) = runtime.block_on(async { create_test_state_machine().await });
+    let idx = AtomicU64::new(1);
 
     c.bench_function("apply_with_1_watcher", |b| {
         b.to_async(&runtime).iter(|| async {
@@ -311,7 +323,8 @@ fn bench_apply_with_1_watcher(c: &mut Criterion) {
             // Register 1 watcher (keep handle alive to prevent unregistration)
             let _watchers = register_watchers(&registry, 1, "key_");
 
-            let entries = create_entries_without_ttl(100, 1);
+            let start = idx.fetch_add(100, Ordering::Relaxed);
+            let entries = create_entries_without_ttl(100, start);
 
             for entry in &entries {
                 match &entry.command {
@@ -361,6 +374,7 @@ fn bench_apply_with_10_watchers(c: &mut Criterion) {
     let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
 
     let (sm, _temp_dir) = runtime.block_on(async { create_test_state_machine().await });
+    let idx = AtomicU64::new(1);
 
     c.bench_function("apply_with_10_watchers", |b| {
         b.to_async(&runtime).iter(|| async {
@@ -369,7 +383,8 @@ fn bench_apply_with_10_watchers(c: &mut Criterion) {
             // Register 10 watchers (keep handles alive to prevent unregistration)
             let _watchers = register_watchers(&registry, 10, "key_");
 
-            let entries = create_entries_without_ttl(100, 1);
+            let start = idx.fetch_add(100, Ordering::Relaxed);
+            let entries = create_entries_without_ttl(100, start);
 
             for entry in &entries {
                 match &entry.command {
@@ -419,6 +434,7 @@ fn bench_apply_with_100_watchers(c: &mut Criterion) {
     let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
 
     let (sm, _temp_dir) = runtime.block_on(async { create_test_state_machine().await });
+    let idx = AtomicU64::new(1);
 
     c.bench_function("apply_with_100_watchers", |b| {
         b.to_async(&runtime).iter(|| async {
@@ -427,7 +443,8 @@ fn bench_apply_with_100_watchers(c: &mut Criterion) {
             // Register 100 watchers (keep handles alive to prevent unregistration)
             let _watchers = register_watchers(&registry, 100, "key_");
 
-            let entries = create_entries_without_ttl(100, 1);
+            let start = idx.fetch_add(100, Ordering::Relaxed);
+            let entries = create_entries_without_ttl(100, start);
 
             for entry in &entries {
                 match &entry.command {

--- a/d-engine-server/benches/ttl.rs
+++ b/d-engine-server/benches/ttl.rs
@@ -8,6 +8,7 @@
 //! - TTL registration: < 100ns per entry
 //! - Expired check: < 50ns per key
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use bytes::Bytes;
@@ -151,10 +152,12 @@ fn bench_batch_ttl_registration(c: &mut Criterion) {
 
     let (sm, _temp_dir) = runtime.block_on(async { create_test_state_machine().await });
 
+    let idx = AtomicU64::new(1);
     for size in [10, 100, 1000].iter() {
         group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
             b.to_async(&runtime).iter(|| async {
-                let entries = create_entries_with_ttl(size, 1, 3600);
+                let start = idx.fetch_add(size as u64, Ordering::Relaxed);
+                let entries = create_entries_with_ttl(size, start, 3600);
                 sm.apply_chunk(&entries).await.unwrap();
                 black_box(());
             });
@@ -190,10 +193,11 @@ fn bench_mixed_ttl_workload(c: &mut Criterion) {
         (sm, temp_dir)
     });
 
+    let noop_idx = AtomicU64::new(101); // setup applied 1..=100
     group.bench_function("cleanup_mixed", |b| {
         b.to_async(&runtime).iter(|| async {
-            // Only measure the cleanup operation
-            let noop = create_noop_entry(10000);
+            let i = noop_idx.fetch_add(1, Ordering::Relaxed);
+            let noop = create_noop_entry(i);
             sm.apply_chunk(&[noop]).await.unwrap();
             black_box(());
         });
@@ -215,15 +219,15 @@ fn bench_piggyback_high_frequency(c: &mut Criterion) {
         (temp_dir, sm)
     });
 
+    let idx = AtomicU64::new(1);
     group.bench_function("cleanup_with_expired_entries", |b| {
         b.to_async(&runtime).iter(|| async {
-            // Setup: Populate 100 expired entries (not measured)
-            let entries = create_entries_with_ttl(100, 1, 1);
+            let start = idx.fetch_add(101, Ordering::Relaxed);
+            let entries = create_entries_with_ttl(100, start, 1);
             sm.apply_chunk(&entries).await.unwrap();
             tokio::time::sleep(Duration::from_secs(2)).await;
 
-            // Measure: Trigger cleanup via noop entry
-            let noop = create_noop_entry(10000);
+            let noop = create_noop_entry(start + 100);
             sm.apply_chunk(&[noop]).await.unwrap();
             black_box(());
         });
@@ -241,6 +245,7 @@ fn bench_varying_ttl_durations(c: &mut Criterion) {
     let (sm, _temp_dir) = runtime.block_on(async { create_test_state_machine().await });
 
     // Test with different TTL durations
+    let idx = AtomicU64::new(1);
     for ttl_secs in [60, 3600, 86400].iter() {
         // 1 min, 1 hour, 1 day
         group.bench_with_input(
@@ -248,7 +253,8 @@ fn bench_varying_ttl_durations(c: &mut Criterion) {
             ttl_secs,
             |b, &ttl_secs| {
                 b.to_async(&runtime).iter(|| async {
-                    let entries = create_entries_with_ttl(100, 1, ttl_secs);
+                    let start = idx.fetch_add(100, Ordering::Relaxed);
+                    let entries = create_entries_with_ttl(100, start, ttl_secs);
                     sm.apply_chunk(&entries).await.unwrap();
                     black_box(());
                 });
@@ -281,15 +287,15 @@ fn bench_worst_case_all_expired(c: &mut Criterion) {
         (sm, temp_dir)
     });
 
+    let idx = AtomicU64::new(1);
     group.bench_function("cleanup_all_expired", |b| {
         b.to_async(&runtime).iter(|| async {
-            // Repopulate expired entries before each measurement
-            let entries = create_entries_with_ttl(1000, 1, 1);
+            let start = idx.fetch_add(1001, Ordering::Relaxed);
+            let entries = create_entries_with_ttl(1000, start, 1);
             sm.apply_chunk(&entries).await.unwrap();
             tokio::time::sleep(Duration::from_secs(2)).await;
 
-            // Measure: Trigger cleanup via noop entry
-            let noop = create_noop_entry(10000);
+            let noop = create_noop_entry(start + 1000);
             sm.apply_chunk(&[noop]).await.unwrap();
             black_box(());
         });
@@ -317,10 +323,11 @@ fn bench_best_case_no_expired(c: &mut Criterion) {
         (sm, temp_dir)
     });
 
+    let noop_idx = AtomicU64::new(1001); // setup applied 1..=1000
     group.bench_function("cleanup_no_expired", |b| {
         b.to_async(&runtime).iter(|| async {
-            // Only measure the cleanup operation
-            let noop = create_noop_entry(10000);
+            let i = noop_idx.fetch_add(1, Ordering::Relaxed);
+            let noop = create_noop_entry(i);
             sm.apply_chunk(&[noop]).await.unwrap();
             black_box(());
         });

--- a/d-engine-server/benches/ttl.rs
+++ b/d-engine-server/benches/ttl.rs
@@ -287,7 +287,7 @@ fn bench_worst_case_all_expired(c: &mut Criterion) {
         (sm, temp_dir)
     });
 
-    let idx = AtomicU64::new(1);
+    let idx = AtomicU64::new(1001); // setup applied 1..=1000
     group.bench_function("cleanup_all_expired", |b| {
         b.to_async(&runtime).iter(|| async {
             let start = idx.fetch_add(1001, Ordering::Relaxed);

--- a/d-engine-server/benches/ttl.rs
+++ b/d-engine-server/benches/ttl.rs
@@ -16,17 +16,8 @@ use criterion::Criterion;
 use criterion::black_box;
 use criterion::criterion_group;
 use criterion::criterion_main;
-use d_engine_core::Lease;
-use d_engine_core::StateMachine;
-use d_engine_proto::client::WriteCommand;
-use d_engine_proto::client::write_command::Insert;
-use d_engine_proto::client::write_command::Operation;
-use d_engine_proto::common::Entry;
-use d_engine_proto::common::EntryPayload;
-use d_engine_proto::common::Noop;
-use d_engine_proto::common::entry_payload::Payload;
+use d_engine_core::{ApplyEntry, Command, Lease, StateMachine};
 use d_engine_server::storage::FileStateMachine;
-use prost::Message;
 use tempfile::TempDir;
 
 /// Helper to create a temporary state machine for benchmarking
@@ -58,41 +49,30 @@ fn create_entries_with_ttl(
     count: usize,
     start_index: u64,
     ttl_secs: u64,
-) -> Vec<Entry> {
+) -> Vec<ApplyEntry> {
     (0..count)
         .map(|i| {
             let key = format!("key_ttl_{}", start_index + i as u64);
             let value = format!("value_ttl_{}", start_index + i as u64);
-
-            let insert = Insert {
-                key: Bytes::from(key),
-                value: Bytes::from(value),
-                ttl_secs,
-            };
-            let write_cmd = WriteCommand {
-                operation: Some(Operation::Insert(insert)),
-            };
-            let payload = Payload::Command(write_cmd.encode_to_vec().into());
-
-            Entry {
+            ApplyEntry {
                 index: start_index + i as u64,
                 term: 1,
-                payload: Some(EntryPayload {
-                    payload: Some(payload),
-                }),
+                command: Command::Insert {
+                    key: Bytes::from(key),
+                    value: Bytes::from(value),
+                    ttl_secs: if ttl_secs > 0 { Some(ttl_secs) } else { None },
+                },
             }
         })
         .collect()
 }
 
 /// Helper to create a no-op entry (for triggering piggyback cleanup)
-fn create_noop_entry(index: u64) -> Entry {
-    Entry {
+fn create_noop_entry(index: u64) -> ApplyEntry {
+    ApplyEntry {
         index,
         term: 1,
-        payload: Some(EntryPayload {
-            payload: Some(Payload::Noop(Noop {})),
-        }),
+        command: Command::Noop,
     }
 }
 
@@ -175,8 +155,7 @@ fn bench_batch_ttl_registration(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
             b.to_async(&runtime).iter(|| async {
                 let entries = create_entries_with_ttl(size, 1, 3600);
-
-                sm.apply_chunk(entries).await.unwrap();
+                sm.apply_chunk(&entries).await.unwrap();
                 black_box(());
             });
         });
@@ -199,11 +178,11 @@ fn bench_mixed_ttl_workload(c: &mut Criterion) {
 
         // Insert 50 entries with short TTL (will expire)
         let expired_entries = create_entries_with_ttl(50, 1, 1);
-        sm.apply_chunk(expired_entries).await.unwrap();
+        sm.apply_chunk(&expired_entries).await.unwrap();
 
         // Insert 50 entries with long TTL (will remain active)
         let active_entries = create_entries_with_ttl(50, 51, 3600);
-        sm.apply_chunk(active_entries).await.unwrap();
+        sm.apply_chunk(&active_entries).await.unwrap();
 
         // Wait for first batch to expire
         tokio::time::sleep(Duration::from_secs(2)).await;
@@ -215,7 +194,7 @@ fn bench_mixed_ttl_workload(c: &mut Criterion) {
         b.to_async(&runtime).iter(|| async {
             // Only measure the cleanup operation
             let noop = create_noop_entry(10000);
-            sm.apply_chunk(vec![noop]).await.unwrap();
+            sm.apply_chunk(&[noop]).await.unwrap();
             black_box(());
         });
     });
@@ -240,12 +219,12 @@ fn bench_piggyback_high_frequency(c: &mut Criterion) {
         b.to_async(&runtime).iter(|| async {
             // Setup: Populate 100 expired entries (not measured)
             let entries = create_entries_with_ttl(100, 1, 1);
-            sm.apply_chunk(entries).await.unwrap();
+            sm.apply_chunk(&entries).await.unwrap();
             tokio::time::sleep(Duration::from_secs(2)).await;
 
             // Measure: Trigger cleanup via noop entry
             let noop = create_noop_entry(10000);
-            sm.apply_chunk(vec![noop]).await.unwrap();
+            sm.apply_chunk(&[noop]).await.unwrap();
             black_box(());
         });
     });
@@ -270,8 +249,7 @@ fn bench_varying_ttl_durations(c: &mut Criterion) {
             |b, &ttl_secs| {
                 b.to_async(&runtime).iter(|| async {
                     let entries = create_entries_with_ttl(100, 1, ttl_secs);
-
-                    sm.apply_chunk(entries).await.unwrap();
+                    sm.apply_chunk(&entries).await.unwrap();
                     black_box(());
                 });
             },
@@ -295,7 +273,7 @@ fn bench_worst_case_all_expired(c: &mut Criterion) {
 
         // Insert 1000 entries with very short TTL
         let entries = create_entries_with_ttl(1000, 1, 1);
-        sm.apply_chunk(entries).await.unwrap();
+        sm.apply_chunk(&entries).await.unwrap();
 
         // Wait for all to expire
         tokio::time::sleep(Duration::from_secs(2)).await;
@@ -307,12 +285,12 @@ fn bench_worst_case_all_expired(c: &mut Criterion) {
         b.to_async(&runtime).iter(|| async {
             // Repopulate expired entries before each measurement
             let entries = create_entries_with_ttl(1000, 1, 1);
-            sm.apply_chunk(entries).await.unwrap();
+            sm.apply_chunk(&entries).await.unwrap();
             tokio::time::sleep(Duration::from_secs(2)).await;
 
             // Measure: Trigger cleanup via noop entry
             let noop = create_noop_entry(10000);
-            sm.apply_chunk(vec![noop]).await.unwrap();
+            sm.apply_chunk(&[noop]).await.unwrap();
             black_box(());
         });
     });
@@ -334,7 +312,7 @@ fn bench_best_case_no_expired(c: &mut Criterion) {
 
         // Insert 1000 entries with very long TTL
         let entries = create_entries_with_ttl(1000, 1, 86400); // 1 day
-        sm.apply_chunk(entries).await.unwrap();
+        sm.apply_chunk(&entries).await.unwrap();
 
         (sm, temp_dir)
     });
@@ -343,7 +321,7 @@ fn bench_best_case_no_expired(c: &mut Criterion) {
         b.to_async(&runtime).iter(|| async {
             // Only measure the cleanup operation
             let noop = create_noop_entry(10000);
-            sm.apply_chunk(vec![noop]).await.unwrap();
+            sm.apply_chunk(&[noop]).await.unwrap();
             black_box(());
         });
     });
@@ -362,5 +340,4 @@ criterion_group!(
     bench_worst_case_all_expired,
     bench_best_case_no_expired,
 );
-
 criterion_main!(benches);

--- a/d-engine-server/benches/watch_overhead.rs
+++ b/d-engine-server/benches/watch_overhead.rs
@@ -20,16 +20,9 @@ use criterion::Criterion;
 use criterion::black_box;
 use criterion::criterion_group;
 use criterion::criterion_main;
-use d_engine_core::StateMachine;
-use d_engine_proto::client::WriteCommand;
-use d_engine_proto::client::write_command::Insert;
-use d_engine_proto::client::write_command::Operation;
-use d_engine_proto::common::Entry;
-use d_engine_proto::common::EntryPayload;
-use d_engine_proto::common::entry_payload::Payload;
+use d_engine_core::{ApplyEntry, Command, StateMachine};
 use d_engine_server::RocksDBUnifiedEngine;
 use d_engine_server::api::EmbeddedEngine;
-use prost::Message;
 use tempfile::TempDir;
 use tokio::time::sleep;
 
@@ -59,29 +52,19 @@ fn get_op_timeout() -> Duration {
 fn create_test_entries(
     count: usize,
     start_index: u64,
-) -> Vec<Entry> {
+) -> Vec<ApplyEntry> {
     let mut entries = Vec::new();
     for i in 0..count {
         let key = format!("key_{i}");
         let value = format!("value_{i}");
-
-        let write_cmd = WriteCommand {
-            operation: Some(Operation::Insert(Insert {
-                key: Bytes::from(key.into_bytes()),
-                value: Bytes::from(value.into_bytes()),
-                ttl_secs: 0,
-            })),
-        };
-
-        let mut buf = Vec::new();
-        write_cmd.encode(&mut buf).unwrap();
-
-        entries.push(Entry {
+        entries.push(ApplyEntry {
             index: start_index + i as u64,
             term: 1,
-            payload: Some(EntryPayload {
-                payload: Some(Payload::Command(Bytes::from(buf))),
-            }),
+            command: Command::Insert {
+                key: Bytes::from(key.into_bytes()),
+                value: Bytes::from(value.into_bytes()),
+                ttl_secs: None,
+            },
         });
     }
     entries
@@ -354,7 +337,7 @@ fn bench_apply_chunk_baseline(c: &mut Criterion) {
 
             // Benchmark: apply 100 entries
             let start = std::time::Instant::now();
-            state_machine.apply_chunk(entries).await.expect("apply_chunk failed");
+            state_machine.apply_chunk(&entries).await.expect("apply_chunk failed");
             let elapsed = start.elapsed();
 
             black_box(elapsed);

--- a/d-engine-server/src/lib.rs
+++ b/d-engine-server/src/lib.rs
@@ -154,6 +154,7 @@ pub use node::NodeBuilder;
 pub use storage::{FileStateMachine, FileStorageEngine};
 // Re-export core types needed by applications
 pub use d_engine_core::ApplyResult;
+pub use d_engine_core::{ApplyEntry, Command};
 // Conditional RocksDB exports
 #[cfg(feature = "rocksdb")]
 pub use storage::{RocksDBStateMachine, RocksDBStorageEngine, RocksDBUnifiedEngine};

--- a/d-engine-server/src/storage/adaptors/file/file_state_machine.rs
+++ b/d-engine-server/src/storage/adaptors/file/file_state_machine.rs
@@ -975,6 +975,11 @@ impl FileStateMachine {
         entries: &[ApplyEntry],
         cas_outcomes: &[bool],
     ) -> Result<(), Error> {
+        assert_eq!(
+            entries.len(),
+            cas_outcomes.len(),
+            "cas_outcomes must have the same length as entries"
+        );
         if entries.is_empty() {
             return Ok(());
         }

--- a/d-engine-server/src/storage/adaptors/file/file_state_machine.rs
+++ b/d-engine-server/src/storage/adaptors/file/file_state_machine.rs
@@ -606,15 +606,16 @@ impl FileStateMachine {
                         debug!("Replayed DELETE: key={:?}", key);
                     }
                     WalOpCode::CompareAndSwap => {
-                        // CAS during replay: Just apply the new_value if present
-                        // The comparison was already done before crash, and succeeded
-                        // (otherwise this entry wouldn't be in WAL)
+                        // Legacy WAL format from before the CAS outcome fix.
+                        // Current code writes CAS results as Insert (success) or Noop (failure),
+                        // so this branch is only reached when replaying WAL files created before
+                        // the fix. Apply new_value unconditionally as best-effort.
                         if let Some(new_value) = value {
                             data.insert(key.clone(), (new_value, term));
                             applied_count += 1;
-                            debug!("Replayed CAS: key={:?}", key);
+                            debug!("Replayed legacy CAS: key={:?}", key);
                         } else {
-                            warn!("CAS operation without new_value in WAL");
+                            warn!("Legacy CAS WAL entry missing new_value");
                         }
                     }
                     WalOpCode::Noop | WalOpCode::Config => {
@@ -875,9 +876,14 @@ impl FileStateMachine {
         Ok(())
     }
 
-    /// Batch WAL writes with proper durability guarantees
+    /// Batch WAL writes with proper durability guarantees.
+    ///
+    /// `cas_outcomes[i]` is consulted only when `entries[i].command` is
+    /// `CompareAndSwap`. Successful CAS is recorded as `Insert`; failed CAS as
+    /// `Noop`, so replay never applies a CAS that failed at runtime.
     ///
     /// Format per entry:
+    ///
     /// - 8 bytes: entry index (big-endian u64)
     /// - 8 bytes: entry term (big-endian u64)
     /// - 1 byte: operation code (0=NOOP, 1=INSERT, 2=DELETE, 3=CONFIG)
@@ -888,6 +894,7 @@ impl FileStateMachine {
     pub(crate) async fn append_to_wal(
         &self,
         entries: &[ApplyEntry],
+        cas_outcomes: &[bool],
     ) -> Result<(), Error> {
         if entries.is_empty() {
             return Ok(());
@@ -898,30 +905,28 @@ impl FileStateMachine {
         let mut file =
             OpenOptions::new().write(true).create(true).append(true).open(&wal_path).await?;
 
-        // Pre-allocate buffer with estimated size
+        // Pre-allocate buffer: CAS success = Insert size, CAS failure = Noop size
         let estimated_size: usize = entries
             .iter()
-            .map(|entry| {
-                let key_len = match &entry.command {
-                    Command::Noop => 0,
-                    Command::Insert { key, .. }
-                    | Command::Delete { key }
-                    | Command::CompareAndSwap { key, .. } => key.len(),
-                };
-                let val_len = match &entry.command {
-                    Command::Insert { value, .. } | Command::CompareAndSwap { value, .. } => {
-                        value.len()
+            .enumerate()
+            .map(|(i, entry)| match &entry.command {
+                Command::Noop => 41,
+                Command::Insert { key, value, .. } => 41 + key.len() + value.len(),
+                Command::Delete { key } => 41 + key.len(),
+                Command::CompareAndSwap { key, value, .. } => {
+                    if cas_outcomes[i] {
+                        41 + key.len() + value.len()
+                    } else {
+                        41
                     }
-                    _ => 0,
-                };
-                8 + 8 + 1 + 8 + key_len + 8 + val_len + 8
+                }
             })
             .sum();
 
         // Single batched write instead of multiple small writes
         let mut batch_buffer = Vec::with_capacity(estimated_size);
 
-        for entry in entries {
+        for (i, entry) in entries.iter().enumerate() {
             batch_buffer.extend_from_slice(&entry.index.to_be_bytes());
             batch_buffer.extend_from_slice(&entry.term.to_be_bytes());
 
@@ -962,12 +967,21 @@ impl FileStateMachine {
                     batch_buffer.extend_from_slice(&0u64.to_be_bytes()); // expire_at = 0
                 }
                 Command::CompareAndSwap { key, value, .. } => {
-                    batch_buffer.push(WalOpCode::CompareAndSwap as u8);
-                    batch_buffer.extend_from_slice(&(key.len() as u64).to_be_bytes());
-                    batch_buffer.extend_from_slice(key);
-                    batch_buffer.extend_from_slice(&(value.len() as u64).to_be_bytes());
-                    batch_buffer.extend_from_slice(value);
-                    batch_buffer.extend_from_slice(&0u64.to_be_bytes()); // expire_at = 0
+                    if cas_outcomes[i] {
+                        // CAS succeeded: store as Insert so replay applies it unconditionally
+                        batch_buffer.push(WalOpCode::Insert as u8);
+                        batch_buffer.extend_from_slice(&(key.len() as u64).to_be_bytes());
+                        batch_buffer.extend_from_slice(key);
+                        batch_buffer.extend_from_slice(&(value.len() as u64).to_be_bytes());
+                        batch_buffer.extend_from_slice(value);
+                        batch_buffer.extend_from_slice(&0u64.to_be_bytes()); // no TTL
+                    } else {
+                        // CAS failed: store as Noop so replay skips it
+                        batch_buffer.push(WalOpCode::Noop as u8);
+                        batch_buffer.extend_from_slice(&0u64.to_be_bytes()); // key_len = 0
+                        batch_buffer.extend_from_slice(&0u64.to_be_bytes()); // val_len = 0
+                        batch_buffer.extend_from_slice(&0u64.to_be_bytes()); // expire_at = 0
+                    }
                 }
             }
         }
@@ -1075,14 +1089,37 @@ impl StateMachine for FileStateMachine {
             info!("COMMITTED_LOG_METRIC: {}", entry.index);
         }
 
-        // PHASE 2: Batch WAL writes (minimize I/O latency)
-        self.append_to_wal(chunk).await?;
+        // PRE-PHASE: Evaluate CAS conditions before WAL write.
+        // WAL must record outcomes, not intents — a failed CAS written as-intent
+        // would be applied unconditionally on replay, corrupting data.
+        let cas_outcomes: Vec<bool> = {
+            let data = self.data.read();
+            chunk
+                .iter()
+                .map(|entry| match &entry.command {
+                    Command::CompareAndSwap { key, expected, .. } => {
+                        let current = data.get(key.as_ref());
+                        match (current, expected) {
+                            (Some((c, _)), Some(e)) => c.as_ref() == e.as_ref(),
+                            (None, None) => true,
+                            _ => false,
+                        }
+                    }
+                    _ => false, // non-CAS: value unused in append_to_wal
+                })
+                .collect()
+        };
+
+        // PHASE 2: Batch WAL writes with outcomes known.
+        // Successful CAS → WalOpCode::Insert; failed CAS → WalOpCode::Noop.
+        self.append_to_wal(chunk, &cas_outcomes).await?;
 
         // PHASE 3: Fast in-memory updates with minimal lock time
+        // (CAS uses pre-computed outcomes — no re-evaluation under write lock)
         {
             let mut data = self.data.write();
 
-            for entry in chunk {
+            for (entry, &cas_success) in chunk.iter().zip(cas_outcomes.iter()) {
                 match &entry.command {
                     Command::Noop => {
                         results.push(ApplyResult::success(entry.index));
@@ -1117,15 +1154,9 @@ impl StateMachine for FileStateMachine {
                     }
                     Command::CompareAndSwap {
                         key,
-                        expected,
                         value: new_value,
+                        ..
                     } => {
-                        let current_value = data.get(key.as_ref());
-                        let cas_success = match (current_value, expected) {
-                            (Some((current, _)), Some(exp)) => current.as_ref() == exp.as_ref(),
-                            (None, None) => true,
-                            _ => false,
-                        };
                         debug!(
                             "CAS at index {}: key={:?}, success={}",
                             entry.index,

--- a/d-engine-server/src/storage/adaptors/file/file_state_machine.rs
+++ b/d-engine-server/src/storage/adaptors/file/file_state_machine.rs
@@ -93,23 +93,17 @@ use std::time::SystemTime;
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use d_engine_core::ApplyEntry;
 use d_engine_core::ApplyResult;
+use d_engine_core::Command;
 use d_engine_core::Error;
 use d_engine_core::Lease;
 use d_engine_core::ScanResult;
 use d_engine_core::StateMachine;
 use d_engine_core::StorageError;
-use d_engine_proto::client::WriteCommand;
-use d_engine_proto::client::write_command::CompareAndSwap;
-use d_engine_proto::client::write_command::Delete;
-use d_engine_proto::client::write_command::Insert;
-use d_engine_proto::client::write_command::Operation;
-use d_engine_proto::common::Entry;
 use d_engine_proto::common::LogId;
-use d_engine_proto::common::entry_payload::Payload;
 use d_engine_proto::server::storage::SnapshotMetadata;
 use parking_lot::RwLock;
-use prost::Message;
 use tokio::fs;
 use tokio::fs::File;
 use tokio::fs::OpenOptions;
@@ -137,6 +131,7 @@ enum WalOpCode {
 }
 
 impl WalOpCode {
+    #[allow(dead_code)]
     fn from_str(s: &str) -> Self {
         match s {
             "INSERT" => Self::Insert,
@@ -892,7 +887,7 @@ impl FileStateMachine {
     /// - M bytes: value data (only if length > 0)
     pub(crate) async fn append_to_wal(
         &self,
-        entries: Vec<(Entry, String, Bytes, Option<Bytes>, u64)>,
+        entries: &[ApplyEntry],
     ) -> Result<(), Error> {
         if entries.is_empty() {
             return Ok(());
@@ -906,50 +901,75 @@ impl FileStateMachine {
         // Pre-allocate buffer with estimated size
         let estimated_size: usize = entries
             .iter()
-            .map(|(_, _, key, value, _)| {
-                8 + 8 + 1 + 8 + key.len() + 8 + value.as_ref().map_or(0, |v| v.len()) + 8
+            .map(|entry| {
+                let key_len = match &entry.command {
+                    Command::Noop => 0,
+                    Command::Insert { key, .. }
+                    | Command::Delete { key }
+                    | Command::CompareAndSwap { key, .. } => key.len(),
+                };
+                let val_len = match &entry.command {
+                    Command::Insert { value, .. } | Command::CompareAndSwap { value, .. } => {
+                        value.len()
+                    }
+                    _ => 0,
+                };
+                8 + 8 + 1 + 8 + key_len + 8 + val_len + 8
             })
             .sum();
 
         // Single batched write instead of multiple small writes
         let mut batch_buffer = Vec::with_capacity(estimated_size);
 
-        for (entry, operation, key, value, ttl_secs) in entries {
-            // Write entry index and term (16 bytes total)
+        for entry in entries {
             batch_buffer.extend_from_slice(&entry.index.to_be_bytes());
             batch_buffer.extend_from_slice(&entry.term.to_be_bytes());
 
-            // Write operation code (1 byte)
-            let op_code = WalOpCode::from_str(&operation);
-            batch_buffer.push(op_code as u8);
-
-            // Write key length and data (8 + N bytes)
-            batch_buffer.extend_from_slice(&(key.len() as u64).to_be_bytes());
-            batch_buffer.extend_from_slice(&key);
-
-            // Write value length and data (8 + M bytes)
-            // Always write length field for consistent format
-            if let Some(value_data) = value {
-                batch_buffer.extend_from_slice(&(value_data.len() as u64).to_be_bytes());
-                batch_buffer.extend_from_slice(&value_data);
-            } else {
-                // Write 0 length for operations without value
-                batch_buffer.extend_from_slice(&0u64.to_be_bytes());
+            match &entry.command {
+                Command::Noop => {
+                    batch_buffer.push(WalOpCode::Noop as u8);
+                    batch_buffer.extend_from_slice(&0u64.to_be_bytes()); // key_len = 0
+                    batch_buffer.extend_from_slice(&0u64.to_be_bytes()); // val_len = 0
+                    batch_buffer.extend_from_slice(&0u64.to_be_bytes()); // expire_at = 0
+                }
+                Command::Insert {
+                    key,
+                    value,
+                    ttl_secs,
+                } => {
+                    batch_buffer.push(WalOpCode::Insert as u8);
+                    batch_buffer.extend_from_slice(&(key.len() as u64).to_be_bytes());
+                    batch_buffer.extend_from_slice(key);
+                    batch_buffer.extend_from_slice(&(value.len() as u64).to_be_bytes());
+                    batch_buffer.extend_from_slice(value);
+                    let expire_at_secs = if let Some(ttl) = ttl_secs {
+                        let expire_at =
+                            std::time::SystemTime::now() + std::time::Duration::from_secs(*ttl);
+                        expire_at
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map(|d| d.as_secs())
+                            .unwrap_or(0)
+                    } else {
+                        0
+                    };
+                    batch_buffer.extend_from_slice(&expire_at_secs.to_be_bytes());
+                }
+                Command::Delete { key } => {
+                    batch_buffer.push(WalOpCode::Delete as u8);
+                    batch_buffer.extend_from_slice(&(key.len() as u64).to_be_bytes());
+                    batch_buffer.extend_from_slice(key);
+                    batch_buffer.extend_from_slice(&0u64.to_be_bytes()); // val_len = 0
+                    batch_buffer.extend_from_slice(&0u64.to_be_bytes()); // expire_at = 0
+                }
+                Command::CompareAndSwap { key, value, .. } => {
+                    batch_buffer.push(WalOpCode::CompareAndSwap as u8);
+                    batch_buffer.extend_from_slice(&(key.len() as u64).to_be_bytes());
+                    batch_buffer.extend_from_slice(key);
+                    batch_buffer.extend_from_slice(&(value.len() as u64).to_be_bytes());
+                    batch_buffer.extend_from_slice(value);
+                    batch_buffer.extend_from_slice(&0u64.to_be_bytes()); // expire_at = 0
+                }
             }
-
-            // Write absolute expiration time (8 bytes) - 0 means no TTL
-            // Store UNIX timestamp (seconds since epoch) for crash-safe expiration
-            let expire_at_secs = if ttl_secs > 0 {
-                let expire_at =
-                    std::time::SystemTime::now() + std::time::Duration::from_secs(ttl_secs);
-                expire_at
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map(|d| d.as_secs())
-                    .unwrap_or(0)
-            } else {
-                0
-            };
-            batch_buffer.extend_from_slice(&expire_at_secs.to_be_bytes());
         }
 
         file.write_all(&batch_buffer).await?;
@@ -1032,21 +1052,15 @@ impl StateMachine for FileStateMachine {
     /// Thread-safe: called serially by single-task CommitHandler
     async fn apply_chunk(
         &self,
-        chunk: Vec<Entry>,
+        chunk: &[ApplyEntry],
     ) -> Result<Vec<ApplyResult>, Error> {
         let chunk_len = chunk.len();
-        let mut highest_index_entry: Option<LogId> = None;
-        let mut batch_operations = Vec::new();
         let mut results = Vec::with_capacity(chunk_len);
+        let mut highest_log_id: Option<LogId> = None;
 
-        // PHASE 1: Decode all operations and prepare WAL entries
+        // Validate ordering — Command is already decoded, no proto work here
         for entry in chunk {
-            let entry_index = entry.index;
-
-            assert!(entry.payload.is_some(), "Entry payload should not be None!");
-
-            // Ensure entries are processed in order
-            if let Some(prev) = &highest_index_entry {
+            if let Some(prev) = &highest_log_id {
                 assert!(
                     entry.index > prev.index,
                     "apply_chunk: received unordered entry at index {} (prev={})",
@@ -1054,174 +1068,79 @@ impl StateMachine for FileStateMachine {
                     prev.index
                 );
             }
-            highest_index_entry = Some(LogId {
+            highest_log_id = Some(LogId {
                 index: entry.index,
                 term: entry.term,
             });
-
-            // Decode operations without holding locks
-            match entry.payload.as_ref().unwrap().payload.as_ref() {
-                Some(Payload::Noop(_)) => {
-                    let entry_index = entry.index;
-                    debug!("Handling NOOP command at index {}", entry_index);
-                    batch_operations.push((entry, "NOOP", Bytes::new(), None, 0));
-                    results.push(ApplyResult::success(entry_index));
-                }
-                Some(Payload::Command(bytes)) => match WriteCommand::decode(&bytes[..]) {
-                    Ok(write_cmd) => {
-                        // Extract operation data for batch processing
-                        match write_cmd.operation {
-                            Some(Operation::Insert(Insert {
-                                key,
-                                value,
-                                ttl_secs,
-                            })) => {
-                                let entry_index = entry.index;
-                                batch_operations.push((
-                                    entry,
-                                    "INSERT",
-                                    key,
-                                    Some(value),
-                                    ttl_secs,
-                                ));
-                                results.push(ApplyResult::success(entry_index));
-                            }
-                            Some(Operation::Delete(Delete { key })) => {
-                                let entry_index = entry.index;
-                                batch_operations.push((entry, "DELETE", key, None, 0));
-                                results.push(ApplyResult::success(entry_index));
-                            }
-                            Some(Operation::CompareAndSwap(CompareAndSwap {
-                                key,
-                                expected_value: _,
-                                new_value,
-                            })) => {
-                                batch_operations.push((entry, "CAS", key, Some(new_value), 0));
-                                // Note: CAS result will be pushed in PHASE 3 after comparison
-                            }
-                            None => {
-                                warn!("WriteCommand without operation at index {}", entry.index);
-                                batch_operations.push((entry, "NOOP", Bytes::new(), None, 0));
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        error!(
-                            "Failed to decode WriteCommand at index {}: {:?}",
-                            entry.index, e
-                        );
-                        return Err(StorageError::SerializationError(e.to_string()).into());
-                    }
-                },
-                Some(Payload::Config(_config_change)) => {
-                    debug!("Ignoring config change at index {}", entry.index);
-                    batch_operations.push((entry, "CONFIG", Bytes::new(), None, 0));
-                }
-                None => panic!("Entry payload variant should not be None!"),
-            }
-
-            info!("COMMITTED_LOG_METRIC: {}", entry_index);
+            info!("COMMITTED_LOG_METRIC: {}", entry.index);
         }
 
         // PHASE 2: Batch WAL writes (minimize I/O latency)
-        let mut wal_entries = Vec::new();
-        for (entry, operation, key, value, ttl_secs) in &batch_operations {
-            // Prepare WAL data without immediate I/O - include TTL for crash recovery
-            wal_entries.push((
-                entry.clone(),
-                operation.to_string(),
-                key.clone(),
-                value.clone(),
-                *ttl_secs, // ttl_secs is now u64 (0 = no TTL) from protobuf
-            ));
-        }
+        self.append_to_wal(chunk).await?;
 
-        // Single batch WAL write (reduces I/O overhead)
-        self.append_to_wal(wal_entries).await?;
-
-        // PHASE 3: Fast in-memory updates with minimal lock time (ZERO-COPY)
+        // PHASE 3: Fast in-memory updates with minimal lock time
         {
             let mut data = self.data.write();
 
-            // Process all operations without any awaits inside the lock
-            for (entry, operation, key, value, ttl_secs) in batch_operations {
-                match operation {
-                    "NOOP" => {
-                        // NOOP result already pushed in PHASE 1
+            for entry in chunk {
+                match &entry.command {
+                    Command::Noop => {
+                        results.push(ApplyResult::success(entry.index));
                     }
-                    "INSERT" => {
-                        if let Some(value) = value {
-                            // ZERO-COPY: Use existing Bytes without cloning if possible
-                            data.insert(key.clone(), (value, entry.term));
-
-                            // Register lease if TTL specified
-                            if ttl_secs > 0 {
-                                // Validate lease is enabled before accepting TTL requests
-                                if !self.lease_enabled {
-                                    return Err(StorageError::FeatureNotEnabled(
-                                        "TTL feature is not enabled on this server. \
-                                         Enable it in config: [raft.state_machine.lease] enabled = true".into()
-                                    ).into());
-                                }
-
-                                // Safety: lease_enabled invariant ensures lease.is_some()
-                                let lease = unsafe { self.lease.as_ref().unwrap_unchecked() };
-                                lease.register(key, ttl_secs);
+                    Command::Insert {
+                        key,
+                        value,
+                        ttl_secs,
+                    } => {
+                        data.insert(key.clone(), (value.clone(), entry.term));
+                        if let Some(ttl) = ttl_secs {
+                            if !self.lease_enabled {
+                                return Err(StorageError::FeatureNotEnabled(
+                                    "TTL feature is not enabled on this server. \
+                                     Enable it in config: [raft.state_machine.lease] enabled = true"
+                                        .into(),
+                                )
+                                .into());
                             }
+                            // Safety: lease_enabled invariant ensures lease.is_some()
+                            let lease = unsafe { self.lease.as_ref().unwrap_unchecked() };
+                            lease.register(key.clone(), *ttl);
                         }
-                        // Result already pushed in PHASE 1
+                        results.push(ApplyResult::success(entry.index));
                     }
-                    "DELETE" => {
-                        data.remove(&key);
+                    Command::Delete { key } => {
+                        data.remove(key.as_ref());
                         if let Some(ref lease) = self.lease {
-                            lease.unregister(&key);
+                            lease.unregister(key);
                         }
-                        // Result already pushed in PHASE 1
+                        results.push(ApplyResult::success(entry.index));
                     }
-                    "CAS" => {
-                        // Extract expected_value from original entry
-                        if let Some(Payload::Command(bytes)) =
-                            entry.payload.as_ref().unwrap().payload.as_ref()
-                            && let Ok(write_cmd) = WriteCommand::decode(&bytes[..])
-                            && let Some(Operation::CompareAndSwap(CompareAndSwap {
-                                expected_value,
-                                ..
-                            })) = write_cmd.operation
-                        {
-                            // Read-compare-write is safe due to sequential apply
-                            let current_value = data.get(&key);
-
-                            let cas_success = match (current_value, &expected_value) {
-                                (Some((current, _)), Some(expected)) => {
-                                    current.as_ref() == expected.as_ref()
-                                }
-                                (None, None) => true,
-                                _ => false,
-                            };
-
-                            // Store CAS result for client response
-                            results.push(if cas_success {
-                                ApplyResult::success(entry.index)
-                            } else {
-                                ApplyResult::failure(entry.index)
-                            });
-
-                            debug!(
-                                "CAS at index {}: key={:?}, success={}",
-                                entry.index,
-                                String::from_utf8_lossy(&key),
-                                cas_success
-                            );
-
-                            if cas_success && let Some(new_value) = value {
-                                data.insert(key, (new_value, entry.term));
-                            }
+                    Command::CompareAndSwap {
+                        key,
+                        expected,
+                        value: new_value,
+                    } => {
+                        let current_value = data.get(key.as_ref());
+                        let cas_success = match (current_value, expected) {
+                            (Some((current, _)), Some(exp)) => current.as_ref() == exp.as_ref(),
+                            (None, None) => true,
+                            _ => false,
+                        };
+                        debug!(
+                            "CAS at index {}: key={:?}, success={}",
+                            entry.index,
+                            String::from_utf8_lossy(key),
+                            cas_success
+                        );
+                        results.push(if cas_success {
+                            ApplyResult::success(entry.index)
+                        } else {
+                            ApplyResult::failure(entry.index)
+                        });
+                        if cas_success {
+                            data.insert(key.clone(), (new_value.clone(), entry.term));
                         }
                     }
-                    "CONFIG" => {
-                        // No data modification needed
-                    }
-                    _ => warn!("Unknown operation: {}", operation),
                 }
             }
         } // Lock released immediately - no awaits inside!
@@ -1229,7 +1148,7 @@ impl StateMachine for FileStateMachine {
         // PHASE 4: Update last applied index and conditionally checkpoint.
         // WAL (written in PHASE 2) is the primary crash-safety path.
         // Checkpoint snapshots full data periodically to bound WAL replay time on recovery.
-        if let Some(log_id) = highest_index_entry {
+        if let Some(log_id) = highest_log_id {
             debug!("State machine - updated last_applied: {:?}", log_id);
             self.update_last_applied(log_id);
         }

--- a/d-engine-server/src/storage/adaptors/file/file_state_machine.rs
+++ b/d-engine-server/src/storage/adaptors/file/file_state_machine.rs
@@ -81,7 +81,7 @@
 //! - **Background Cleanup**: Periodic async worker scans and deletes expired keys
 //! - **Zero Overhead**: When TTL feature is disabled, no lease components are initialized
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -128,27 +128,101 @@ enum WalOpCode {
     Delete = 2,
     Config = 3,
     CompareAndSwap = 4,
+    CasFailed = 5,
 }
 
 impl WalOpCode {
     #[allow(dead_code)]
-    fn from_str(s: &str) -> Self {
+    fn from_str(s: &str) -> Option<Self> {
         match s {
-            "INSERT" => Self::Insert,
-            "DELETE" => Self::Delete,
-            "CONFIG" => Self::Config,
-            "CAS" => Self::CompareAndSwap,
-            _ => Self::Noop,
+            "NOOP" => Some(Self::Noop),
+            "INSERT" => Some(Self::Insert),
+            "DELETE" => Some(Self::Delete),
+            "CONFIG" => Some(Self::Config),
+            "CAS" => Some(Self::CompareAndSwap),
+            "CAS_FAILED" => Some(Self::CasFailed),
+            _ => None,
         }
     }
 
-    fn from_u8(byte: u8) -> Self {
+    fn from_u8(byte: u8) -> Option<Self> {
         match byte {
-            1 => Self::Insert,
-            2 => Self::Delete,
-            3 => Self::Config,
-            4 => Self::CompareAndSwap,
-            _ => Self::Noop,
+            0 => Some(Self::Noop),
+            1 => Some(Self::Insert),
+            2 => Some(Self::Delete),
+            3 => Some(Self::Config),
+            4 => Some(Self::CompareAndSwap),
+            5 => Some(Self::CasFailed),
+            _ => None,
+        }
+    }
+}
+
+/// Encodes a single WAL entry into `buf`.
+///
+/// For `CompareAndSwap`, `cas_success` determines whether to write
+/// `Insert` (success, replay applies unconditionally) or
+/// `CasFailed` (failure, replay skips).
+fn encode_wal_entry(
+    buf: &mut Vec<u8>,
+    entry: &ApplyEntry,
+    cas_success: bool,
+) {
+    buf.extend_from_slice(&entry.index.to_be_bytes());
+    buf.extend_from_slice(&entry.term.to_be_bytes());
+    match &entry.command {
+        Command::Noop => {
+            buf.push(WalOpCode::Noop as u8);
+            buf.extend_from_slice(&0u64.to_be_bytes());
+            buf.extend_from_slice(&0u64.to_be_bytes());
+            buf.extend_from_slice(&0u64.to_be_bytes());
+        }
+        Command::Insert {
+            key,
+            value,
+            ttl_secs,
+        } => {
+            buf.push(WalOpCode::Insert as u8);
+            buf.extend_from_slice(&(key.len() as u64).to_be_bytes());
+            buf.extend_from_slice(key);
+            buf.extend_from_slice(&(value.len() as u64).to_be_bytes());
+            buf.extend_from_slice(value);
+            // expire_at is computed at WAL-encode time, not at apply time. Any delay
+            // between Raft commit and WAL write (e.g. slow I/O) causes a small under-count
+            // (key expires slightly earlier than intended). This is a known, accepted
+            // trade-off: TTL precision is best-effort, not a hard guarantee.
+            let expire_at_secs = if let Some(ttl) = ttl_secs {
+                let expire_at = std::time::SystemTime::now() + std::time::Duration::from_secs(*ttl);
+                expire_at
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0)
+            } else {
+                0
+            };
+            buf.extend_from_slice(&expire_at_secs.to_be_bytes());
+        }
+        Command::Delete { key } => {
+            buf.push(WalOpCode::Delete as u8);
+            buf.extend_from_slice(&(key.len() as u64).to_be_bytes());
+            buf.extend_from_slice(key);
+            buf.extend_from_slice(&0u64.to_be_bytes()); // val_len = 0
+            buf.extend_from_slice(&0u64.to_be_bytes()); // expire_at = 0
+        }
+        Command::CompareAndSwap { key, value, .. } => {
+            if cas_success {
+                buf.push(WalOpCode::Insert as u8);
+                buf.extend_from_slice(&(key.len() as u64).to_be_bytes());
+                buf.extend_from_slice(key);
+                buf.extend_from_slice(&(value.len() as u64).to_be_bytes());
+                buf.extend_from_slice(value);
+                buf.extend_from_slice(&0u64.to_be_bytes()); // no TTL
+            } else {
+                buf.push(WalOpCode::CasFailed as u8);
+                buf.extend_from_slice(&0u64.to_be_bytes()); // key_len = 0
+                buf.extend_from_slice(&0u64.to_be_bytes()); // val_len = 0
+                buf.extend_from_slice(&0u64.to_be_bytes()); // expire_at = 0
+            }
         }
     }
 }
@@ -451,7 +525,10 @@ impl FileStateMachine {
             pos += 8;
 
             // Read operation code (1 byte)
-            let op_code = WalOpCode::from_u8(buffer[pos]);
+            let op_code =
+                WalOpCode::from_u8(buffer[pos]).ok_or_else(|| StorageError::DataCorruption {
+                    location: format!("WAL opcode {} at byte offset {}", buffer[pos], pos),
+                })?;
             pos += 1;
 
             // Check if we have enough bytes for key length
@@ -518,19 +595,19 @@ impl FileStateMachine {
             // 1. Gracefully stop the old version (persists state.data + ttl_state.bin)
             // 2. Upgrade to v0.2.0+
             // 3. Start the new version (loads from persisted state, not WAL)
-            let expire_at_secs = if pos + 8 <= buffer.len() {
-                let secs = u64::from_be_bytes(buffer[pos..pos + 8].try_into().unwrap());
-                pos += 8;
-                if secs > 0 { Some(secs) } else { None }
-            } else {
-                // Incomplete WAL entry - log and skip
-                // This indicates corrupted WAL or incomplete write before crash
-                debug!(
-                    "No expiration time field at position {}, assuming no TTL (incomplete WAL entry)",
+            // Truncated tail: stop here rather than continuing with garbage bytes.
+            // A partial write at the WAL tail is expected on a crash; entries after
+            // the truncation point are discarded and will be re-applied via Raft.
+            if pos + 8 > buffer.len() {
+                warn!(
+                    "Incomplete WAL entry at byte offset {} (expected expire_at field), truncating replay here",
                     pos
                 );
-                None
-            };
+                break;
+            }
+            let secs = u64::from_be_bytes(buffer[pos..pos + 8].try_into().unwrap());
+            pos += 8;
+            let expire_at_secs = if secs > 0 { Some(secs) } else { None };
 
             operations.push((op_code, key, value, term, expire_at_secs));
             replayed_count += 1;
@@ -618,7 +695,7 @@ impl FileStateMachine {
                             warn!("Legacy CAS WAL entry missing new_value");
                         }
                     }
-                    WalOpCode::Noop | WalOpCode::Config => {
+                    WalOpCode::Noop | WalOpCode::Config | WalOpCode::CasFailed => {
                         // No data modification needed
                         applied_count += 1;
                         debug!("Replayed {:?} operation", op_code);
@@ -632,14 +709,15 @@ impl FileStateMachine {
             replayed_count, applied_count, skipped_expired
         );
 
-        // Clear WAL only if replay was successful
-        if applied_count > 0 {
-            self.clear_wal_async().await?;
-            debug!(
-                "Cleared WAL after successful replay of {} operations",
-                applied_count
-            );
-        }
+        // Unconditionally clear WAL after replay. load_data() already restored the last
+        // checkpoint; WAL is only the post-checkpoint delta. Even if 0 entries were applied
+        // (e.g. truncated tail only), the WAL is stale. Keeping it would cause infinite
+        // replay-of-the-same-truncated-entry on every subsequent startup.
+        self.clear_wal_async().await?;
+        debug!(
+            "Cleared WAL after replay ({} operations applied)",
+            applied_count
+        );
 
         Ok(())
     }
@@ -891,6 +969,7 @@ impl FileStateMachine {
     /// - N bytes: key data
     /// - 8 bytes: value length (big-endian u64, 0 if no value)
     /// - M bytes: value data (only if length > 0)
+    #[cfg(test)]
     pub(crate) async fn append_to_wal(
         &self,
         entries: &[ApplyEntry],
@@ -901,89 +980,12 @@ impl FileStateMachine {
         }
 
         let wal_path = self.data_dir.join("wal.log");
-
         let mut file =
             OpenOptions::new().write(true).create(true).append(true).open(&wal_path).await?;
 
-        // Pre-allocate buffer: CAS success = Insert size, CAS failure = Noop size
-        let estimated_size: usize = entries
-            .iter()
-            .enumerate()
-            .map(|(i, entry)| match &entry.command {
-                Command::Noop => 41,
-                Command::Insert { key, value, .. } => 41 + key.len() + value.len(),
-                Command::Delete { key } => 41 + key.len(),
-                Command::CompareAndSwap { key, value, .. } => {
-                    if cas_outcomes[i] {
-                        41 + key.len() + value.len()
-                    } else {
-                        41
-                    }
-                }
-            })
-            .sum();
-
-        // Single batched write instead of multiple small writes
-        let mut batch_buffer = Vec::with_capacity(estimated_size);
-
+        let mut batch_buffer = Vec::with_capacity(entries.len() * 64);
         for (i, entry) in entries.iter().enumerate() {
-            batch_buffer.extend_from_slice(&entry.index.to_be_bytes());
-            batch_buffer.extend_from_slice(&entry.term.to_be_bytes());
-
-            match &entry.command {
-                Command::Noop => {
-                    batch_buffer.push(WalOpCode::Noop as u8);
-                    batch_buffer.extend_from_slice(&0u64.to_be_bytes()); // key_len = 0
-                    batch_buffer.extend_from_slice(&0u64.to_be_bytes()); // val_len = 0
-                    batch_buffer.extend_from_slice(&0u64.to_be_bytes()); // expire_at = 0
-                }
-                Command::Insert {
-                    key,
-                    value,
-                    ttl_secs,
-                } => {
-                    batch_buffer.push(WalOpCode::Insert as u8);
-                    batch_buffer.extend_from_slice(&(key.len() as u64).to_be_bytes());
-                    batch_buffer.extend_from_slice(key);
-                    batch_buffer.extend_from_slice(&(value.len() as u64).to_be_bytes());
-                    batch_buffer.extend_from_slice(value);
-                    let expire_at_secs = if let Some(ttl) = ttl_secs {
-                        let expire_at =
-                            std::time::SystemTime::now() + std::time::Duration::from_secs(*ttl);
-                        expire_at
-                            .duration_since(std::time::UNIX_EPOCH)
-                            .map(|d| d.as_secs())
-                            .unwrap_or(0)
-                    } else {
-                        0
-                    };
-                    batch_buffer.extend_from_slice(&expire_at_secs.to_be_bytes());
-                }
-                Command::Delete { key } => {
-                    batch_buffer.push(WalOpCode::Delete as u8);
-                    batch_buffer.extend_from_slice(&(key.len() as u64).to_be_bytes());
-                    batch_buffer.extend_from_slice(key);
-                    batch_buffer.extend_from_slice(&0u64.to_be_bytes()); // val_len = 0
-                    batch_buffer.extend_from_slice(&0u64.to_be_bytes()); // expire_at = 0
-                }
-                Command::CompareAndSwap { key, value, .. } => {
-                    if cas_outcomes[i] {
-                        // CAS succeeded: store as Insert so replay applies it unconditionally
-                        batch_buffer.push(WalOpCode::Insert as u8);
-                        batch_buffer.extend_from_slice(&(key.len() as u64).to_be_bytes());
-                        batch_buffer.extend_from_slice(key);
-                        batch_buffer.extend_from_slice(&(value.len() as u64).to_be_bytes());
-                        batch_buffer.extend_from_slice(value);
-                        batch_buffer.extend_from_slice(&0u64.to_be_bytes()); // no TTL
-                    } else {
-                        // CAS failed: store as Noop so replay skips it
-                        batch_buffer.push(WalOpCode::Noop as u8);
-                        batch_buffer.extend_from_slice(&0u64.to_be_bytes()); // key_len = 0
-                        batch_buffer.extend_from_slice(&0u64.to_be_bytes()); // val_len = 0
-                        batch_buffer.extend_from_slice(&0u64.to_be_bytes()); // expire_at = 0
-                    }
-                }
-            }
+            encode_wal_entry(&mut batch_buffer, entry, cas_outcomes[i]);
         }
 
         file.write_all(&batch_buffer).await?;
@@ -1089,30 +1091,93 @@ impl StateMachine for FileStateMachine {
             info!("COMMITTED_LOG_METRIC: {}", entry.index);
         }
 
-        // PRE-PHASE: Evaluate CAS conditions before WAL write.
-        // WAL must record outcomes, not intents — a failed CAS written as-intent
-        // would be applied unconditionally on replay, corrupting data.
-        let cas_outcomes: Vec<bool> = {
-            let data = self.data.read();
-            chunk
+        // PRE-PHASE + PHASE 2 combined: evaluate outcomes and encode WAL in one pass.
+        //
+        // WAL records outcomes, not intents. We simulate in chunk order so earlier
+        // entries are visible to later CAS — matching Raft's serial apply semantics.
+        //
+        // Key-scoped snapshot: only CAS entries need to read the current value.
+        // We fetch only CAS-referenced keys from self.data (read lock held briefly)
+        // and track chunk-level mutations in a small `delta` map, avoiding a full
+        // HashMap clone regardless of data set size.
+        //
+        // Encoding happens in the same loop as evaluation, eliminating the second
+        // pass over chunk that a separate append_to_wal call would require.
+        let (cas_outcomes, wal_buf) = {
+            // Collect keys that any CAS in this chunk will compare against.
+            let cas_keys: HashSet<&Bytes> = chunk
                 .iter()
-                .map(|entry| match &entry.command {
-                    Command::CompareAndSwap { key, expected, .. } => {
-                        let current = data.get(key.as_ref());
-                        match (current, expected) {
-                            (Some((c, _)), Some(e)) => c.as_ref() == e.as_ref(),
-                            (None, None) => true,
-                            _ => false,
-                        }
-                    }
-                    _ => false, // non-CAS: value unused in append_to_wal
+                .filter_map(|e| match &e.command {
+                    Command::CompareAndSwap { key, .. } => Some(key),
+                    _ => None,
                 })
-                .collect()
+                .collect();
+
+            // Fetch only those keys; read lock released at end of this block.
+            let base: HashMap<Bytes, (Bytes, u64)> = {
+                let guard = self.data.read();
+                cas_keys
+                    .iter()
+                    .filter_map(|k| guard.get(k.as_ref()).map(|v| ((*k).clone(), v.clone())))
+                    .collect()
+            };
+
+            // delta tracks mutations made by earlier entries in this chunk.
+            // None = deleted by an earlier Delete in the same chunk.
+            let mut delta: HashMap<Bytes, Option<(Bytes, u64)>> = HashMap::new();
+            let mut wal_buf: Vec<u8> = Vec::with_capacity(chunk.len() * 64);
+
+            let outcomes: Vec<bool> = chunk
+                .iter()
+                .map(|entry| {
+                    let success = match &entry.command {
+                        Command::Insert { key, value, .. } => {
+                            delta.insert(key.clone(), Some((value.clone(), entry.term)));
+                            false
+                        }
+                        Command::Delete { key } => {
+                            delta.insert(key.clone(), None);
+                            false
+                        }
+                        Command::CompareAndSwap {
+                            key,
+                            expected,
+                            value: new_value,
+                        } => {
+                            // Look up current value: delta (this chunk) takes precedence over base.
+                            let current =
+                                delta.get(key).map(|v| v.as_ref()).unwrap_or_else(|| base.get(key));
+                            let success = match (current, expected) {
+                                (Some((c, _)), Some(e)) => c.as_ref() == e.as_ref(),
+                                (None, None) => true,
+                                _ => false,
+                            };
+                            if success {
+                                delta.insert(key.clone(), Some((new_value.clone(), entry.term)));
+                            }
+                            success
+                        }
+                        Command::Noop => false,
+                    };
+                    encode_wal_entry(&mut wal_buf, entry, success);
+                    success
+                })
+                .collect();
+
+            (outcomes, wal_buf)
         };
 
-        // PHASE 2: Batch WAL writes with outcomes known.
-        // Successful CAS → WalOpCode::Insert; failed CAS → WalOpCode::Noop.
-        self.append_to_wal(chunk, &cas_outcomes).await?;
+        // PHASE 2: single fsync with buffer built during evaluation above.
+        // Successful CAS → WalOpCode::Insert; failed CAS → WalOpCode::CasFailed.
+        // Note: wal_buf is never empty here in practice — every entry encodes at least
+        // 41 bytes — but the guard is kept as a cheap defensive check.
+        if !wal_buf.is_empty() {
+            let wal_path = self.data_dir.join("wal.log");
+            let mut file =
+                OpenOptions::new().write(true).create(true).append(true).open(&wal_path).await?;
+            file.write_all(&wal_buf).await?;
+            file.flush().await?;
+        }
 
         // PHASE 3: Fast in-memory updates with minimal lock time
         // (CAS uses pre-computed outcomes — no re-evaluation under write lock)

--- a/d-engine-server/src/storage/adaptors/file/file_state_machine_test.rs
+++ b/d-engine-server/src/storage/adaptors/file/file_state_machine_test.rs
@@ -1,12 +1,5 @@
 use bytes::Bytes;
-use d_engine_core::StateMachine;
-use d_engine_proto::client::WriteCommand;
-use d_engine_proto::client::write_command::Insert;
-use d_engine_proto::client::write_command::Operation;
-use d_engine_proto::common::Entry;
-use d_engine_proto::common::EntryPayload;
-use d_engine_proto::common::entry_payload::Payload;
-use prost::Message;
+use d_engine_core::{ApplyEntry, Command, StateMachine};
 use std::sync::Arc;
 
 use crate::storage::adaptors::file::FileStateMachine;
@@ -70,66 +63,45 @@ async fn test_wal_replay_after_crash() {
 
     let sm = FileStateMachine::new(data_dir.clone()).await.unwrap();
 
-    // Create proper Raft entries with payloads
     let entries = vec![
-        Entry {
+        ApplyEntry {
             index: 1,
             term: 1,
-            payload: Some(EntryPayload {
-                payload: Some(Payload::Command(
-                    WriteCommand {
-                        operation: Some(Operation::Insert(Insert {
-                            ttl_secs: 0,
-                            key: Bytes::from("key1"),
-                            value: Bytes::from("value1"),
-                        })),
-                    }
-                    .encode_to_vec()
-                    .into(),
-                )),
-            }),
+            command: Command::Insert {
+                key: Bytes::from("key1"),
+                value: Bytes::from("value1"),
+                ttl_secs: None,
+            },
         },
-        Entry {
+        ApplyEntry {
             index: 2,
             term: 1,
-            payload: Some(EntryPayload {
-                payload: Some(Payload::Command(
-                    WriteCommand {
-                        operation: Some(Operation::Insert(Insert {
-                            ttl_secs: 0,
-                            key: Bytes::from("key2"),
-                            value: Bytes::from("value2"),
-                        })),
-                    }
-                    .encode_to_vec()
-                    .into(),
-                )),
-            }),
+            command: Command::Insert {
+                key: Bytes::from("key2"),
+                value: Bytes::from("value2"),
+                ttl_secs: None,
+            },
         },
     ];
 
     // Apply entries (this writes WAL + updates memory)
-    sm.apply_chunk(entries).await.unwrap();
+    sm.apply_chunk(&entries).await.unwrap();
 
     // Verify data is in memory
     assert_eq!(sm.get(b"key1").unwrap(), Some(Bytes::from("value1")));
     assert_eq!(sm.get(b"key2").unwrap(), Some(Bytes::from("value2")));
 
-    // Now test crash recovery with WAL
-
-    // Manually append to WAL without updating memory (simulate partial write)
-    let crash_entries = vec![(
-        Entry {
-            index: 3,
-            term: 1,
-            payload: None,
+    // Manually append to WAL without updating memory (simulate partial write before crash)
+    let crash_entries = vec![ApplyEntry {
+        index: 3,
+        term: 1,
+        command: Command::Insert {
+            key: Bytes::from("key3"),
+            value: Bytes::from("value3"),
+            ttl_secs: None,
         },
-        "INSERT".to_string(),
-        Bytes::from("key3"),
-        Some(Bytes::from("value3")),
-        0, // No TTL
-    )];
-    sm.append_to_wal(crash_entries).await.unwrap();
+    }];
+    sm.append_to_wal(&crash_entries).await.unwrap();
 
     // Don't call flush - simulate crash before persistence
     drop(sm);
@@ -157,66 +129,40 @@ async fn test_wal_replay_after_crash() {
 /// scan_prefix returns only keys that start with the prefix, not all keys.
 #[tokio::test]
 async fn test_file_sm_scan_prefix_returns_matching_keys() {
-    use d_engine_core::StateMachine;
-
     let temp_dir = tempfile::tempdir().unwrap();
     let sm = FileStateMachine::new(temp_dir.path().to_path_buf()).await.unwrap();
 
     let entries = vec![
-        Entry {
+        ApplyEntry {
             index: 1,
             term: 1,
-            payload: Some(EntryPayload {
-                payload: Some(Payload::Command(
-                    WriteCommand {
-                        operation: Some(Operation::Insert(Insert {
-                            key: Bytes::from("/services/node1"),
-                            value: Bytes::from("10.0.0.1"),
-                            ttl_secs: 0,
-                        })),
-                    }
-                    .encode_to_vec()
-                    .into(),
-                )),
-            }),
+            command: Command::Insert {
+                key: Bytes::from("/services/node1"),
+                value: Bytes::from("10.0.0.1"),
+                ttl_secs: None,
+            },
         },
-        Entry {
+        ApplyEntry {
             index: 2,
             term: 1,
-            payload: Some(EntryPayload {
-                payload: Some(Payload::Command(
-                    WriteCommand {
-                        operation: Some(Operation::Insert(Insert {
-                            key: Bytes::from("/services/node2"),
-                            value: Bytes::from("10.0.0.2"),
-                            ttl_secs: 0,
-                        })),
-                    }
-                    .encode_to_vec()
-                    .into(),
-                )),
-            }),
+            command: Command::Insert {
+                key: Bytes::from("/services/node2"),
+                value: Bytes::from("10.0.0.2"),
+                ttl_secs: None,
+            },
         },
-        Entry {
+        ApplyEntry {
             index: 3,
             term: 1,
-            payload: Some(EntryPayload {
-                payload: Some(Payload::Command(
-                    WriteCommand {
-                        operation: Some(Operation::Insert(Insert {
-                            key: Bytes::from("/other/key"),
-                            value: Bytes::from("must_not_appear"),
-                            ttl_secs: 0,
-                        })),
-                    }
-                    .encode_to_vec()
-                    .into(),
-                )),
-            }),
+            command: Command::Insert {
+                key: Bytes::from("/other/key"),
+                value: Bytes::from("must_not_appear"),
+                ttl_secs: None,
+            },
         },
     ];
 
-    sm.apply_chunk(entries).await.unwrap();
+    sm.apply_chunk(&entries).await.unwrap();
 
     let result = sm.scan_prefix(b"/services/").unwrap();
 
@@ -233,27 +179,17 @@ async fn test_file_sm_scan_prefix_returns_matching_keys() {
 /// scan_prefix on a missing prefix returns empty entries, not an error.
 #[tokio::test]
 async fn test_file_sm_scan_prefix_empty_namespace() {
-    use d_engine_core::StateMachine;
-
     let temp_dir = tempfile::tempdir().unwrap();
     let sm = FileStateMachine::new(temp_dir.path().to_path_buf()).await.unwrap();
 
-    sm.apply_chunk(vec![Entry {
+    sm.apply_chunk(&[ApplyEntry {
         index: 1,
         term: 1,
-        payload: Some(EntryPayload {
-            payload: Some(Payload::Command(
-                WriteCommand {
-                    operation: Some(Operation::Insert(Insert {
-                        key: Bytes::from("/other/key"),
-                        value: Bytes::from("v"),
-                        ttl_secs: 0,
-                    })),
-                }
-                .encode_to_vec()
-                .into(),
-            )),
-        }),
+        command: Command::Insert {
+            key: Bytes::from("/other/key"),
+            value: Bytes::from("v"),
+            ttl_secs: None,
+        },
     }])
     .await
     .unwrap();
@@ -269,32 +205,22 @@ async fn test_file_sm_scan_prefix_empty_namespace() {
 /// scan_prefix revision equals last_applied_index at scan time.
 #[tokio::test]
 async fn test_file_sm_scan_prefix_revision_reflects_applied_index() {
-    use d_engine_core::StateMachine;
-
     let temp_dir = tempfile::tempdir().unwrap();
     let sm = FileStateMachine::new(temp_dir.path().to_path_buf()).await.unwrap();
 
-    let entries: Vec<Entry> = (1u64..=3)
-        .map(|i| Entry {
+    let entries: Vec<ApplyEntry> = (1u64..=3)
+        .map(|i| ApplyEntry {
             index: i,
             term: 1,
-            payload: Some(EntryPayload {
-                payload: Some(Payload::Command(
-                    WriteCommand {
-                        operation: Some(Operation::Insert(Insert {
-                            key: Bytes::from(format!("/s/{i}")),
-                            value: Bytes::from(format!("{i}")),
-                            ttl_secs: 0,
-                        })),
-                    }
-                    .encode_to_vec()
-                    .into(),
-                )),
-            }),
+            command: Command::Insert {
+                key: Bytes::from(format!("/s/{i}")),
+                value: Bytes::from(format!("{i}")),
+                ttl_secs: None,
+            },
         })
         .collect();
 
-    sm.apply_chunk(entries).await.unwrap();
+    sm.apply_chunk(&entries).await.unwrap();
 
     let result = sm.scan_prefix(b"/s/").unwrap();
 

--- a/d-engine-server/src/storage/adaptors/file/file_state_machine_test.rs
+++ b/d-engine-server/src/storage/adaptors/file/file_state_machine_test.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 use d_engine_core::{ApplyEntry, Command, StateMachine};
 use std::sync::Arc;
+use tokio::io::AsyncWriteExt;
 
 use crate::storage::adaptors::file::FileStateMachine;
 use async_trait::async_trait;
@@ -182,6 +183,43 @@ async fn test_cas_failure_wal_replay_does_not_corrupt_data() {
     );
 }
 
+/// CAS that depends on an earlier Insert in the same chunk must succeed.
+///
+/// The shadow-map simulation must process entries in order so the CAS sees
+/// the Insert's effect even though self.data hasn't been updated yet.
+#[tokio::test]
+async fn test_cas_in_same_chunk_as_preceding_insert() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let sm = FileStateMachine::new(temp_dir.path().to_path_buf()).await.unwrap();
+
+    let results = sm
+        .apply_chunk(&[
+            ApplyEntry {
+                index: 1,
+                term: 1,
+                command: Command::Insert {
+                    key: Bytes::from("k"),
+                    value: Bytes::from("v1"),
+                    ttl_secs: None,
+                },
+            },
+            ApplyEntry {
+                index: 2,
+                term: 1,
+                command: Command::CompareAndSwap {
+                    key: Bytes::from("k"),
+                    expected: Some(Bytes::from("v1")),
+                    value: Bytes::from("v2"),
+                },
+            },
+        ])
+        .await
+        .unwrap();
+
+    assert!(results[1].succeeded, "CAS must see Insert from same chunk");
+    assert_eq!(sm.get(b"k").unwrap(), Some(Bytes::from("v2")));
+}
+
 /// A successful CAS must be correctly applied after WAL replay.
 #[tokio::test]
 async fn test_cas_success_wal_replay_applies_new_value() {
@@ -228,6 +266,56 @@ async fn test_cas_success_wal_replay_applies_new_value() {
         sm2.get(b"k").unwrap(),
         Some(Bytes::from("v2")),
         "Successful CAS must survive WAL replay"
+    );
+}
+
+/// WAL replay must return an error when the WAL contains an unrecognised opcode byte.
+///
+/// An unknown opcode means the WAL is corrupt or was written by a future/incompatible
+/// binary. Silently treating it as a no-op would hide the corruption and leave the
+/// state machine in an undefined state. The correct behaviour is to fail loudly so
+/// the operator can investigate rather than continuing with silently missing entries.
+#[tokio::test]
+async fn test_replay_wal_unknown_opcode_returns_error() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let data_dir = temp_dir.path().to_path_buf();
+
+    // Write one valid entry so the WAL file exists and has a known-good prefix.
+    let sm = FileStateMachine::new(data_dir.clone()).await.unwrap();
+    sm.apply_chunk(&[ApplyEntry {
+        index: 1,
+        term: 1,
+        command: Command::Insert {
+            key: Bytes::from("k"),
+            value: Bytes::from("v"),
+            ttl_secs: None,
+        },
+    }])
+    .await
+    .unwrap();
+    drop(sm);
+
+    // Append a syntactically complete WAL entry whose opcode byte (99) is not
+    // defined in WalOpCode. Format: index(8) + term(8) + opcode(1) + key_len(8)
+    // + val_len(8) + expire_at(8) = 41 bytes total (matches the Noop/CasFailed layout).
+    let wal_path = data_dir.join("wal.log");
+    let mut file = tokio::fs::OpenOptions::new().append(true).open(&wal_path).await.unwrap();
+    let mut corrupt_entry = Vec::with_capacity(41);
+    corrupt_entry.extend_from_slice(&2u64.to_be_bytes()); // index = 2
+    corrupt_entry.extend_from_slice(&1u64.to_be_bytes()); // term  = 1
+    corrupt_entry.push(99u8); // unknown opcode
+    corrupt_entry.extend_from_slice(&0u64.to_be_bytes()); // key_len = 0
+    corrupt_entry.extend_from_slice(&0u64.to_be_bytes()); // val_len = 0
+    corrupt_entry.extend_from_slice(&0u64.to_be_bytes()); // expire_at = 0
+    file.write_all(&corrupt_entry).await.unwrap();
+    file.flush().await.unwrap();
+    drop(file);
+
+    // Recovery must fail — unknown opcode must not be silently skipped.
+    let result = FileStateMachine::new(data_dir).await;
+    assert!(
+        result.is_err(),
+        "WAL replay must return an error on unknown opcode, not silently skip it"
     );
 }
 

--- a/d-engine-server/src/storage/adaptors/file/file_state_machine_test.rs
+++ b/d-engine-server/src/storage/adaptors/file/file_state_machine_test.rs
@@ -101,7 +101,8 @@ async fn test_wal_replay_after_crash() {
             ttl_secs: None,
         },
     }];
-    sm.append_to_wal(&crash_entries).await.unwrap();
+    let dummy_outcomes = vec![false; crash_entries.len()]; // non-CAS entries: outcome unused
+    sm.append_to_wal(&crash_entries, &dummy_outcomes).await.unwrap();
 
     // Don't call flush - simulate crash before persistence
     drop(sm);
@@ -121,6 +122,112 @@ async fn test_wal_replay_after_crash() {
     assert_eq!(
         sm_recovered.get(b"key3").unwrap(),
         Some(Bytes::from("value3"))
+    );
+}
+
+// ── CAS WAL crash-safety tests ────────────────────────────────────────────────
+
+/// A failed CAS must NOT corrupt data when the node crashes and replays WAL.
+///
+/// Before the fix, apply_chunk wrote all entries (including CAS) to WAL before
+/// evaluating the comparison. On replay the CAS was applied unconditionally,
+/// overwriting data that should never have changed.
+#[tokio::test]
+async fn test_cas_failure_wal_replay_does_not_corrupt_data() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let data_dir = temp_dir.path().to_path_buf();
+    let sm = FileStateMachine::new(data_dir.clone()).await.unwrap();
+
+    // Establish initial value
+    sm.apply_chunk(&[ApplyEntry {
+        index: 1,
+        term: 1,
+        command: Command::Insert {
+            key: Bytes::from("k"),
+            value: Bytes::from("original"),
+            ttl_secs: None,
+        },
+    }])
+    .await
+    .unwrap();
+
+    // CAS with wrong expected value — must fail at runtime
+    let results = sm
+        .apply_chunk(&[ApplyEntry {
+            index: 2,
+            term: 1,
+            command: Command::CompareAndSwap {
+                key: Bytes::from("k"),
+                expected: Some(Bytes::from("wrong_expected")),
+                value: Bytes::from("should_not_appear"),
+            },
+        }])
+        .await
+        .unwrap();
+
+    assert!(
+        !results[0].succeeded,
+        "CAS should fail when expected != current"
+    );
+    assert_eq!(sm.get(b"k").unwrap(), Some(Bytes::from("original")));
+
+    // Simulate crash + WAL replay
+    drop(sm);
+    let sm2 = FileStateMachine::new(data_dir).await.unwrap();
+
+    assert_eq!(
+        sm2.get(b"k").unwrap(),
+        Some(Bytes::from("original")),
+        "WAL replay of failed CAS must not corrupt data"
+    );
+}
+
+/// A successful CAS must be correctly applied after WAL replay.
+#[tokio::test]
+async fn test_cas_success_wal_replay_applies_new_value() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let data_dir = temp_dir.path().to_path_buf();
+    let sm = FileStateMachine::new(data_dir.clone()).await.unwrap();
+
+    sm.apply_chunk(&[ApplyEntry {
+        index: 1,
+        term: 1,
+        command: Command::Insert {
+            key: Bytes::from("k"),
+            value: Bytes::from("v1"),
+            ttl_secs: None,
+        },
+    }])
+    .await
+    .unwrap();
+
+    let results = sm
+        .apply_chunk(&[ApplyEntry {
+            index: 2,
+            term: 1,
+            command: Command::CompareAndSwap {
+                key: Bytes::from("k"),
+                expected: Some(Bytes::from("v1")),
+                value: Bytes::from("v2"),
+            },
+        }])
+        .await
+        .unwrap();
+
+    assert!(
+        results[0].succeeded,
+        "CAS should succeed when expected matches"
+    );
+    assert_eq!(sm.get(b"k").unwrap(), Some(Bytes::from("v2")));
+
+    // Simulate crash + WAL replay
+    drop(sm);
+    let sm2 = FileStateMachine::new(data_dir).await.unwrap();
+
+    assert_eq!(
+        sm2.get(b"k").unwrap(),
+        Some(Bytes::from("v2")),
+        "Successful CAS must survive WAL replay"
     );
 }
 

--- a/d-engine-server/src/storage/adaptors/rocksdb/rocksdb_state_machine.rs
+++ b/d-engine-server/src/storage/adaptors/rocksdb/rocksdb_state_machine.rs
@@ -6,23 +6,17 @@ use std::time::SystemTime;
 
 use arc_swap::ArcSwap;
 use bytes::Bytes;
+use d_engine_core::ApplyEntry;
 use d_engine_core::ApplyResult;
+use d_engine_core::Command;
 use d_engine_core::Error;
 use d_engine_core::Lease;
 use d_engine_core::ScanResult;
 use d_engine_core::StateMachine;
 use d_engine_core::StorageError;
-use d_engine_proto::client::WriteCommand;
-use d_engine_proto::client::write_command::CompareAndSwap;
-use d_engine_proto::client::write_command::Delete;
-use d_engine_proto::client::write_command::Insert;
-use d_engine_proto::client::write_command::Operation;
-use d_engine_proto::common::Entry;
 use d_engine_proto::common::LogId;
-use d_engine_proto::common::entry_payload::Payload;
 use d_engine_proto::server::storage::SnapshotMetadata;
 use parking_lot::RwLock;
-use prost::Message;
 use std::path::Path;
 
 use async_trait::async_trait;
@@ -723,7 +717,7 @@ impl StateMachine for RocksDBStateMachine {
     #[instrument(skip(self, chunk))]
     async fn apply_chunk(
         &self,
-        chunk: Vec<Entry>,
+        chunk: &[ApplyEntry],
     ) -> Result<Vec<ApplyResult>, Error> {
         let db = self.db.load();
         let cf = db
@@ -735,8 +729,6 @@ impl StateMachine for RocksDBStateMachine {
         let mut results = Vec::with_capacity(chunk.len());
 
         for entry in chunk {
-            assert!(entry.payload.is_some(), "Entry payload should not be None!");
-
             if let Some(prev) = highest_index_entry {
                 assert!(
                     entry.index > prev.index,
@@ -750,104 +742,76 @@ impl StateMachine for RocksDBStateMachine {
                 term: entry.term,
             });
 
-            match entry.payload.unwrap().payload {
-                Some(Payload::Noop(_)) => {
+            match &entry.command {
+                Command::Noop => {
                     debug!("Handling NOOP command at index {}", entry.index);
-                    // NOOP always succeeds
                     results.push(ApplyResult::success(entry.index));
                 }
-                Some(Payload::Command(data)) => match WriteCommand::decode(&data[..]) {
-                    Ok(write_cmd) => match write_cmd.operation {
-                        Some(Operation::Insert(Insert {
-                            key,
-                            value,
-                            ttl_secs,
-                        })) => {
-                            batch.put_cf(&cf, &key, &value);
+                Command::Insert {
+                    key,
+                    value,
+                    ttl_secs,
+                } => {
+                    batch.put_cf(&cf, key, value);
 
-                            // Register lease if TTL specified
-                            if ttl_secs > 0 {
-                                // Validate lease is enabled before accepting TTL requests
-                                if !self.lease_enabled {
-                                    return Err(StorageError::FeatureNotEnabled(
-                                        "TTL feature is not enabled on this server. \
-                                         Enable it in config: [raft.state_machine.lease] enabled = true".into()
-                                    ).into());
-                                }
-
-                                // Safety: lease_enabled invariant ensures lease.is_some()
-                                let lease = unsafe { self.lease.as_ref().unwrap_unchecked() };
-                                lease.register(key.clone(), ttl_secs);
-                            }
-
-                            // PUT always succeeds (errors returned as Err)
-                            results.push(ApplyResult::success(entry.index));
+                    if let Some(ttl) = ttl_secs {
+                        if !self.lease_enabled {
+                            return Err(StorageError::FeatureNotEnabled(
+                                "TTL feature is not enabled on this server. \
+                                 Enable it in config: [raft.state_machine.lease] enabled = true"
+                                    .into(),
+                            )
+                            .into());
                         }
-                        Some(Operation::Delete(Delete { key })) => {
-                            batch.delete_cf(&cf, &key);
-
-                            // Unregister TTL for deleted key
-                            if let Some(ref lease) = self.lease {
-                                lease.unregister(&key);
-                            }
-
-                            // DELETE always succeeds (errors returned as Err)
-                            results.push(ApplyResult::success(entry.index));
-                        }
-                        Some(Operation::CompareAndSwap(CompareAndSwap {
-                            key,
-                            expected_value,
-                            new_value,
-                        })) => {
-                            // RocksDB doesn't have native CAS, implement via read-compare-write.
-                            // Read through WriteBatchWithIndex so that earlier CAS writes in the
-                            // same batch are visible, preventing stale-read linearizability violations.
-                            let current_value = batch
-                                .get_from_batch_and_db_cf(&*db, &cf, &key, &ReadOptions::default())
-                                .map_err(|e| {
-                                    StorageError::DbError(format!("CAS read failed: {e}"))
-                                })?;
-
-                            let cas_success = match (current_value, &expected_value) {
-                                (Some(current), Some(expected)) => current == expected.as_ref(),
-                                (None, None) => true,
-                                _ => false,
-                            };
-
-                            if cas_success {
-                                batch.put_cf(&cf, &key, &new_value);
-                            }
-
-                            // Store CAS result for client response
-                            results.push(if cas_success {
-                                ApplyResult::success(entry.index)
-                            } else {
-                                ApplyResult::failure(entry.index)
-                            });
-
-                            debug!(
-                                "CAS at index {}: key={:?}, success={}",
-                                entry.index,
-                                String::from_utf8_lossy(&key),
-                                cas_success
-                            );
-                        }
-                        None => {
-                            warn!("WriteCommand without operation at index {}", entry.index);
-                        }
-                    },
-                    Err(e) => {
-                        error!(
-                            "Failed to decode WriteCommand at index {}: {:?}",
-                            entry.index, e
-                        );
-                        return Err(StorageError::SerializationError(e.to_string()).into());
+                        // Safety: lease_enabled invariant ensures lease.is_some()
+                        let lease = unsafe { self.lease.as_ref().unwrap_unchecked() };
+                        lease.register(key.clone(), *ttl);
                     }
-                },
-                Some(Payload::Config(_config_change)) => {
-                    debug!("Ignoring config change at index {}", entry.index);
+
+                    results.push(ApplyResult::success(entry.index));
                 }
-                None => panic!("Entry payload variant should not be None!"),
+                Command::Delete { key } => {
+                    batch.delete_cf(&cf, key);
+                    if let Some(ref lease) = self.lease {
+                        lease.unregister(key);
+                    }
+                    results.push(ApplyResult::success(entry.index));
+                }
+                Command::CompareAndSwap {
+                    key,
+                    expected,
+                    value: new_value,
+                } => {
+                    // RocksDB doesn't have native CAS; implement via read-compare-write.
+                    // Read through WriteBatchWithIndex so earlier writes in this batch
+                    // are visible, preventing stale-read linearizability violations.
+                    let current_value = batch
+                        .get_from_batch_and_db_cf(&*db, &cf, key, &ReadOptions::default())
+                        .map_err(|e| StorageError::DbError(format!("CAS read failed: {e}")))?;
+
+                    let cas_success = match (current_value, expected) {
+                        (Some(current), Some(exp)) => current == exp.as_ref(),
+                        (None, None) => true,
+                        _ => false,
+                    };
+
+                    if cas_success {
+                        batch.put_cf(&cf, key, new_value);
+                    }
+
+                    results.push(if cas_success {
+                        ApplyResult::success(entry.index)
+                    } else {
+                        ApplyResult::failure(entry.index)
+                    });
+
+                    debug!(
+                        "CAS at index {}: key={:?}, success={}",
+                        entry.index,
+                        String::from_utf8_lossy(key),
+                        cas_success
+                    );
+                }
             }
         }
 
@@ -856,12 +820,6 @@ impl StateMachine for RocksDBStateMachine {
             .write_wbwi(&batch)
             .map_err(|e| StorageError::DbError(e.to_string()))?;
 
-        // Note: Lease cleanup is now handled by:
-        // - Lazy strategy: cleanup in get() method
-        // - Background strategy: dedicated async task
-        // This avoids blocking the Raft apply hot path
-
-        // Update last_applied after successful batch write
         if let Some(highest) = highest_index_entry {
             self.update_last_applied(highest);
         }

--- a/d-engine-server/src/storage/adaptors/rocksdb/rocksdb_state_machine_test.rs
+++ b/d-engine-server/src/storage/adaptors/rocksdb/rocksdb_state_machine_test.rs
@@ -4,11 +4,7 @@ use crate::{Error, StateMachine};
 use async_trait::async_trait;
 use bytes::Bytes;
 use d_engine_core::state_machine_test::{StateMachineBuilder, StateMachineTestSuite};
-use d_engine_proto::client::WriteCommand;
-use d_engine_proto::client::write_command::{CompareAndSwap, Delete, Insert, Operation};
-use d_engine_proto::common::Entry;
-use d_engine_proto::common::entry_payload::Payload;
-use prost::Message;
+use d_engine_core::{ApplyEntry, Command};
 use std::sync::Arc;
 use std::sync::Mutex;
 use tempfile::TempDir;
@@ -102,26 +98,17 @@ async fn test_get_rejected_when_not_serving() {
     let test_key = b"test_key";
     let test_value = b"test_value";
 
-    let write_cmd = WriteCommand {
-        operation: Some(Operation::Insert(Insert {
-            key: test_key.to_vec().into(),
-            value: test_value.to_vec().into(),
-            ttl_secs: 0,
-        })),
-    };
-
-    let mut buf = Vec::new();
-    write_cmd.encode(&mut buf).expect("Failed to encode");
-
-    let entry = Entry {
+    let entry = ApplyEntry {
         index: 1,
         term: 1,
-        payload: Some(d_engine_proto::common::EntryPayload {
-            payload: Some(Payload::Command(buf.into())),
-        }),
+        command: Command::Insert {
+            key: Bytes::from(test_key.to_vec()),
+            value: Bytes::from(test_value.to_vec()),
+            ttl_secs: None,
+        },
     };
 
-    state_machine.apply_chunk(vec![entry]).await.expect("Failed to apply entry");
+    state_machine.apply_chunk(&[entry]).await.expect("Failed to apply entry");
 
     // Verify data exists before stopping
     let value = state_machine.get(test_key).expect("Failed to get");
@@ -168,10 +155,10 @@ async fn test_scan_prefix_returns_only_matching_keys() {
     let dir = tempfile::TempDir::new().unwrap();
     let (_storage, sm) = RocksDBUnifiedEngine::open(dir.path()).unwrap();
 
-    sm.apply_chunk(vec![
-        encode_insert_at(b"/services/node1", b"10.0.0.1", 1),
-        encode_insert_at(b"/services/node2", b"10.0.0.2", 2),
-        encode_insert_at(b"/other/key", b"must_not_appear", 3),
+    sm.apply_chunk(&[
+        insert_at(b"/services/node1", b"10.0.0.1", 1),
+        insert_at(b"/services/node2", b"10.0.0.2", 2),
+        insert_at(b"/other/key", b"must_not_appear", 3),
     ])
     .await
     .unwrap();
@@ -201,10 +188,10 @@ async fn test_scan_prefix_upper_bound_excludes_adjacent_namespace() {
     let dir = tempfile::TempDir::new().unwrap();
     let (_storage, sm) = RocksDBUnifiedEngine::open(dir.path()).unwrap();
 
-    sm.apply_chunk(vec![
-        encode_insert_at(b"/services/last", b"v", 1),
+    sm.apply_chunk(&[
+        insert_at(b"/services/last", b"v", 1),
         // '/t' > '/s' in byte order — sits right after '/services/' in the keyspace
-        encode_insert_at(b"/t/trap", b"must_not_appear", 2),
+        insert_at(b"/t/trap", b"must_not_appear", 2),
     ])
     .await
     .unwrap();
@@ -227,7 +214,7 @@ async fn test_scan_prefix_empty_namespace_returns_empty_vec() {
     let dir = tempfile::TempDir::new().unwrap();
     let (_storage, sm) = RocksDBUnifiedEngine::open(dir.path()).unwrap();
 
-    sm.apply_chunk(vec![encode_insert_at(b"/other/key", b"v", 1)]).await.unwrap();
+    sm.apply_chunk(&[insert_at(b"/other/key", b"v", 1)]).await.unwrap();
 
     let result = sm.scan_prefix(b"/missing/").unwrap();
 
@@ -250,10 +237,10 @@ async fn test_scan_prefix_revision_reflects_applied_index() {
     let (_storage, sm) = RocksDBUnifiedEngine::open(dir.path()).unwrap();
 
     // Apply 3 entries as a single chunk; last_applied_index becomes 3
-    sm.apply_chunk(vec![
-        encode_insert_at(b"/s/a", b"1", 1),
-        encode_insert_at(b"/s/b", b"2", 2),
-        encode_insert_at(b"/s/c", b"3", 3),
+    sm.apply_chunk(&[
+        insert_at(b"/s/a", b"1", 1),
+        insert_at(b"/s/b", b"2", 2),
+        insert_at(b"/s/c", b"3", 3),
     ])
     .await
     .unwrap();
@@ -284,9 +271,9 @@ async fn test_scan_prefix_0xff_suffix_carry_propagation() {
     let key: &[u8] = b"\x61\xFFnode";
     let decoy: &[u8] = b"\x62decoy"; // sits above [0x62], must not appear
 
-    sm.apply_chunk(vec![
-        encode_insert_at(key, b"value", 1),
-        encode_insert_at(decoy, b"must_not_appear", 2),
+    sm.apply_chunk(&[
+        insert_at(key, b"value", 1),
+        insert_at(decoy, b"must_not_appear", 2),
     ])
     .await
     .unwrap();
@@ -312,9 +299,7 @@ async fn test_scan_prefix_empty_prefix_returns_empty() {
     let dir = tempfile::TempDir::new().unwrap();
     let (_storage, sm) = RocksDBUnifiedEngine::open(dir.path()).unwrap();
 
-    sm.apply_chunk(vec![encode_insert_at(b"/services/node1", b"v", 1)])
-        .await
-        .unwrap();
+    sm.apply_chunk(&[insert_at(b"/services/node1", b"v", 1)]).await.unwrap();
 
     let result = sm.scan_prefix(b"").unwrap();
 
@@ -341,9 +326,9 @@ async fn test_scan_prefix_all_0xff_no_upper_bound() {
     let key: &[u8] = b"\xFF\xFF\x01";
     let decoy: &[u8] = b"\xFE\xAA"; // lexicographically below the prefix
 
-    sm.apply_chunk(vec![
-        encode_insert_at(key, b"top_value", 1),
-        encode_insert_at(decoy, b"must_not_appear", 2),
+    sm.apply_chunk(&[
+        insert_at(key, b"top_value", 1),
+        insert_at(decoy, b"must_not_appear", 2),
     ])
     .await
     .unwrap();
@@ -360,79 +345,66 @@ async fn test_scan_prefix_all_0xff_no_upper_bound() {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-fn encode_insert(
+fn insert_at(
+    key: &[u8],
+    value: &[u8],
+    index: u64,
+) -> ApplyEntry {
+    ApplyEntry {
+        index,
+        term: 1,
+        command: Command::Insert {
+            key: Bytes::copy_from_slice(key),
+            value: Bytes::copy_from_slice(value),
+            ttl_secs: None,
+        },
+    }
+}
+
+fn insert_with_ttl(
     key: &[u8],
     value: &[u8],
     ttl_secs: u64,
-) -> Entry {
-    let cmd = WriteCommand {
-        operation: Some(Operation::Insert(Insert {
-            key: key.to_vec().into(),
-            value: value.to_vec().into(),
-            ttl_secs,
-        })),
-    };
-    encode_entry(cmd, 1, 1)
-}
-
-/// Like encode_insert but with an explicit log index, required when placing
-/// multiple entries in a single apply_chunk call (indices must be strictly increasing).
-fn encode_insert_at(
-    key: &[u8],
-    value: &[u8],
     index: u64,
-) -> Entry {
-    let cmd = WriteCommand {
-        operation: Some(Operation::Insert(Insert {
-            key: key.to_vec().into(),
-            value: value.to_vec().into(),
-            ttl_secs: 0,
-        })),
-    };
-    encode_entry(cmd, index, 1)
+) -> ApplyEntry {
+    ApplyEntry {
+        index,
+        term: 1,
+        command: Command::Insert {
+            key: Bytes::copy_from_slice(key),
+            value: Bytes::copy_from_slice(value),
+            ttl_secs: if ttl_secs > 0 { Some(ttl_secs) } else { None },
+        },
+    }
 }
 
-fn encode_delete(
+fn delete_at(
     key: &[u8],
     index: u64,
-) -> Entry {
-    let cmd = WriteCommand {
-        operation: Some(Operation::Delete(Delete {
-            key: key.to_vec().into(),
-        })),
-    };
-    encode_entry(cmd, index, 1)
+) -> ApplyEntry {
+    ApplyEntry {
+        index,
+        term: 1,
+        command: Command::Delete {
+            key: Bytes::copy_from_slice(key),
+        },
+    }
 }
 
-fn encode_cas(
+fn cas_at(
     key: &[u8],
     expected: Option<&[u8]>,
     new_value: &[u8],
     index: u64,
-) -> Entry {
-    let cmd = WriteCommand {
-        operation: Some(Operation::CompareAndSwap(CompareAndSwap {
-            key: key.to_vec().into(),
-            expected_value: expected.map(|v| v.to_vec().into()),
-            new_value: new_value.to_vec().into(),
-        })),
-    };
-    encode_entry(cmd, index, 1)
-}
-
-fn encode_entry(
-    cmd: WriteCommand,
-    index: u64,
-    term: u64,
-) -> Entry {
-    let mut buf = Vec::new();
-    cmd.encode(&mut buf).expect("encode");
-    Entry {
+) -> ApplyEntry {
+    ApplyEntry {
         index,
-        term,
-        payload: Some(d_engine_proto::common::EntryPayload {
-            payload: Some(Payload::Command(buf.into())),
-        }),
+        term: 1,
+        command: Command::CompareAndSwap {
+            key: Bytes::copy_from_slice(key),
+            expected: expected.map(Bytes::copy_from_slice),
+            value: Bytes::copy_from_slice(new_value),
+        },
     }
 }
 
@@ -446,10 +418,10 @@ async fn test_apply_chunk_cas_match_succeeds_and_writes_new_value() {
     let (_storage, sm) = RocksDBUnifiedEngine::open(dir.path()).unwrap();
 
     // Pre-populate key
-    sm.apply_chunk(vec![encode_insert(b"k", b"old", 0)]).await.unwrap();
+    sm.apply_chunk(&[insert_with_ttl(b"k", b"old", 0, 1)]).await.unwrap();
 
     // CAS with matching expected value
-    let results = sm.apply_chunk(vec![encode_cas(b"k", Some(b"old"), b"new", 2)]).await.unwrap();
+    let results = sm.apply_chunk(&[cas_at(b"k", Some(b"old"), b"new", 2)]).await.unwrap();
 
     assert!(
         results[0].succeeded,
@@ -465,10 +437,10 @@ async fn test_apply_chunk_cas_mismatch_returns_failure_and_preserves_value() {
     let dir = tempfile::TempDir::new().unwrap();
     let (_storage, sm) = RocksDBUnifiedEngine::open(dir.path()).unwrap();
 
-    sm.apply_chunk(vec![encode_insert(b"k", b"current", 0)]).await.unwrap();
+    sm.apply_chunk(&[insert_with_ttl(b"k", b"current", 0, 1)]).await.unwrap();
 
     let results = sm
-        .apply_chunk(vec![encode_cas(b"k", Some(b"wrong_expected"), b"new", 2)])
+        .apply_chunk(&[cas_at(b"k", Some(b"wrong_expected"), b"new", 2)])
         .await
         .unwrap();
 
@@ -486,7 +458,7 @@ async fn test_apply_chunk_cas_none_expected_on_absent_key_succeeds() {
     let dir = tempfile::TempDir::new().unwrap();
     let (_storage, sm) = RocksDBUnifiedEngine::open(dir.path()).unwrap();
 
-    let results = sm.apply_chunk(vec![encode_cas(b"new_key", None, b"value", 1)]).await.unwrap();
+    let results = sm.apply_chunk(&[cas_at(b"new_key", None, b"value", 1)]).await.unwrap();
 
     assert!(
         results[0].succeeded,
@@ -501,9 +473,9 @@ async fn test_apply_chunk_cas_none_expected_on_existing_key_fails() {
     let dir = tempfile::TempDir::new().unwrap();
     let (_storage, sm) = RocksDBUnifiedEngine::open(dir.path()).unwrap();
 
-    sm.apply_chunk(vec![encode_insert(b"k", b"exists", 0)]).await.unwrap();
+    sm.apply_chunk(&[insert_with_ttl(b"k", b"exists", 0, 1)]).await.unwrap();
 
-    let results = sm.apply_chunk(vec![encode_cas(b"k", None, b"new", 2)]).await.unwrap();
+    let results = sm.apply_chunk(&[cas_at(b"k", None, b"new", 2)]).await.unwrap();
 
     assert!(
         !results[0].succeeded,
@@ -524,14 +496,14 @@ async fn test_apply_chunk_two_cas_same_key_second_must_see_first_write() {
     let dir = tempfile::TempDir::new().unwrap();
     let (_storage, sm) = RocksDBUnifiedEngine::open(dir.path()).unwrap();
 
-    sm.apply_chunk(vec![encode_insert(b"k", b"v0", 0)]).await.unwrap();
+    sm.apply_chunk(&[insert_with_ttl(b"k", b"v0", 0, 1)]).await.unwrap();
 
     // CAS1: v0 → v1  (should succeed)
     // CAS2: v0 → v2  (must fail — CAS1 already changed value to v1)
     let results = sm
-        .apply_chunk(vec![
-            encode_cas(b"k", Some(b"v0"), b"v1", 2),
-            encode_cas(b"k", Some(b"v0"), b"v2", 3),
+        .apply_chunk(&[
+            cas_at(b"k", Some(b"v0"), b"v1", 2),
+            cas_at(b"k", Some(b"v0"), b"v2", 3),
         ])
         .await
         .unwrap();
@@ -554,8 +526,8 @@ async fn test_apply_chunk_delete_removes_key() {
     let dir = tempfile::TempDir::new().unwrap();
     let (_storage, sm) = RocksDBUnifiedEngine::open(dir.path()).unwrap();
 
-    sm.apply_chunk(vec![encode_insert(b"to_delete", b"v", 0)]).await.unwrap();
-    sm.apply_chunk(vec![encode_delete(b"to_delete", 2)]).await.unwrap();
+    sm.apply_chunk(&[insert_with_ttl(b"to_delete", b"v", 0, 1)]).await.unwrap();
+    sm.apply_chunk(&[delete_at(b"to_delete", 2)]).await.unwrap();
 
     assert_eq!(sm.get(b"to_delete").unwrap(), None);
 }
@@ -574,7 +546,7 @@ async fn test_apply_chunk_returns_error_on_read_only_db() {
     let (_storage, sm) = RocksDBUnifiedEngine::open(&db_path).unwrap();
 
     // Confirm the state machine works normally first
-    sm.apply_chunk(vec![encode_insert(b"k", b"v", 0)]).await.unwrap();
+    sm.apply_chunk(&[insert_with_ttl(b"k", b"v", 0, 1)]).await.unwrap();
 
     // Open the same DB as read-only and inject it — writes will now return NotSupported
     let ro_db = DB::open_cf_for_read_only(
@@ -587,7 +559,7 @@ async fn test_apply_chunk_returns_error_on_read_only_db() {
     sm.swap_db_for_test(ro_db);
 
     // Write to a read-only DB must fail
-    let result = sm.apply_chunk(vec![encode_insert(b"k2", b"v2", 0)]).await;
+    let result = sm.apply_chunk(&[insert_with_ttl(b"k2", b"v2", 0, 2)]).await;
     assert!(
         result.is_err(),
         "apply_chunk should return Err when DB is read-only"

--- a/d-engine-server/src/storage/lease_integration_test.rs
+++ b/d-engine-server/src/storage/lease_integration_test.rs
@@ -419,21 +419,22 @@ mod file_state_machine_tests {
         }
     }
 
-    /// Test: WAL replay handles incomplete entries gracefully
+    /// WAL replay stops at the first truncated entry and discards the tail.
     ///
-    /// Verifies that if WAL file is corrupted or has incomplete entries (e.g., missing
-    /// expiration field), the system doesn't crash and treats the entry as permanent (no TTL).
+    /// A WAL tail truncation is the expected outcome of a crash mid-write. Per the same
+    /// principle used by etcd and TiKV, replay stops at the first incomplete entry rather
+    /// than continuing with garbage bytes or silently loading a partial entry with wrong TTL.
+    /// Complete entries before the truncation point are applied; the truncated entry and
+    /// anything after it are dropped.
     #[tokio::test]
     async fn test_wal_replay_handles_incomplete_entries() {
         let temp_dir = TempDir::new().unwrap();
         let state_machine_path = temp_dir.path().to_path_buf();
 
-        // Manually create a WAL file with incomplete entry (missing expire_at field)
-        // Format: [op_code(1), term(8), key_len(8), key, value_len(8), value, (missing expire_at)]
         let wal_path = state_machine_path.join("wal.log");
         let mut wal_data = Vec::new();
 
-        // Complete entry first
+        // Complete entry — must survive replay
         wal_data.extend_from_slice(&1u64.to_be_bytes()); // index
         wal_data.extend_from_slice(&1u64.to_be_bytes()); // term
         wal_data.push(1u8); // Insert
@@ -443,7 +444,7 @@ mod file_state_machine_tests {
         wal_data.extend_from_slice(b"value1"); // value
         wal_data.extend_from_slice(&0u64.to_be_bytes()); // expire_at = 0 (no TTL)
 
-        // Incomplete entry (missing expire_at field)
+        // Truncated entry: missing expire_at — must be discarded, replay stops here
         wal_data.extend_from_slice(&2u64.to_be_bytes()); // index
         wal_data.extend_from_slice(&1u64.to_be_bytes()); // term
         wal_data.push(1u8); // Insert
@@ -451,20 +452,22 @@ mod file_state_machine_tests {
         wal_data.extend_from_slice(b"incomplete"); // key
         wal_data.extend_from_slice(&6u64.to_be_bytes()); // value_len
         wal_data.extend_from_slice(b"value2"); // value
-        // Missing expire_at field (should be 8 bytes)
+        // expire_at deliberately omitted — simulates crash mid-write
 
         std::fs::write(&wal_path, wal_data).unwrap();
 
-        // Create new state machine instance to trigger WAL replay
+        // Replay must succeed (truncated tail is not a fatal error)
         let sm = FileStateMachine::new(state_machine_path.clone()).await.unwrap();
 
-        // Should have loaded the complete entry
-        let result = sm.get(b"complete").unwrap();
-        assert_eq!(result, Some(Bytes::from("value1")));
+        // Complete entry is applied
+        assert_eq!(sm.get(b"complete").unwrap(), Some(Bytes::from("value1")));
 
-        // Incomplete entry should be loaded as permanent (no TTL) rather than being skipped
-        let result = sm.get(b"incomplete").unwrap();
-        assert_eq!(result, Some(Bytes::from("value2")));
+        // Truncated entry is dropped — replay stopped before applying it
+        assert_eq!(
+            sm.get(b"incomplete").unwrap(),
+            None,
+            "Truncated WAL tail must be discarded, not loaded with assumed TTL"
+        );
     }
 
     /// Test: WAL replay with only expired entries results in empty state

--- a/d-engine-server/src/storage/lease_integration_test.rs
+++ b/d-engine-server/src/storage/lease_integration_test.rs
@@ -104,14 +104,7 @@ mod file_state_machine_tests {
     use std::time::Duration;
 
     use bytes::Bytes;
-    use d_engine_core::StateMachine;
-    use d_engine_proto::client::WriteCommand;
-    use d_engine_proto::client::write_command::Insert;
-    use d_engine_proto::client::write_command::Operation;
-    use d_engine_proto::common::Entry;
-    use d_engine_proto::common::EntryPayload;
-    use d_engine_proto::common::entry_payload::Payload;
-    use prost::Message;
+    use d_engine_core::{ApplyEntry, Command, StateMachine};
     use tempfile::TempDir;
     use tokio::time::sleep;
 
@@ -130,30 +123,21 @@ mod file_state_machine_tests {
         sm
     }
 
-    /// Helper to create an entry with Insert command
     fn create_insert_entry(
         index: u64,
         term: u64,
         key: &[u8],
         value: &[u8],
         ttl_secs: u64,
-    ) -> Entry {
-        let insert = Insert {
-            key: Bytes::from(key.to_vec()),
-            value: Bytes::from(value.to_vec()),
-            ttl_secs,
-        };
-        let write_cmd = WriteCommand {
-            operation: Some(Operation::Insert(insert)),
-        };
-        let payload = Payload::Command(write_cmd.encode_to_vec().into());
-
-        Entry {
+    ) -> ApplyEntry {
+        ApplyEntry {
             index,
             term,
-            payload: Some(EntryPayload {
-                payload: Some(payload),
-            }),
+            command: Command::Insert {
+                key: Bytes::copy_from_slice(key),
+                value: Bytes::copy_from_slice(value),
+                ttl_secs: if ttl_secs > 0 { Some(ttl_secs) } else { None },
+            },
         }
     }
 
@@ -170,7 +154,7 @@ mod file_state_machine_tests {
 
         // Insert key with 2 second TTL
         let entry = create_insert_entry(1, 1, b"ttl_key", b"ttl_value", 2);
-        sm.apply_chunk(vec![entry]).await.unwrap();
+        sm.apply_chunk(&[entry]).await.unwrap();
 
         // Key should exist immediately
         let value = sm.get(b"ttl_key").unwrap();
@@ -203,7 +187,7 @@ mod file_state_machine_tests {
 
         // Insert key with 3600 second TTL (won't expire during test)
         let entry = create_insert_entry(1, 1, b"persistent_key", b"persistent_value", 3600);
-        sm.apply_chunk(vec![entry]).await.unwrap();
+        sm.apply_chunk(&[entry]).await.unwrap();
 
         // Create snapshot
         let snapshot_dir = temp_dir.path().join("snapshot");
@@ -257,7 +241,7 @@ mod file_state_machine_tests {
             let entry2 = create_insert_entry(2, 1, b"long_ttl_key", b"value2", 3600);
             let entry3 = create_insert_entry(3, 1, b"no_ttl_key", b"value3", 0);
 
-            sm.apply_chunk(vec![entry1, entry2, entry3]).await.unwrap();
+            sm.apply_chunk(&[entry1, entry2, entry3]).await.unwrap();
 
             // Verify all keys exist
             assert_eq!(
@@ -322,11 +306,11 @@ mod file_state_machine_tests {
 
         // Insert key with 2 second TTL
         let entry1 = create_insert_entry(1, 1, b"update_key", b"value1", 2);
-        sm.apply_chunk(vec![entry1]).await.unwrap();
+        sm.apply_chunk(&[entry1]).await.unwrap();
 
         // Immediately update with longer TTL
         let entry2 = create_insert_entry(2, 1, b"update_key", b"value2", 10);
-        sm.apply_chunk(vec![entry2]).await.unwrap();
+        sm.apply_chunk(&[entry2]).await.unwrap();
 
         // Wait past original TTL
         sleep(Duration::from_secs(3)).await;
@@ -364,7 +348,7 @@ mod file_state_machine_tests {
             // Insert key with no TTL
             let entry3 = create_insert_entry(3, 1, b"permanent_key", b"value3", 0);
 
-            sm.apply_chunk(vec![entry1, entry2, entry3]).await.unwrap();
+            sm.apply_chunk(&[entry1, entry2, entry3]).await.unwrap();
 
             // Verify all keys exist immediately after write
             assert_eq!(sm.get(b"expired_key").unwrap(), Some(Bytes::from("value1")));
@@ -613,7 +597,7 @@ mod file_state_machine_tests {
         for i in 0..20 {
             let key = format!("bg_key_{}", i);
             let entry = create_insert_entry(i + 1, 1, key.as_bytes(), b"value", 1);
-            sm.apply_chunk(vec![entry]).await.unwrap();
+            sm.apply_chunk(&[entry]).await.unwrap();
         }
 
         // All keys should exist immediately
@@ -666,7 +650,7 @@ mod file_state_machine_tests {
         for i in 0..100 {
             let key = format!("duration_key_{}", i);
             let entry = create_insert_entry(i + 1, 1, key.as_bytes(), b"value", 1);
-            sm.apply_chunk(vec![entry]).await.unwrap();
+            sm.apply_chunk(&[entry]).await.unwrap();
         }
 
         // Wait for expiration
@@ -698,15 +682,7 @@ mod rocksdb_state_machine_tests {
     use std::time::Duration;
 
     use bytes::Bytes;
-    use d_engine_core::StateMachine;
-    use d_engine_proto::client::WriteCommand;
-    use d_engine_proto::client::write_command::Delete;
-    use d_engine_proto::client::write_command::Insert;
-    use d_engine_proto::client::write_command::Operation;
-    use d_engine_proto::common::Entry;
-    use d_engine_proto::common::EntryPayload;
-    use d_engine_proto::common::entry_payload::Payload;
-    use prost::Message;
+    use d_engine_core::{ApplyEntry, Command, StateMachine};
     use tempfile::TempDir;
     use tokio::time::sleep;
 
@@ -727,53 +703,35 @@ mod rocksdb_state_machine_tests {
         (storage, sm)
     }
 
-    /// Helper to create an entry with Insert command
     fn create_insert_entry(
         index: u64,
         term: u64,
         key: &[u8],
         value: &[u8],
         ttl_secs: u64,
-    ) -> Entry {
-        let insert = Insert {
-            key: Bytes::from(key.to_vec()),
-            value: Bytes::from(value.to_vec()),
-            ttl_secs,
-        };
-        let write_cmd = WriteCommand {
-            operation: Some(Operation::Insert(insert)),
-        };
-        let payload = Payload::Command(write_cmd.encode_to_vec().into());
-
-        Entry {
+    ) -> ApplyEntry {
+        ApplyEntry {
             index,
             term,
-            payload: Some(EntryPayload {
-                payload: Some(payload),
-            }),
+            command: Command::Insert {
+                key: Bytes::copy_from_slice(key),
+                value: Bytes::copy_from_slice(value),
+                ttl_secs: if ttl_secs > 0 { Some(ttl_secs) } else { None },
+            },
         }
     }
 
-    /// Helper to create an entry with Delete command
     fn create_delete_entry(
         index: u64,
         term: u64,
         key: &[u8],
-    ) -> Entry {
-        let delete = Delete {
-            key: Bytes::from(key.to_vec()),
-        };
-        let write_cmd = WriteCommand {
-            operation: Some(Operation::Delete(delete)),
-        };
-        let payload = Payload::Command(write_cmd.encode_to_vec().into());
-
-        Entry {
+    ) -> ApplyEntry {
+        ApplyEntry {
             index,
             term,
-            payload: Some(EntryPayload {
-                payload: Some(payload),
-            }),
+            command: Command::Delete {
+                key: Bytes::copy_from_slice(key),
+            },
         }
     }
 
@@ -791,7 +749,7 @@ mod rocksdb_state_machine_tests {
 
         // Insert key with 2 second TTL
         let entry = create_insert_entry(1, 1, b"ttl_key", b"ttl_value", 2);
-        sm.apply_chunk(vec![entry]).await.unwrap();
+        sm.apply_chunk(&[entry]).await.unwrap();
 
         // Key should exist immediately
         let value = sm.get(b"ttl_key").unwrap();
@@ -825,7 +783,7 @@ mod rocksdb_state_machine_tests {
 
         // Insert key with 3600 second TTL (won't expire during test)
         let entry = create_insert_entry(1, 1, b"persistent_key", b"persistent_value", 3600);
-        sm.apply_chunk(vec![entry]).await.unwrap();
+        sm.apply_chunk(&[entry]).await.unwrap();
 
         // Create snapshot
         let snapshot_dir = temp_dir.path().join("snapshot");
@@ -877,18 +835,18 @@ mod rocksdb_state_machine_tests {
 
         // Insert key with 2 second TTL
         let entry1 = create_insert_entry(1, 1, b"update_key", b"value1", 2);
-        sm.apply_chunk(vec![entry1]).await.unwrap();
+        sm.apply_chunk(&[entry1]).await.unwrap();
 
         // Immediately update with longer TTL
         let entry2 = create_insert_entry(2, 1, b"update_key", b"value2", 10);
-        sm.apply_chunk(vec![entry2]).await.unwrap();
+        sm.apply_chunk(&[entry2]).await.unwrap();
 
         // Wait past original TTL
         sleep(Duration::from_secs(3)).await;
 
         // Trigger expiration check
         let entry3 = create_insert_entry(3, 1, b"trigger", b"trigger", 0);
-        sm.apply_chunk(vec![entry3]).await.unwrap();
+        sm.apply_chunk(&[entry3]).await.unwrap();
 
         // Key should still exist (new TTL not expired)
         let value = sm.get(b"update_key").unwrap();
@@ -909,11 +867,11 @@ mod rocksdb_state_machine_tests {
 
         // Insert key with TTL
         let entry1 = create_insert_entry(1, 1, b"delete_key", b"delete_value", 3600);
-        sm.apply_chunk(vec![entry1]).await.unwrap();
+        sm.apply_chunk(&[entry1]).await.unwrap();
 
         // Delete the key
         let entry2 = create_delete_entry(2, 1, b"delete_key");
-        sm.apply_chunk(vec![entry2]).await.unwrap();
+        sm.apply_chunk(&[entry2]).await.unwrap();
 
         // Key should not exist
         let value = sm.get(b"delete_key").unwrap();
@@ -922,7 +880,7 @@ mod rocksdb_state_machine_tests {
         // Even after waiting, no expiration should occur (TTL was unregistered)
         sleep(Duration::from_secs(2)).await;
         let entry3 = create_insert_entry(3, 1, b"trigger", b"trigger", 0);
-        sm.apply_chunk(vec![entry3]).await.unwrap();
+        sm.apply_chunk(&[entry3]).await.unwrap();
     }
 
     #[tokio::test]
@@ -942,7 +900,7 @@ mod rocksdb_state_machine_tests {
         let entry2 = create_insert_entry(2, 1, b"key_5sec", b"value2", 5);
         let entry3 = create_insert_entry(3, 1, b"key_no_ttl", b"value3", 0);
 
-        sm.apply_chunk(vec![entry1, entry2, entry3]).await.unwrap();
+        sm.apply_chunk(&[entry1, entry2, entry3]).await.unwrap();
 
         // All keys should exist initially
         assert_eq!(sm.get(b"key_1sec").unwrap(), Some(Bytes::from("value1")));
@@ -995,7 +953,7 @@ mod rocksdb_state_machine_tests {
             let entry2 = create_insert_entry(2, 1, b"long_ttl_key", b"value2", 3600);
             let entry3 = create_insert_entry(3, 1, b"no_ttl_key", b"value3", 0);
 
-            sm.apply_chunk(vec![entry1, entry2, entry3]).await.unwrap();
+            sm.apply_chunk(&[entry1, entry2, entry3]).await.unwrap();
 
             // Verify all keys exist
             assert_eq!(
@@ -1063,7 +1021,7 @@ mod rocksdb_state_machine_tests {
         // Insert keys with TTL
         let entry1 = create_insert_entry(1, 1, b"key1", b"value1", 3600);
         let entry2 = create_insert_entry(2, 1, b"key2", b"value2", 7200);
-        sm.apply_chunk(vec![entry1, entry2]).await.unwrap();
+        sm.apply_chunk(&[entry1, entry2]).await.unwrap();
 
         // Reset the state machine
         sm.reset().await.unwrap();
@@ -1088,7 +1046,7 @@ mod rocksdb_state_machine_tests {
     //
     //         // Insert key with 1 second TTL
     //         let entry = create_insert_entry(1, 1, b"passive_key", b"passive_value", 1);
-    //         sm.apply_chunk(vec![entry]).await.unwrap();
+    //         sm.apply_chunk(&[entry]).await.unwrap();
     //
     //         // Key should exist immediately
     //         let value = sm.get(b"passive_key").unwrap();
@@ -1119,13 +1077,13 @@ mod rocksdb_state_machine_tests {
     //         for i in 0..10 {
     //             let key = format!("no_ttl_key_{i}");
     //             let entry = create_insert_entry(i + 1, 1, key.as_bytes(), b"value", 0);
-    //             sm.apply_chunk(vec![entry]).await.unwrap();
+    //             sm.apply_chunk(&[entry]).await.unwrap();
     //         }
     //
     //         // Apply 150 more entries (should trigger piggyback cleanup check)
     //         for i in 10..160 {
     //             let entry = create_insert_entry(i + 1, 1, b"dummy", b"dummy", 0);
-    //             sm.apply_chunk(vec![entry]).await.unwrap();
+    //             sm.apply_chunk(&[entry]).await.unwrap();
     //         }
     //
     //         // All keys should still exist (no TTL, lazy activation should skip cleanup)

--- a/d-engine-server/src/test_utils/integration/mod.rs
+++ b/d-engine-server/src/test_utils/integration/mod.rs
@@ -42,6 +42,7 @@ use std::ops::RangeInclusive;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use bytes::Bytes;
 use d_engine_core::DefaultStateMachineHandler;
 use d_engine_core::ElectionHandler;
 use d_engine_core::FlushPolicy;
@@ -61,6 +62,7 @@ use d_engine_core::alias::SMOF;
 use d_engine_core::alias::TROF;
 use d_engine_core::generate_delete_commands;
 use d_engine_core::generate_insert_commands;
+use d_engine_core::{ApplyEntry, Command};
 use d_engine_proto::common::Entry;
 use d_engine_proto::common::EntryPayload;
 use d_engine_proto::common::NodeRole::Follower;
@@ -323,14 +325,17 @@ pub(crate) async fn insert_state_machine(
 ) {
     let mut entries = Vec::new();
     for id in ids {
-        let log = Entry {
+        entries.push(ApplyEntry {
             index: id,
             term,
-            payload: Some(EntryPayload::command(generate_insert_commands(vec![id]))),
-        };
-        entries.push(log);
+            command: Command::Insert {
+                key: Bytes::from(id.to_be_bytes().to_vec()),
+                value: Bytes::from(id.to_be_bytes().to_vec()),
+                ttl_secs: None,
+            },
+        });
     }
-    if let Err(e) = state_machine.apply_chunk(entries).await {
+    if let Err(e) = state_machine.apply_chunk(&entries).await {
         panic!("error: {e:?}");
     }
 }

--- a/d-engine/src/docs/server_guide/customize-state-machine.md
+++ b/d-engine/src/docs/server_guide/customize-state-machine.md
@@ -53,19 +53,29 @@ impl StateMachine for CustomStateMachine {
         // The framework pre-decodes proto bytes — match on Command directly, no prost needed.
         let mut results = Vec::with_capacity(chunk.len());
         for entry in chunk {
-            match &entry.command {
+            let result = match &entry.command {
                 Command::Insert { key, value, ttl_secs } => {
                     self.backend.put(key, value, *ttl_secs)?;
+                    ApplyResult::success(entry.index)
                 }
                 Command::Delete { key } => {
                     self.backend.delete(key)?;
+                    ApplyResult::success(entry.index)
                 }
                 Command::CompareAndSwap { key, expected, value } => {
-                    self.backend.cas(key, expected.as_deref(), value)?;
+                    // CAS must return failure when the comparison does not match.
+                    // Callers (e.g. client CAS requests) inspect ApplyResult::succeeded
+                    // to determine whether the swap actually took effect.
+                    let succeeded = self.backend.cas(key, expected.as_deref(), value)?;
+                    if succeeded {
+                        ApplyResult::success(entry.index)
+                    } else {
+                        ApplyResult::failure(entry.index)
+                    }
                 }
-                Command::Noop => {}
-            }
-            results.push(ApplyResult::success(entry.index));
+                Command::Noop => ApplyResult::success(entry.index),
+            };
+            results.push(result);
         }
         Ok(results)
     }

--- a/d-engine/src/docs/server_guide/customize-state-machine.md
+++ b/d-engine/src/docs/server_guide/customize-state-machine.md
@@ -12,7 +12,7 @@ d-engine supports **pluggable state machines** through the `StateMachine` trait.
 ## 1. Implement the Trait
 
 ```rust,ignore
-use d_engine::{StateMachine, Result, Entry, LogId, SnapshotMetadata};
+use d_engine::{ApplyEntry, ApplyResult, Command, Error, LogId, SnapshotMetadata, StateMachine};
 use async_trait::async_trait;
 
 struct CustomStateMachine {
@@ -49,13 +49,25 @@ impl StateMachine for CustomStateMachine {
         Some(1)
     }
 
-    async fn apply_chunk(&self, chunk: Vec<Entry>) -> Result<()> {
-        // Deserialize and process entries
+    async fn apply_chunk(&self, chunk: &[ApplyEntry]) -> Result<Vec<ApplyResult>, Error> {
+        // The framework pre-decodes proto bytes — match on Command directly, no prost needed.
+        let mut results = Vec::with_capacity(chunk.len());
         for entry in chunk {
-            let cmd: AppCommand = bincode::deserialize(&entry.data)?;
-            self.backend.execute(cmd)?;
+            match &entry.command {
+                Command::Insert { key, value, ttl_secs } => {
+                    self.backend.put(key, value, *ttl_secs)?;
+                }
+                Command::Delete { key } => {
+                    self.backend.delete(key)?;
+                }
+                Command::CompareAndSwap { key, expected, value } => {
+                    self.backend.cas(key, expected.as_deref(), value)?;
+                }
+                Command::Noop => {}
+            }
+            results.push(ApplyResult::success(entry.index));
         }
-        Ok(())
+        Ok(results)
     }
 
     fn len(&self) -> usize {
@@ -135,7 +147,7 @@ async fn test_custom_state_machine() -> Result<(), Error> {
 
     // Test apply_chunk with sample entries
     let entries = vec![create_test_entry(1, 1)];
-    sm.apply_chunk(entries).await?;
+    sm.apply_chunk(&entries).await?;
     assert_eq!(sm.len(), 1);
 
     // Test snapshot operations

--- a/deny.toml
+++ b/deny.toml
@@ -218,6 +218,11 @@ skip = [
     { crate = "windows-sys@0.52.0", reason = "transitive dep of ring 0.17 and socket2 0.5" },
     # bindgen (rocksdb build dep) pins itertools 0.13
     { crate = "itertools@0.13.0", reason = "bindgen (rocksdb build dep) pins itertools 0.13" },
+    # tempfile/uuid pull getrandom 0.4.x while rand_core 0.9 still requires 0.3.x
+    { crate = "getrandom@0.4.2", reason = "tempfile 3.27 and uuid 1.x use getrandom 0.4; rand_core 0.9 pins 0.3" },
+    # getrandom 0.3.x→wasip2 and 0.4.x→wasip3 pull different wit-bindgen versions
+    { crate = "wit-bindgen@0.51.0", reason = "transitive dep of getrandom 0.4.x via wasip3" },
+    { crate = "wit-bindgen@0.57.1", reason = "transitive dep of getrandom 0.3.x via wasip2" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive

--- a/examples/sled-cluster/Cargo.toml
+++ b/examples/sled-cluster/Cargo.toml
@@ -28,6 +28,7 @@ sha2 = "0.10"
 uuid = { version = "1.4", features = ["v4"] }
 
 [dev-dependencies]
+d-engine = { path = "../../d-engine", features = ["server", "__test_support"], default-features = false }
 tempfile = "3.19"
 mockall = "0.12"
 tracing-test = "0.2"

--- a/examples/sled-cluster/src/lib.rs
+++ b/examples/sled-cluster/src/lib.rs
@@ -12,6 +12,8 @@ use tokio::fs;
 
 #[cfg(test)]
 mod sled_engine_test;
+#[cfg(test)]
+mod state_machine;
 
 pub(crate) async fn compute_checksum_from_folder_path(
     folder_path: &Path

--- a/examples/sled-cluster/src/sled_state_machine.rs
+++ b/examples/sled-cluster/src/sled_state_machine.rs
@@ -5,16 +5,11 @@ use async_trait::async_trait;
 use bincode::config;
 use bytes::Bytes;
 use d_engine::{
-    ApplyResult, Result, ScanResult, SnapshotError, StateMachine, StorageError,
-    client::{
-        WriteCommand,
-        write_command::{CompareAndSwap, Delete, Insert, Operation},
-    },
-    common::{Entry, LogId, entry_payload::Payload},
+    ApplyEntry, ApplyResult, Command, Result, ScanResult, SnapshotError, StateMachine, StorageError,
+    common::LogId,
     server_storage::SnapshotMetadata,
 };
 use parking_lot::Mutex;
-use prost::Message;
 use sled::Batch;
 use std::path::Path;
 use std::path::PathBuf;
@@ -29,7 +24,6 @@ use tracing::error;
 use tracing::info;
 use tracing::instrument;
 use tracing::trace;
-use tracing::warn;
 
 use crate::compute_checksum_from_folder_path;
 use crate::{safe_kv, safe_vk, safe_vk_ivec};
@@ -188,20 +182,15 @@ impl StateMachine for SledStateMachine {
         }
     }
 
-    async fn apply_chunk(
-        &self,
-        chunk: Vec<Entry>,
-    ) -> Result<Vec<ApplyResult>> {
+    async fn apply_chunk(&self, chunk: &[ApplyEntry]) -> Result<Vec<ApplyResult>> {
         trace!("Applying chunk: {} entries", chunk.len());
 
-        let mut highest_index_entry: Option<LogId> = None;
+        let mut highest_log_id: Option<LogId> = None;
         let mut batch = Batch::default();
         let mut results = Vec::with_capacity(chunk.len());
 
         for entry in chunk {
-            assert!(entry.payload.is_some(), "Entry payload should not be None!");
-
-            if let Some(prev) = highest_index_entry {
+            if let Some(prev) = &highest_log_id {
                 assert!(
                     entry.index > prev.index,
                     "apply_chunk: received unordered entry at index {} (prev={})",
@@ -209,83 +198,51 @@ impl StateMachine for SledStateMachine {
                     prev.index
                 );
             }
-            highest_index_entry = Some(LogId {
-                index: entry.index,
-                term: entry.term,
-            });
+            highest_log_id = Some(LogId { index: entry.index, term: entry.term });
 
-            match entry.payload.unwrap().payload {
-                Some(Payload::Noop(_)) => {
+            match &entry.command {
+                Command::Noop => {
                     debug!("NOOP at index {}", entry.index);
                     results.push(ApplyResult::success(entry.index));
                 }
-                Some(Payload::Command(data)) => {
-                    match WriteCommand::decode(&data[..]) {
-                        Ok(write_cmd) => match write_cmd.operation {
-                            Some(Operation::Insert(Insert {
-                                key,
-                                value,
-                                ttl_secs: _,
-                            })) => {
-                                batch.insert(key.as_ref(), value.as_ref());
-                                results.push(ApplyResult::success(entry.index));
-                            }
-                            Some(Operation::Delete(Delete { key })) => {
-                                batch.remove(key.as_ref());
-                                results.push(ApplyResult::success(entry.index));
-                            }
-                            Some(Operation::CompareAndSwap(CompareAndSwap {
-                                key,
-                                expected_value,
-                                new_value,
-                            })) => {
-                                // Flush pending batch before CAS (Sled batch doesn't support atomic CAS)
-                                self.apply_batch(std::mem::take(&mut batch))?;
-
-                                // Perform native Sled CAS
-                                let tree = self.current_tree();
-                                let old = expected_value.as_ref().map(|v| v.as_ref());
-
-                                let cas_success = match tree.compare_and_swap(
-                                    &key,
-                                    old,
-                                    Some(new_value.as_ref()),
-                                ) {
-                                    Ok(Ok(_)) => true,
-                                    Ok(Err(_)) => false,
-                                    Err(e) => {
-                                        error!("CAS error at index {}: {:?}", entry.index, e);
-                                        return Err(StorageError::DbError(e.to_string()).into());
-                                    }
-                                };
-
-                                results.push(if cas_success {
-                                    ApplyResult::success(entry.index)
-                                } else {
-                                    ApplyResult::failure(entry.index)
-                                });
-
-                                debug!(
-                                    "CAS at index {}: key={:?}, success={}",
-                                    entry.index,
-                                    String::from_utf8_lossy(&key),
-                                    cas_success
-                                );
-                            }
-                            None => {
-                                warn!("WriteCommand without operation at index {}", entry.index);
-                            }
-                        },
-                        Err(e) => {
-                            error!("Decode error at index {}: {}", entry.index, e);
-                            return Err(StorageError::SerializationError(e.to_string()).into());
-                        }
-                    }
+                Command::Insert { key, value, .. } => {
+                    batch.insert(key.as_ref(), value.as_ref());
+                    results.push(ApplyResult::success(entry.index));
                 }
-                Some(Payload::Config(_)) => {
-                    debug!("Config change at index {} (ignored)", entry.index);
+                Command::Delete { key } => {
+                    batch.remove(key.as_ref());
+                    results.push(ApplyResult::success(entry.index));
                 }
-                None => panic!("Entry payload should not be None!"),
+                Command::CompareAndSwap { key, expected, value: new_value } => {
+                    // Flush pending batch before CAS (Sled batch doesn't support atomic CAS)
+                    self.apply_batch(std::mem::take(&mut batch))?;
+
+                    // Perform native Sled CAS
+                    let tree = self.current_tree();
+                    let old = expected.as_ref().map(|v| v.as_ref());
+
+                    let cas_success =
+                        match tree.compare_and_swap(key.as_ref(), old, Some(new_value.as_ref())) {
+                            Ok(Ok(_)) => true,
+                            Ok(Err(_)) => false,
+                            Err(e) => {
+                                error!("CAS error at index {}: {:?}", entry.index, e);
+                                return Err(StorageError::DbError(e.to_string()).into());
+                            }
+                        };
+
+                    debug!(
+                        "CAS at index {}: key={:?}, success={}",
+                        entry.index,
+                        String::from_utf8_lossy(key),
+                        cas_success
+                    );
+                    results.push(if cas_success {
+                        ApplyResult::success(entry.index)
+                    } else {
+                        ApplyResult::failure(entry.index)
+                    });
+                }
             }
         }
 
@@ -293,7 +250,7 @@ impl StateMachine for SledStateMachine {
         self.apply_batch(batch)?;
 
         // Update last applied index
-        if let Some(log_id) = highest_index_entry {
+        if let Some(log_id) = highest_log_id {
             self.update_last_applied(log_id);
         }
 
@@ -392,38 +349,26 @@ impl StateMachine for SledStateMachine {
         let mut batch = sled::Batch::default();
         let mut counter = 0;
 
+        // Copy all current data. Keys are arbitrary bytes — we cannot interpret them
+        // as log indices. The SM already reflects state at last_included.index, so
+        // all current entries are valid snapshot content.
         for item in exist_db_tree.iter() {
             let (k, v) = item.map_err(|e| StorageError::DbError(e.to_string()))?;
-
-            let key_num = match safe_vk(&k) {
-                Ok(v) => v,
-                Err(e) => {
-                    error!(?e, "generate_snapshot_data::safe_vk");
-                    return Err(e.into());
-                }
-            };
-            if key_num > last_included.index {
-                break; // Stop applying further entries as they will all be greater
-            }
 
             batch.insert(k, v);
             counter += 1;
 
-            // Perform a batch insert every 100 records
             if counter % 100 == 0 {
                 new_state_machine_tree
                     .apply_batch(batch)
                     .map_err(|e| StorageError::DbError(e.to_string()))?;
-                batch = sled::Batch::default(); // Reset the batch object
+                batch = sled::Batch::default();
             }
         }
 
-        // Process the remaining data (the tail data of less than 100 records)
-        if counter % 100 != 0 {
-            new_state_machine_tree
-                .apply_batch(batch)
-                .map_err(|e| StorageError::DbError(e.to_string()))?;
-        }
+        new_state_machine_tree
+            .apply_batch(batch)
+            .map_err(|e| StorageError::DbError(e.to_string()))?;
 
         // Make sure flush into disk
         new_db.flush().map_err(|e| StorageError::DbError(e.to_string()))?;
@@ -543,7 +488,17 @@ impl StateMachine for SledStateMachine {
 
     async fn reset(&self) -> Result<()> {
         let db = self.db.load();
-        db.clear().map_err(|e| StorageError::DbError(e.to_string()))?;
+        for tree_name in &[STATE_MACHINE_TREE, STATE_MACHINE_META_NAMESPACE, STATE_SNAPSHOT_METADATA_TREE] {
+            db.open_tree(tree_name)
+                .map_err(|e| StorageError::DbError(e.to_string()))?
+                .clear()
+                .map_err(|e| StorageError::DbError(e.to_string()))?;
+        }
+        self.last_applied_index.store(0, Ordering::SeqCst);
+        self.last_applied_term.store(0, Ordering::SeqCst);
+        self.last_included_index.store(0, Ordering::SeqCst);
+        self.last_included_term.store(0, Ordering::SeqCst);
+        *self.last_snapshot_checksum.lock() = None;
         Ok(())
     }
 

--- a/examples/sled-cluster/src/state_machine/mod.rs
+++ b/examples/sled-cluster/src/state_machine/mod.rs
@@ -1,7 +1,2 @@
-mod sled_state_machine;
-// mod snapshot_assembler;
-
-pub use sled_state_machine::*;
-
 #[cfg(test)]
 mod sled_state_machine_test;

--- a/examples/sled-cluster/src/state_machine/sled_state_machine_test.rs
+++ b/examples/sled-cluster/src/state_machine/sled_state_machine_test.rs
@@ -1,676 +1,179 @@
-use std::path::PathBuf;
+//! Validates SledStateMachine against the standard StateMachine test suite.
+//!
+//! All custom state machines must pass StateMachineTestSuite. This file wires
+//! SledStateMachine to that suite and adds sled-specific scenarios not covered
+//! by the standard suite.
+
 use std::sync::Arc;
-use std::time::Duration;
 
-use sled::Batch;
-use tracing::debug;
-use tracing_test::traced_test;
-
-use super::*;
-use d_engine::constants::LAST_SNAPSHOT_METADATA_KEY;
-use d_engine::constants::STATE_MACHINE_META_NAMESPACE;
-use d_engine::constants::STATE_MACHINE_TREE;
-use d_engine::constants::STATE_SNAPSHOT_METADATA_TREE;
-use d_engine::convert::safe_kv;
-use d_engine::file_io::compute_checksum_from_folder_path;
-use d_engine::init_sled_state_machine_db;
-use d_engine::init_sled_storages;
-use d_engine::test_utils::generate_delete_commands;
-use d_engine::test_utils::generate_insert_commands;
-use d_engine::test_utils::reset_dbs;
-use d_engine::test_utils::reuse_dbs;
-use d_engine::StateMachine;
-use d_engine::common::Entry;
-use d_engine::common::EntryPayload;
+use async_trait::async_trait;
+use bytes::Bytes;
+use d_engine::{ApplyEntry, Command, Error, StateMachine};
 use d_engine::common::LogId;
-use d_engine::storage::SnapshotMetadata;
+use d_engine::state_machine_test::{StateMachineBuilder, StateMachineTestSuite};
+use tempfile::TempDir;
 
-pub fn setup_raft_components(
-    db_path: &str,
-    restart: bool,
-) -> SledStateMachine {
-    println!("Test setup_raft_components ...");
-    //start from fresh
-    let (_storage_engine_db, state_machine_db) = if restart {
-        reuse_dbs(db_path)
-    } else {
-        reset_dbs(db_path)
-    };
-    SledStateMachine::new(1, Arc::new(state_machine_db)).unwrap()
-}
-#[tokio::test]
-#[traced_test]
-async fn test_start_stop() {
-    let root_path = "/tmp/test_start_stop";
-    let state_machine = setup_raft_components(root_path, false);
+use crate::{SledStateMachine, init_sled_state_machine_db, STATE_SNAPSHOT_METADATA_TREE};
 
-    // Test default is running
-    assert!(state_machine.is_running());
+// ── Builder ───────────────────────────────────────────────────────────────────
 
-    state_machine.start().expect("should succeed");
-    assert!(state_machine.is_running());
-    state_machine.stop().expect("should succeed");
-    assert!(!state_machine.is_running());
-    state_machine.start().expect("should succeed");
-    assert!(state_machine.is_running());
+/// Builder that creates SledStateMachine instances sharing the same path.
+///
+/// Persistence tests (test_drop_flushes_data, test_data_survives_reopen, etc.)
+/// call build() multiple times and rely on all instances sharing the same path
+/// so that data written by the first instance is readable by the second.
+struct SledBuilder {
+    temp_dir: TempDir,
 }
 
-#[tokio::test]
-#[traced_test]
-async fn test_apply_committed_raft_logs_in_batch() {
-    let root_path = "/tmp/test_apply_committed_raft_logs_in_batch";
-    let state_machine = setup_raft_components(root_path, false);
+impl SledBuilder {
+    fn new() -> Self {
+        Self { temp_dir: TempDir::new().expect("create TempDir") }
+    }
+}
 
-    //step1: prepare some entries inside state machine
-    let mut entries = Vec::new();
-    for id in 1..=3 {
-        let log = Entry {
-            index: id,
+#[async_trait]
+impl StateMachineBuilder for SledBuilder {
+    async fn build(&self) -> Result<Arc<dyn StateMachine>, Error> {
+        let sm = SledStateMachine::new(self.temp_dir.path(), 1)?;
+        Ok(Arc::new(sm))
+    }
+
+    async fn cleanup(&self) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+// ── Standard suite ────────────────────────────────────────────────────────────
+
+/// Full coverage via the shared StateMachineTestSuite.
+///
+/// Covers: start/stop, KV ops, CAS, apply_chunk, last_applied tracking,
+/// snapshot generate+apply, persistence, drop flush, crash recovery, reset.
+#[tokio::test]
+async fn test_standard_suite() {
+    StateMachineTestSuite::run_all_tests(SledBuilder::new()).await.unwrap();
+}
+
+/// Optional performance regression check (excluded from normal CI).
+#[tokio::test]
+#[ignore]
+async fn test_performance_suite() {
+    StateMachineTestSuite::run_performance_tests(SledBuilder::new()).await.unwrap();
+}
+
+// ── Sled-specific: snapshot content correctness ───────────────────────────────
+
+/// Snapshot must capture all current SM data as arbitrary byte keys.
+///
+/// Verifies that generate_snapshot_data correctly copies all key-value pairs
+/// regardless of key encoding — sled keys are not log indices.
+#[tokio::test]
+async fn test_snapshot_captures_all_current_data() {
+    let temp = TempDir::new().unwrap();
+    let sm = SledStateMachine::new(temp.path(), 1).unwrap();
+
+    let entries: Vec<_> = (1u64..=5)
+        .map(|i| ApplyEntry {
+            index: i,
             term: 1,
-            payload: Some(EntryPayload::command(generate_insert_commands(vec![id]))),
-        };
-        entries.push(log);
-    }
-    state_machine.apply_chunk(entries).await.expect("should succeed");
-    assert_eq!(state_machine.last_applied(), LogId { index: 3, term: 1 });
-}
+            command: Command::Insert {
+                key: Bytes::from(format!("snap_key_{i}")),
+                value: Bytes::from(format!("snap_val_{i}")),
+                ttl_secs: None,
+            },
+        })
+        .collect();
+    sm.apply_chunk(&entries).await.unwrap();
 
-fn init(path: &str) -> Arc<sled::Db> {
-    let (_raft_log_db, state_machine_db) = init_sled_storages(path.to_string()).unwrap();
-    Arc::new(state_machine_db)
-}
+    let snap_dir = temp.path().join("snapshot");
+    sm.generate_snapshot_data(snap_dir.clone(), LogId { index: 5, term: 1 })
+        .await
+        .unwrap();
 
-/// # Case 1: test if node restart, the state machine entries should load from disk
-#[test]
-fn test_state_machine_flush() {
-    let p = "/tmp/test_state_machine_flush";
-    {
-        let _ = std::fs::remove_dir_all(p);
-        println!("Test setup ...");
-        let state_machine_db = init(p);
-        let state_machine = Arc::new(SledStateMachine::new(1, state_machine_db).expect("success"));
-        let mut batch = Batch::default();
-        batch.insert(&safe_kv(1), &safe_kv(1));
-        batch.insert(&safe_kv(2), &safe_kv(2));
-        state_machine.apply_batch(batch).expect("should succeed");
-        state_machine.flush().expect("should succeed");
-        println!(">>state_machine disk length: {:?}", state_machine.len());
-    }
-
-    {
-        let state_machine_db = init(p);
-        let state_machine = SledStateMachine::new(1, state_machine_db).expect("success");
-        assert_eq!(state_machine.len(), 2);
+    // Open the snapshot as a fresh SM and verify all 5 keys were captured.
+    let snap_sm = SledStateMachine::new(&snap_dir, 1).unwrap();
+    for i in 1u64..=5 {
+        let key = format!("snap_key_{i}");
+        let val = format!("snap_val_{i}");
         assert_eq!(
-            state_machine.get(&safe_kv(2)).unwrap(),
-            Some(safe_kv(2).to_vec())
+            snap_sm.get(key.as_bytes()).unwrap(),
+            Some(Bytes::from(val)),
+            "key {key} missing from snapshot"
         );
     }
+
+    // Snapshot metadata must reflect the requested last_included index.
+    let meta = sm.snapshot_metadata().unwrap();
+    assert_eq!(meta.last_included.unwrap().index, 5);
 }
 
+/// Snapshot DB must contain the snapshot metadata tree with the correct index,
+/// so a joining follower can verify the snapshot before applying it.
 #[tokio::test]
-#[traced_test]
-async fn test_basic_kv_operations() {
-    let root_path = "/tmp/test_basic_kv_operations";
-    let state_machine = setup_raft_components(root_path, false);
+async fn test_snapshot_db_contains_metadata_tree() {
+    let temp = TempDir::new().unwrap();
+    let sm = SledStateMachine::new(temp.path(), 1).unwrap();
 
-    let test_key = 42u64;
-    let test_value = safe_kv(test_key);
+    let snap_dir = temp.path().join("meta_snapshot");
+    sm.generate_snapshot_data(snap_dir.clone(), LogId { index: 42, term: 5 })
+        .await
+        .unwrap();
 
-    // Test insert and read
-    let mut batch = Batch::default();
-    batch.insert(&test_value.clone(), &test_value.clone());
-    state_machine.apply_batch(batch).unwrap();
+    let snap_db = init_sled_state_machine_db(&snap_dir).unwrap();
+    let metadata_tree = snap_db.open_tree(STATE_SNAPSHOT_METADATA_TREE).unwrap();
 
-    match state_machine.get(&test_value) {
-        Ok(Some(v)) => assert_eq!(v, test_value),
-        _ => panic!("Value not found"),
-    }
-
-    // Test delete
-    let mut batch = Batch::default();
-    batch.remove(&test_value.clone());
-    state_machine.apply_batch(batch).unwrap();
-
-    assert_eq!(state_machine.get(&test_value).unwrap(), None);
+    let stored = SledStateMachine::load_snapshot_metadata(&metadata_tree)
+        .unwrap()
+        .expect("snapshot metadata must be present in snapshot DB");
+    let li = stored.last_included.unwrap();
+    assert_eq!(li.index, 42);
+    assert_eq!(li.term, 5);
 }
 
+/// Snapshot must only include data that was in the SM at generation time.
+/// Entries inserted AFTER generate_snapshot_data must NOT appear in the snapshot.
 #[tokio::test]
-#[traced_test]
-async fn test_last_entry_detection() {
-    let root_path = "/tmp/test_last_entry_detection";
-    let state_machine = setup_raft_components(root_path, false);
+async fn test_snapshot_does_not_include_post_snapshot_entries() {
+    let temp = TempDir::new().unwrap();
+    let sm = SledStateMachine::new(temp.path(), 1).unwrap();
 
-    // Insert test data
-    let mut entries = Vec::new();
-    for id in 1..=5 {
-        let log = Entry {
-            index: id,
-            term: 1,
-            payload: Some(EntryPayload::command(generate_insert_commands(vec![id]))),
-        };
-        entries.push(log);
-    }
-    state_machine.apply_chunk(entries).await.unwrap();
-
-    // Verify last entry
-    assert_eq!(state_machine.last_applied(), LogId { index: 5, term: 1 });
-}
-
-#[tokio::test]
-#[traced_test]
-async fn test_batch_error_handling() {
-    let root_path = "/tmp/test_batch_error_handling";
-    let state_machine = setup_raft_components(root_path, false);
-
-    // Create invalid batch (simulate error)
-    let mut batch = Batch::default();
-    batch.insert(&safe_kv(999), b"bad-value".to_vec());
-
-    // This test might need mocking for specific error conditions
-    // For demonstration purposes:
-    assert!(state_machine.apply_batch(batch).is_ok());
-}
-
-#[tokio::test]
-#[traced_test]
-async fn test_iter_functionality() {
-    let root_path = "/tmp/test_iter_functionality";
-    let state_machine = setup_raft_components(root_path, false);
-
-    // Insert test data
-    let mut batch = Batch::default();
-    for i in 1..=3 {
-        let key = safe_kv(i);
-        batch.insert(&key, &key);
-    }
-    state_machine.apply_batch(batch).unwrap();
-
-    // Verify iterator
-    let mut count = 0;
-    for item in state_machine.iter() {
-        let (k, v) = item.unwrap();
-        assert_eq!(k.to_vec(), v.to_vec());
-        count += 1;
-    }
-    assert_eq!(count, 3);
-}
-
-#[tokio::test]
-#[traced_test]
-async fn test_apply_chunk_functionality() {
-    let root_path = "/tmp/test_apply_chunk_functionality";
-    let state_machine = setup_raft_components(root_path, false);
-
-    let test_entries = vec![
-        Entry {
+    // Write two keys before snapshot
+    let pre_entries = vec![
+        ApplyEntry {
             index: 1,
-            payload: Some(EntryPayload::command(generate_insert_commands(vec![1, 2]))),
             term: 1,
-        },
-        Entry {
-            index: 2,
-            payload: Some(EntryPayload::command(generate_delete_commands(1..=1))),
-            term: 1,
+            command: Command::Insert {
+                key: Bytes::from_static(b"before"),
+                value: Bytes::from_static(b"v1"),
+                ttl_secs: None,
+            },
         },
     ];
+    sm.apply_chunk(&pre_entries).await.unwrap();
 
-    // Test chunk application
-    state_machine.apply_chunk(test_entries).await.unwrap();
-
-    // Verify results
-    assert_eq!(state_machine.get(&safe_kv(1)).unwrap(), None);
-    assert_eq!(state_machine.last_applied(), LogId { index: 2, term: 1 });
-}
-
-/// # Case 1: test basic functionality
-#[tokio::test]
-#[traced_test]
-async fn test_generate_snapshot_data_case1() {
-    let root = tempfile::tempdir().unwrap();
-    let state_machine = setup_raft_components("/tmp/test_generate_snapshot_data_case1", false);
-
-    // Insert 3 test entries
-    let mut batch = Batch::default();
-    for i in 1..=3 {
-        let key = safe_kv(i);
-        batch.insert(&key, &key);
-    }
-    state_machine.apply_batch(batch).unwrap();
-
-    // Generate snapshot with last included index=3
-    let temp_path = root.path().join("snapshot1");
-    state_machine
-        .generate_snapshot_data(temp_path.clone(), LogId { index: 3, term: 1 })
+    let snap_dir = temp.path().join("partial_snapshot");
+    sm.generate_snapshot_data(snap_dir.clone(), LogId { index: 1, term: 1 })
         .await
         .unwrap();
 
-    // Verify snapshot contents
-    let snapshot_db = init_sled_state_machine_db(&temp_path).unwrap();
-    let tree = snapshot_db.open_tree(STATE_MACHINE_TREE).unwrap();
-    let metadata_tree = snapshot_db.open_tree(STATE_SNAPSHOT_METADATA_TREE).unwrap();
+    // Write another key AFTER snapshot
+    let post_entries = vec![ApplyEntry {
+        index: 2,
+        term: 1,
+        command: Command::Insert {
+            key: Bytes::from_static(b"after"),
+            value: Bytes::from_static(b"v2"),
+            ttl_secs: None,
+        },
+    }];
+    sm.apply_chunk(&post_entries).await.unwrap();
 
-    let expected_checksum = compute_checksum_from_folder_path(&temp_path).await.expect("success");
-
-    // Check data entries
-    for i in 1..=3 {
-        assert!(tree.get(safe_kv(i)).unwrap().is_some());
-    }
-
-    // Check metadata (stored in same tree due to code limitation)
+    // Snapshot SM must have "before" but not "after"
+    let snap_sm = SledStateMachine::new(&snap_dir, 1).unwrap();
     assert_eq!(
-        state_machine.snapshot_metadata(),
-        (Some(SnapshotMetadata {
-            last_included: Some(LogId {
-                index: 3u64,
-                term: 1u64
-            }),
-            checksum: expected_checksum.to_vec()
-        }))
+        snap_sm.get(b"before").unwrap(),
+        Some(Bytes::from_static(b"v1"))
     );
-
-    let last_included = SledStateMachine::load_snapshot_metadata(&metadata_tree)
-        .unwrap()
-        .unwrap()
-        .last_included
-        .unwrap();
-    assert_eq!(last_included.index, 3u64);
-    assert_eq!(last_included.term, 1u64);
-}
-
-/// # Case 2: Exclude upper entries
-#[tokio::test]
-#[traced_test]
-async fn test_generate_snapshot_data_case2() {
-    let root = tempfile::tempdir().unwrap();
-    let state_machine = setup_raft_components("/tmp/test_generate_snapshot_data_case2", false);
-
-    // Insert 5 test entries
-    let mut batch = Batch::default();
-    for i in 1..=5 {
-        let key = safe_kv(i);
-        batch.insert(&key, &key);
-    }
-    state_machine.apply_batch(batch).unwrap();
-
-    // Generate snapshot with last included index=3
-    let temp_path = root.path().join("snapshot2");
-    state_machine
-        .generate_snapshot_data(temp_path.clone(), LogId { index: 3, term: 1 })
-        .await
-        .unwrap();
-
-    // Verify snapshot contents
-    let snapshot_db = init_sled_state_machine_db(&temp_path).unwrap();
-    let tree = snapshot_db.open_tree(STATE_MACHINE_TREE).unwrap();
-
-    // Entries <=3 should exist
-    for i in 1..=3 {
-        assert!(tree.get(safe_kv(i)).unwrap().is_some());
-    }
-
-    // Entries >3 should not exist
-    for i in 4..=5 {
-        assert!(tree.get(safe_kv(i)).unwrap().is_none());
-    }
-}
-
-/// # Case 3: Metadata correctness
-#[tokio::test]
-#[traced_test]
-async fn test_generate_snapshot_data_case3() {
-    let root = tempfile::tempdir().unwrap();
-    let state_machine = setup_raft_components("/tmp/test_generate_snapshot_data_case3", false);
-
-    // Generate snapshot with specific metadata
-    let temp_path = root.path().join("snapshot3");
-    state_machine
-        .generate_snapshot_data(temp_path.clone(), LogId { index: 42, term: 5 })
-        .await
-        .unwrap();
-
-    // Verify metadata
-    let snapshot_db = init_sled_state_machine_db(&temp_path).unwrap();
-    let metadata_tree = snapshot_db.open_tree(STATE_SNAPSHOT_METADATA_TREE).unwrap();
-
-    let last_included = SledStateMachine::load_snapshot_metadata(&metadata_tree)
-        .unwrap()
-        .unwrap()
-        .last_included
-        .unwrap();
-    assert_eq!(last_included.index, 42u64);
-    assert_eq!(last_included.term, 5u64);
-}
-
-/// # Case 4: Batch processing
-#[tokio::test]
-#[traced_test]
-async fn test_generate_snapshot_data_case4() {
-    let root = tempfile::tempdir().unwrap();
-    let state_machine = setup_raft_components("/tmp/test_generate_snapshot_data_case4", false);
-
-    // Insert 150 test entries
-    let mut batch = Batch::default();
-    for i in 1..=150 {
-        let key = safe_kv(i);
-        batch.insert(&key, &key);
-    }
-    state_machine.apply_batch(batch).unwrap();
-
-    // Generate snapshot
-    let temp_path = root.path().join("snapshot4");
-    state_machine
-        .generate_snapshot_data(
-            temp_path.clone(),
-            LogId {
-                index: 150,
-                term: 1,
-            },
-        )
-        .await
-        .unwrap();
-
-    // Verify all entries exist
-    let snapshot_db = init_sled_state_machine_db(&temp_path).unwrap();
-    let tree = snapshot_db.open_tree(STATE_MACHINE_TREE).unwrap();
-
-    assert_eq!(tree.len(), 150);
-    for i in 1..=150 {
-        assert!(tree.get(safe_kv(i)).unwrap().is_some());
-    }
-}
-
-#[cfg(test)]
-mod apply_snapshot_from_file_tests {
-    use std::path::Path;
-
-    use super::*;
-    use d_engine::file_io::create_valid_snapshot;
-
-    /// # Case 1: Basic snapshot application
-    #[tokio::test]
-    async fn test_apply_snapshot_from_file_case1() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let case_path = temp_dir.path().join("test_apply_snapshot_from_file_case1");
-        let state_machine = setup_raft_components("/tmp/test_apply_snapshot_case1", false);
-
-        // Generate test snapshot - UNCOMPRESSED DIRECTORY
-        let snapshot_dir = case_path.join("snapshot_basic");
-        let checksum = create_valid_snapshot(&snapshot_dir, |db| {
-            let tree = db.open_tree(STATE_MACHINE_TREE).unwrap();
-            tree.insert(safe_kv(456), b"test_value").unwrap();
-            db.flush().unwrap();
-        })
-        .await;
-
-        let last_included = LogId { index: 5, term: 2 };
-        let metadata = SnapshotMetadata {
-            last_included: Some(last_included),
-            checksum: checksum.to_vec(),
-        };
-
-        // Apply snapshot
-        state_machine.apply_snapshot_from_file(&metadata, snapshot_dir).await.unwrap();
-
-        // Verify data and metadata
-        assert_eq!(
-            state_machine.get(&safe_kv(456)).unwrap(),
-            Some(b"test_value".to_vec())
-        );
-        assert_eq!(state_machine.last_applied(), last_included);
-        assert_eq!(state_machine.snapshot_metadata(), Some(metadata.clone()));
-    }
-
-    /// # Case 2: Overwrite existing state
-    #[tokio::test]
-    async fn test_apply_snapshot_from_file_case2() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let case_path = temp_dir.path().join("test_apply_snapshot_from_file_case2");
-        let state_machine = setup_raft_components(case_path.to_str().unwrap(), false);
-
-        // Add initial data
-        let mut batch = Batch::default();
-        batch.insert(&safe_kv(232), b"old_value");
-        state_machine.apply_batch(batch).unwrap();
-
-        // Create UNCOMPRESSED snapshot directory with new data
-        let snapshot_dir = case_path.join("snapshot_overwrite");
-        let last_included = LogId { index: 10, term: 3 };
-
-        let checksum = create_valid_snapshot(&snapshot_dir, |db| {
-            let tree = db.open_tree(STATE_MACHINE_TREE).unwrap();
-            tree.insert(safe_kv(5654), b"new_value").unwrap();
-            db.flush().unwrap();
-        })
-        .await;
-
-        let metadata = SnapshotMetadata {
-            last_included: Some(last_included),
-            checksum: checksum.to_vec(),
-        };
-
-        // Apply snapshot
-        state_machine.apply_snapshot_from_file(&metadata, snapshot_dir).await.unwrap();
-
-        // Verify state overwrite
-        assert_eq!(state_machine.get(&safe_kv(232)).unwrap(), None);
-        assert_eq!(
-            state_machine.get(&safe_kv(5654)).unwrap(),
-            Some(b"new_value".to_vec())
-        );
-    }
-
-    /// # Case 3: Metadata consistency check
-    #[tokio::test]
-    async fn test_apply_snapshot_from_file_case3() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let case_path = temp_dir.path().join("test_apply_snapshot_from_file_case3");
-        let state_machine = setup_raft_components(case_path.to_str().unwrap(), false);
-
-        // Create COMPRESSED snapshot
-        let temp_path = case_path.join("snapshot_metadata.tar.gz");
-        let last_included = LogId { index: 15, term: 4 };
-
-        let checksum = create_valid_snapshot(&temp_path, |db| {
-            let metadata_tree = db.open_tree(STATE_SNAPSHOT_METADATA_TREE).unwrap();
-            let value = bincode::serialize(&SnapshotMetadata {
-                last_included: Some(last_included),
-                checksum: vec![],
-            })
-            .unwrap();
-            metadata_tree.insert(LAST_SNAPSHOT_METADATA_KEY, value).unwrap();
-            db.flush().unwrap();
-        })
-        .await;
-
-        let metadata = SnapshotMetadata {
-            last_included: Some(last_included),
-            checksum: checksum.to_vec(),
-        };
-
-        state_machine.apply_snapshot_from_file(&metadata, temp_path).await.unwrap();
-
-        // Verify metadata propagation
-        assert_eq!(state_machine.snapshot_metadata(), Some(metadata.clone()));
-        assert_eq!(state_machine.last_applied(), last_included);
-    }
-
-    /// # Case 4: Concurrent snapshot protection
-    #[tokio::test]
-    async fn test_apply_snapshot_from_file_case4() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let case_path = temp_dir.path().join("test_apply_snapshot_from_file_case4");
-        let state_machine = Arc::new(setup_raft_components(case_path.to_str().unwrap(), false));
-
-        let snapshot_dir = case_path.join("snapshot_basic");
-        let last_included = LogId { index: 20, term: 5 };
-        let checksum = create_valid_snapshot(&snapshot_dir, |db| {
-            let tree = db.open_tree(STATE_MACHINE_TREE).unwrap();
-            tree.insert(safe_kv(456), b"test_value").unwrap();
-            db.flush().unwrap();
-        })
-        .await;
-
-        let metadata = SnapshotMetadata {
-            last_included: Some(last_included),
-            checksum: checksum.to_vec(),
-        };
-
-        // Start two concurrent apply operations
-        let handle1 = tokio::spawn({
-            let sm = state_machine.clone();
-            let path = snapshot_dir.clone();
-            let metadata = metadata.clone();
-            async move { sm.apply_snapshot_from_file(&metadata, path).await }
-        });
-
-        let handle2 = tokio::spawn({
-            let sm = state_machine.clone();
-            let path = snapshot_dir.clone();
-            let metadata = metadata.clone();
-            async move {
-                tokio::time::sleep(Duration::from_millis(10)).await;
-                sm.apply_snapshot_from_file(&metadata, path).await
-            }
-        });
-
-        // Verify only one succeeds
-        let results = futures::join!(handle1, handle2);
-        println!(" > {results:?}",);
-
-        match (results.0, results.1) {
-            (Ok(Ok(_)), Ok(Err(_))) | (Ok(Err(_)), Ok(Ok(_))) => (), // Expected scenario
-            _ => panic!("Both snapshot applications should not succeed concurrently"),
-        }
-    }
-
-    /// # Case 5: Invalid snapshot handling
-    #[tokio::test]
-    async fn test_apply_snapshot_from_file_case5() {
-        let state_machine =
-            setup_raft_components("/tmp/test_apply_snapshot_from_file_case5", false);
-
-        let result = state_machine
-            .apply_snapshot_from_file(
-                &SnapshotMetadata {
-                    last_included: Some(LogId { term: 1, index: 1 }),
-                    checksum: [0_u8; 32].to_vec(),
-                },
-                PathBuf::from("/non/existent/path"),
-            )
-            .await;
-
-        debug!(?result, "test_apply_snapshot_from_file_case5");
-        assert!(result.is_err());
-    }
-
-    /// # Case 6: Checksum validation failure
-    #[tokio::test]
-    async fn test_apply_snapshot_from_file_case6_checksum_failure() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let case_path =
-            temp_dir.path().join("test_apply_snapshot_from_file_case6_checksum_failure");
-        let state_machine = setup_raft_components(case_path.to_str().unwrap(), false);
-
-        // Create valid snapshot directory
-        let snapshot_dir = case_path.join("snapshot_checksum_failure");
-        let checksum = create_valid_snapshot(&snapshot_dir, |_| {}).await;
-
-        let last_included = LogId { index: 25, term: 6 };
-        let mut metadata = SnapshotMetadata {
-            last_included: Some(last_included),
-            checksum: checksum.to_vec(),
-        };
-
-        // Corrupt checksum
-        metadata.checksum[0] = !metadata.checksum[0];
-
-        // Should fail on checksum validation
-        let result = state_machine.apply_snapshot_from_file(&metadata, snapshot_dir).await;
-        assert!(result.is_err());
-    }
-
-    /// Creates an invalid snapshot directory (empty or corrupted)
-    async fn create_invalid_snapshot(dir_path: &Path) {
-        tokio::fs::create_dir_all(dir_path).await.unwrap();
-        // Intentionally leave empty or create invalid files
-    }
-
-    /// # Case 7: Empty snapshot application
-    #[tokio::test]
-    async fn test_apply_snapshot_from_file_case7_empty() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let case_path = temp_dir.path().join("test_apply_snapshot_from_file_case7_empty");
-        let state_machine = setup_raft_components(case_path.to_str().unwrap(), false);
-
-        // Create empty snapshot directory
-        let snapshot_dir = case_path.join("empty_snapshot");
-        create_invalid_snapshot(&snapshot_dir).await;
-
-        let last_included = LogId { index: 0, term: 0 };
-        let metadata = SnapshotMetadata {
-            last_included: Some(last_included),
-            checksum: vec![], // Special empty checksum
-        };
-
-        // Should handle empty snapshot
-        let result = state_machine.apply_snapshot_from_file(&metadata, snapshot_dir).await;
-        debug!(?result, "test_apply_snapshot_from_file_case7_empty");
-        assert!(result.is_err());
-
-        // Should reset to initial state
-        assert_eq!(state_machine.get(&safe_kv(67)).unwrap(), None);
-        assert_eq!(state_machine.last_applied(), last_included);
-    }
-
-    /// # Case 8: Invalid file format
-    #[tokio::test]
-    async fn test_apply_snapshot_from_file_case8_invalid_format() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let case_path = temp_dir.path().join("test_apply_snapshot_from_file_case8_invalid_format");
-        let state_machine = setup_raft_components(case_path.to_str().unwrap(), false);
-
-        // Create directory with invalid snapshot contents
-        let invalid_dir = case_path.join("invalid_snapshot");
-        tokio::fs::create_dir_all(&invalid_dir).await.unwrap();
-
-        // Add some files that don't form a valid snapshot
-        tokio::fs::write(invalid_dir.join("random.txt"), "Invalid snapshot content")
-            .await
-            .unwrap();
-
-        let metadata = SnapshotMetadata {
-            last_included: Some(LogId { index: 30, term: 8 }),
-            checksum: vec![],
-        };
-
-        let result = state_machine.apply_snapshot_from_file(&metadata, invalid_dir).await;
-        assert!(result.is_err());
-    }
-}
-
-#[tokio::test]
-#[traced_test]
-async fn test_state_machine_drop() {
-    let temp_dir = tempfile::tempdir().unwrap();
-    let case_path = temp_dir.path().join("test_state_machine_drop");
-
-    {
-        let db = Arc::new(sled::open(case_path.clone()).unwrap());
-        // Create real instance instead of mock
-        let state_machine = Arc::new(SledStateMachine::new(1, db.clone()).expect("success"));
-
-        // Insert test data
-        let mut batch = Batch::default();
-        batch.insert(&safe_kv(1), &safe_kv(1));
-        batch.insert(&safe_kv(2), &safe_kv(2));
-        state_machine.apply_batch(batch).expect("should succeed");
-
-        // Explicitly drop to trigger flush
-        drop(state_machine);
-    }
-
-    // Verify flush occurred by checking persistence
-    let reloaded_db = sled::open(case_path).unwrap();
-    assert!(!reloaded_db.open_tree(STATE_MACHINE_META_NAMESPACE).unwrap().is_empty());
+    assert!(snap_sm.get(b"after").unwrap().is_none());
 }


### PR DESCRIPTION
## What Does This PR Do?

Moves the `Entry → Command` proto decode boundary from every `StateMachine`
implementation into `DefaultStateMachineHandler`, so SM implementations never
see raw proto types. Introduces `Command` and `ApplyEntry` as first-class public
types re-exported through the `d-engine` facade.

**Type:**

- [ ] Bug Fix (with test)
- [ ] Feature (issue #___ approved)
- [ ] Documentation
- [ ] Test/Coverage
- [x] Performance (with benchmark)

---

## Why Is This Needed?

Closes #384.

Every `StateMachine` implementation was forced to write the same three-layer
proto decode boilerplate (`entry.payload → Payload::Command(data) →
WriteCommand::decode(&data[..]) → operation match`). This pattern is error-prone,
violates the anti-corruption layer principle, and imposes unnecessary decode cost
on each SM independently.

The correct boundary is: decode once in the framework handler, pass clean domain
types down to SM implementations.

---

## Checklist

**Required:**

- [x] `make test` passes
- [x] Added tests for new code
- [x] Commits squashed to 1-2 logical units

**If changing APIs:**

- [x] Updated relevant docs
- [x] Explained why complexity is justified

---

## Testing

**How tested:**

- Unit tests: `TryFrom<WriteCommand> for Command` — all variants, `ttl_secs=0→None`,
  Config→Noop, decode failure (`d-engine-core/src/command_test.rs`)
- Unit tests: `DefaultStateMachineHandler::decode_entries()` — Noop, Config, Command,
  malformed payload (`default_state_machine_handler_test.rs`)
- Unit tests: RocksDB and File SM `apply_chunk` updated and passing
- Integration tests: `StateMachineTestSuite::run_all_tests` wired for `SledStateMachine`
  (8 tests: KV ops, CAS, last_applied tracking, snapshot, persistence, reset, crash recovery)
- Full suite: 1612 tests pass, 0 failures

**For bug fixes:**

- [x] Added test that fails without this fix

  Two bugs discovered and fixed in `SledStateMachine` while wiring to
  `StateMachineTestSuite`:
  1. `reset()` was calling `db.clear()` (clears default unnamed sled tree only);
     fixed to explicitly clear all three named SM trees + reset in-memory atomics
  2. `generate_snapshot_data()` used `safe_vk(key)` to filter keys as u64 log
     indices — an artifact of an old design; breaks entirely with arbitrary byte
     keys from the new `Command::Insert` API; removed the filter

---

## Does This Follow d-engine's Principles?

- [x] Solves a real problem for most users (not just my edge case)
- [x] Keeps implementation simple
- [x] Doesn't bloat the API surface

---

## Reviewer Notes

**Critical invariant to verify (Decision 6):** `decode_entries()` must convert
both `Payload::Config` and `Payload::Noop` to `Command::Noop` — neither can be
silently dropped. Dropping Config entries leaves `sm.last_applied` stuck below
any subsequent Config index; ReadIndex `pending_reads` drain never completes →
`ConnectionTimeout` on cluster scale-up. This was confirmed by regression in
`test_scale_single_to_cluster`. See `default_state_machine_handler.rs:decode_entries`.

**Hot path:** `chunk.clone()` removed from handler; per-SM proto decode eliminated.
Watch path (`read_prev_values`) reuses `ApplyEntry.command` — no second decode.

**Estimated review complexity:**

- [ ] Quick (< 100 lines)
- [ ] Medium (< 300 lines)
- [x] Deep (> 300 lines)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds structured command/apply-entry types and re-exports them for direct state-machine consumption.

* **Improvements**
  * Single-step decode flow for apply processing, improved watch-event accuracy and prev-value handling, and refined TTL/persistence/snapshot behavior and performance.

* **Bug Fixes**
  * More robust WAL replay and CAS crash-safety; ensures applied-index progression is preserved.

* **Tests**
  * Expanded unit, integration and benchmark coverage; updated examples and docs to match new apply contract.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deventlab/d-engine/pull/388?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->