### PR TITLE
fix #425: propagate leader_hint on non-leader rejection across write/read/scan

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,13 @@
 # Nextest configuration for d-engine
 
+# Throttles (not serializes) the ~28 real-multi-node-cluster tests — full parallelism let
+# too many race for CPU and fail under load. Two groups: local vs CI (2 vCPU) core counts differ.
+[test-groups.multi-node-cluster-local]
+max-threads = 4
+
+[test-groups.multi-node-cluster-ci]
+max-threads = 2
+
 [profile.default]
 
 # Force serial execution for tests that use /tmp/db
@@ -7,10 +15,52 @@
 filter = "test(tmp_db) | test(config_path_env)"
 threads-required = 'num-cpus'
 
-# Force serial execution for wall-clock performance assertions (hardcoded ms/ops-per-sec
-# thresholds). These catch real perf regressions and have run clean across releases —
-# the problem is CPU contention from running alongside ~2000 other tests, not the
-# assertions themselves. Do not #[ignore] them; isolate them instead.
+# Serialize wall-clock perf assertions — CPU contention causes false failures, not the
+# assertions. Don't #[ignore] them, isolate instead.
 [[profile.default.overrides]]
 filter = "test(storage_buffered_raft_log::performance_test)"
 threads-required = 'num-cpus'
+
+# Per-directory, not per-file — a few dirs also hold light tests, throttled as fallout.
+[[profile.default.overrides]]
+filter = '''
+  test(cas_operations::)
+  | test(cluster_lifecycle::)
+  | test(cluster_membership::)
+  | test(cluster_state_and_metadata::)
+  | test(consistent_reads::)
+  | test(failover_and_recovery::)
+  | test(leader_election::)
+  | test(readonly_and_learner_mode::)
+  | test(replication_and_sync::)
+  | test(snapshot_and_recovery::)
+  | test(watch_and_subscriptions::)
+'''
+test-group = "multi-node-cluster-local"
+
+# CI profile — select with `--profile ci` (see .github/workflows/ci.yml).
+[profile.ci]
+
+[[profile.ci.overrides]]
+filter = "test(tmp_db) | test(config_path_env)"
+threads-required = 'num-cpus'
+
+[[profile.ci.overrides]]
+filter = "test(storage_buffered_raft_log::performance_test)"
+threads-required = 'num-cpus'
+
+[[profile.ci.overrides]]
+filter = '''
+  test(cas_operations::)
+  | test(cluster_lifecycle::)
+  | test(cluster_membership::)
+  | test(cluster_state_and_metadata::)
+  | test(consistent_reads::)
+  | test(failover_and_recovery::)
+  | test(leader_election::)
+  | test(readonly_and_learner_mode::)
+  | test(replication_and_sync::)
+  | test(snapshot_and_recovery::)
+  | test(watch_and_subscriptions::)
+'''
+test-group = "multi-node-cluster-ci"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,3 +6,11 @@
 [[profile.default.overrides]]
 filter = "test(tmp_db) | test(config_path_env)"
 threads-required = 'num-cpus'
+
+# Force serial execution for wall-clock performance assertions (hardcoded ms/ops-per-sec
+# thresholds). These catch real perf regressions and have run clean across releases —
+# the problem is CPU contention from running alongside ~2000 other tests, not the
+# assertions themselves. Do not #[ignore] them; isolate them instead.
+[[profile.default.overrides]]
+filter = "test(storage_buffered_raft_log::performance_test)"
+threads-required = 'num-cpus'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Run tests with nextest and generate coverage
         run: |
-          cargo llvm-cov nextest --all-features --workspace --lcov --output-path lcov.info --ignore-filename-regex "src/generated/.*|src/errors.rs"
+          cargo llvm-cov nextest --profile ci --all-features --workspace --lcov --output-path lcov.info --ignore-filename-regex "src/generated/.*|src/errors.rs"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ docker/monitoring/prometheus/data/
 .clj-kondo
 .lsp
 .zed
+.agents/
 lcov.info
 
 CONTEXT

--- a/d-engine-client/src/error_test.rs
+++ b/d-engine-client/src/error_test.rs
@@ -29,16 +29,22 @@ fn test_network_error_retry_logic() {
 }
 
 #[test]
-fn test_business_error_with_action() {
+fn test_not_leader_error_is_network_variant() {
+    // NotLeader is redirectable (carries a leader_hint when available), so it
+    // must be ClientApiError::Network, not Business — Business has no
+    // leader_hint field. The bare `From<ErrorCode>` conversion has no
+    // metadata to populate leader_hint from; that only happens in
+    // `ClientResponseExt::validate_error()`, which has `self.metadata`.
     let error = ClientApiError::from(ErrorCode::NotLeader);
 
     match error {
-        ClientApiError::Business {
-            required_action, ..
+        ClientApiError::Network {
+            code, leader_hint, ..
         } => {
-            assert_eq!(required_action, Some("redirect to leader".to_string()));
+            assert_eq!(code, ErrorCode::NotLeader);
+            assert_eq!(leader_hint, None);
         }
-        _ => panic!("Expected Business error"),
+        _ => panic!("Expected Network error"),
     }
 }
 

--- a/d-engine-client/src/grpc_client.rs
+++ b/d-engine-client/src/grpc_client.rs
@@ -5,11 +5,11 @@ use crate::scoped_timer::ScopedTimer;
 use arc_swap::ArcSwap;
 use bytes::Bytes;
 use d_engine_core::BatchOp;
-use d_engine_core::ScanResult;
 use d_engine_core::client::ErrorCode;
 use d_engine_core::client::KvEntry;
 use d_engine_core::client::{ClientApi, ClientApiResult};
 use d_engine_core::config::ReadConsistencyPolicy;
+use d_engine_core::types::ScanResults;
 use d_engine_proto::client::ClientReadRequest;
 use d_engine_proto::client::ClientWriteRequest;
 use d_engine_proto::client::MembershipSnapshot;
@@ -581,7 +581,7 @@ impl ClientApi for GrpcClient {
     async fn scan_prefix(
         &self,
         prefix: impl AsRef<[u8]> + Send,
-    ) -> ClientApiResult<ScanResult> {
+    ) -> ClientApiResult<ScanResults> {
         let client_inner = self.client_inner.load();
         let mut client = self.make_leader_client().await?;
 
@@ -596,9 +596,6 @@ impl ClientApi for GrpcClient {
             .map_err(ClientApiError::from)?
             .into_inner();
 
-        Ok(ScanResult {
-            entries: response.entries.into_iter().map(|e| (e.key, e.value)).collect(),
-            revision: response.revision,
-        })
+        response.into_scan_results()
     }
 }

--- a/d-engine-client/src/grpc_client_test.rs
+++ b/d-engine-client/src/grpc_client_test.rs
@@ -1684,22 +1684,16 @@ mod scan_tests {
     #[tokio::test]
     #[traced_test]
     async fn test_scan_prefix_success() {
-        use d_engine_proto::client::{KvEntry, ScanResponse};
+        use d_engine_core::client::ClientResponse;
 
         let (_tx, rx) = oneshot::channel::<()>();
-        let response = ScanResponse {
-            entries: vec![
-                KvEntry {
-                    key: Bytes::from("/services/node1"),
-                    value: Bytes::from("10.0.0.1"),
-                },
-                KvEntry {
-                    key: Bytes::from("/services/node2"),
-                    value: Bytes::from("10.0.0.2"),
-                },
+        let response = ClientResponse::scan_results(
+            vec![
+                (Bytes::from("/services/node1"), Bytes::from("10.0.0.1")),
+                (Bytes::from("/services/node2"), Bytes::from("10.0.0.2")),
             ],
-            revision: 7,
-        };
+            7,
+        );
         let (_channel, port) = MockNode::simulate_scan_mock_server(rx, response).await.unwrap();
 
         let client = make_client(port).await;
@@ -1722,13 +1716,10 @@ mod scan_tests {
     #[tokio::test]
     #[traced_test]
     async fn test_scan_prefix_empty_result() {
-        use d_engine_proto::client::ScanResponse;
+        use d_engine_core::client::ClientResponse;
 
         let (_tx, rx) = oneshot::channel::<()>();
-        let response = ScanResponse {
-            entries: vec![],
-            revision: 3,
-        };
+        let response = ClientResponse::scan_results(vec![], 3);
         let (_channel, port) = MockNode::simulate_scan_mock_server(rx, response).await.unwrap();
 
         let client = make_client(port).await;

--- a/d-engine-client/src/lib.rs
+++ b/d-engine-client/src/lib.rs
@@ -74,6 +74,7 @@ mod utils;
 pub use builder::*;
 pub use config::*;
 pub use d_engine_core::client::ErrorCode;
+pub use d_engine_core::client::ScanResults;
 pub use d_engine_core::client::{ClientApi, ClientApiError, ClientApiResult};
 pub use grpc_client::*;
 pub(crate) use pool::*;

--- a/d-engine-client/src/mock_rpc.rs
+++ b/d-engine-client/src/mock_rpc.rs
@@ -7,7 +7,6 @@ use d_engine_proto::client::ClientResponse;
 use d_engine_proto::client::ClientWriteRequest;
 use d_engine_proto::client::MembershipSnapshot;
 use d_engine_proto::client::ScanRequest;
-use d_engine_proto::client::ScanResponse;
 use d_engine_proto::client::WatchMembershipRequest;
 use d_engine_proto::client::WatchRequest;
 use d_engine_proto::client::WatchResponse;
@@ -45,7 +44,7 @@ pub struct MockRpcService {
     pub expected_watch_membership_events: Option<Result<Vec<MembershipSnapshot>, tonic::Status>>,
 
     /// Scan response. None means return unimplemented.
-    pub expected_client_scan_response: Option<Result<ScanResponse, tonic::Status>>,
+    pub expected_client_scan_response: Option<Result<CoreClientResponse, tonic::Status>>,
 }
 impl MockRpcService {
     pub fn with_metadata_response(
@@ -69,8 +68,8 @@ impl MockRpcService {
 fn core_to_proto_response(r: CoreClientResponse) -> ClientResponse {
     use d_engine_core::client::{ClientResponsePayload, WriteResult};
     use d_engine_proto::client::{
-        ClientResult, ReadResults as ProtoReadResults, WriteResult as ProtoWriteResult,
-        client_response::SuccessResult,
+        ClientResult, KvEntry, ReadResults as ProtoReadResults, ScanResults as ProtoScanResults,
+        WriteResult as ProtoWriteResult, client_response::SuccessResult,
     };
     use d_engine_proto::error::ErrorMetadata;
 
@@ -98,6 +97,10 @@ fn core_to_proto_response(r: CoreClientResponse) -> ClientResponse {
                     value: e.value,
                 })
                 .collect(),
+        }),
+        ClientResponsePayload::Scan(sr) => SuccessResult::ScanData(ProtoScanResults {
+            entries: sr.entries.into_iter().map(|(key, value)| KvEntry { key, value }).collect(),
+            revision: sr.revision,
         }),
     });
     ClientResponse {
@@ -230,9 +233,11 @@ impl RaftClientService for MockRpcService {
     async fn handle_client_scan(
         &self,
         _request: tonic::Request<ScanRequest>,
-    ) -> std::result::Result<tonic::Response<ScanResponse>, tonic::Status> {
+    ) -> std::result::Result<tonic::Response<ClientResponse>, tonic::Status> {
         match &self.expected_client_scan_response {
-            Some(Ok(response)) => Ok(tonic::Response::new(response.clone())),
+            Some(Ok(response)) => Ok(tonic::Response::new(core_to_proto_response(
+                response.clone(),
+            ))),
             Some(Err(status)) => Err(status.clone()),
             None => Err(tonic::Status::unimplemented("Scan not configured in mock")),
         }

--- a/d-engine-client/src/mock_rpc_service.rs
+++ b/d-engine-client/src/mock_rpc_service.rs
@@ -342,10 +342,10 @@ impl MockNode {
         Ok((channel, port))
     }
 
-    /// Simulate a scan server that returns the given ScanResponse.
+    /// Simulate a scan server that returns the given ClientResponse.
     pub(crate) async fn simulate_scan_mock_server(
         rx: oneshot::Receiver<()>,
-        response: d_engine_proto::client::ScanResponse,
+        response: ClientResponse,
     ) -> std::result::Result<(Channel, u16), tonic::Status> {
         let builder = Box::new(|port: u16| {
             Ok(ClusterMembership {

--- a/d-engine-client/src/proto/client_ext.rs
+++ b/d-engine-client/src/proto/client_ext.rs
@@ -1,5 +1,15 @@
+//! Extends the generated proto `ClientResponse` with typed conversions.
+//!
+//! `ClientResponse` carries its payload as an untyped `oneof` (write/read/scan)
+//! plus a numeric error code. This module unwraps that wire shape into the
+//! typed result each RPC caller actually wants (`bool`, `Vec<KvEntry>`,
+//! `ScanResults`), checking the error code first. Used by `GrpcClient` and the
+//! mock RPC service to go from raw proto response to `ClientApiResult<T>`.
+
 use d_engine_core::client::ErrorCode;
 use d_engine_core::client::KvEntry;
+use d_engine_core::client::LeaderHint;
+use d_engine_core::types::ScanResults;
 use d_engine_proto::client::ClientResponse;
 use d_engine_proto::client::client_response::SuccessResult;
 use tracing::error;
@@ -20,6 +30,12 @@ pub trait ClientResponseExt {
     /// # Returns
     /// Vector of optional key-value pairs wrapped in Result
     fn into_read_results(self) -> std::result::Result<Vec<Option<KvEntry>>, ClientApiError>;
+
+    /// Convert response to prefix-scan results
+    ///
+    /// # Returns
+    /// Matching key-value entries plus the revision anchor
+    fn into_scan_results(self) -> std::result::Result<ScanResults, ClientApiError>;
 
     /// Validate error code in response header
     ///
@@ -100,15 +116,65 @@ impl ClientResponseExt for ClientResponse {
         }
     }
 
+    /// Convert response to prefix-scan results
+    ///
+    /// # Returns
+    /// Matching key-value entries plus the revision anchor
+    fn into_scan_results(self) -> std::result::Result<ScanResults, ClientApiError> {
+        self.validate_error()?;
+        match self.success_result {
+            Some(SuccessResult::ScanData(data)) => Ok(ScanResults {
+                entries: data.entries.into_iter().map(|e| (e.key, e.value)).collect(),
+                revision: data.revision,
+            }),
+            other => {
+                let found = match &other {
+                    Some(SuccessResult::WriteResult(_)) => "WriteResult",
+                    Some(SuccessResult::ReadData(_)) => "ReadData",
+                    None => "None",
+                    _ => "Unknown",
+                };
+                error!(
+                    "Unexpected response type for scan operation: expected ScanData, found {found}"
+                );
+                Err(ClientApiError::Protocol {
+                    code: ErrorCode::InvalidResponse,
+                    message: format!("Unexpected response type: expected ScanData, found {found}"),
+                    supported_versions: None,
+                })
+            }
+        }
+    }
+
     /// Validate error code in response header
     ///
     /// # Internal Logic
     /// Converts numeric error code to enum variant
     fn validate_error(&self) -> std::result::Result<(), ClientApiError> {
-        match ErrorCode::try_from(self.error).unwrap_or(ErrorCode::Uncategorized) {
-            ErrorCode::Success => Ok(()),
-            e => Err(e.into()),
+        let code = ErrorCode::try_from(self.error).unwrap_or(ErrorCode::Uncategorized);
+        if code == ErrorCode::Success {
+            return Ok(());
         }
+
+        // NotLeader carries redirect info in `metadata`, which the generic
+        // `From<ErrorCode>` conversion has no way to see — extract it here,
+        // where `self.metadata` is actually in scope.
+        if code == ErrorCode::NotLeader {
+            let leader_hint = self.metadata.as_ref().and_then(|m| {
+                let leader_id = m.leader_id.as_ref()?.parse::<u32>().ok()?;
+                let address = m.leader_address.clone()?;
+                Some(LeaderHint { leader_id, address })
+            });
+            let retry_after_ms = self.metadata.as_ref().and_then(|m| m.retry_after_ms);
+            return Err(ClientApiError::Network {
+                code,
+                message: "Not leader".to_string(),
+                retry_after_ms: retry_after_ms.or(Some(100)),
+                leader_hint,
+            });
+        }
+
+        Err(code.into())
     }
 
     fn is_write_success(&self) -> bool {

--- a/d-engine-client/src/proto/client_ext_test.rs
+++ b/d-engine-client/src/proto/client_ext_test.rs
@@ -1,11 +1,13 @@
 use bytes::Bytes;
 use d_engine_core::client::ErrorCode;
 use d_engine_core::client::KvEntry;
+use d_engine_core::client::LeaderHint;
 use d_engine_proto::client::ClientResponse;
 use d_engine_proto::client::ClientResult;
 use d_engine_proto::client::ReadResults;
 use d_engine_proto::client::WriteResult;
 use d_engine_proto::client::client_response::SuccessResult;
+use d_engine_proto::error::ErrorMetadata;
 
 use super::*;
 use crate::ClientApiError;
@@ -89,11 +91,49 @@ fn test_into_write_result_with_error_code() {
     let result = response.into_write_result();
     assert!(result.is_err());
 
-    // Should fail at validate_error() before checking success_result
-    if let Err(ClientApiError::Business { code, .. }) = result {
+    // Should fail at validate_error() before checking success_result.
+    // NotLeader carries a leader_hint, so it must be ClientApiError::Network, not Business.
+    if let Err(ClientApiError::Network { code, .. }) = result {
         assert_eq!(code, ErrorCode::NotLeader);
     } else {
-        panic!("Expected Business error with NotLeader code");
+        panic!("Expected Network error with NotLeader code");
+    }
+}
+
+#[test]
+fn test_validate_error_not_leader_carries_leader_hint() {
+    let response = ClientResponse {
+        error: ErrorCode::NotLeader as i32,
+        metadata: Some(ErrorMetadata {
+            retry_after_ms: Some(100),
+            leader_id: Some("2".to_string()),
+            leader_address: Some("127.0.0.1:9082".to_string()),
+            debug_message: None,
+        }),
+        success_result: None,
+    };
+
+    let result = response.validate_error();
+    assert!(result.is_err());
+
+    match result {
+        Err(ClientApiError::Network {
+            code,
+            leader_hint,
+            retry_after_ms,
+            ..
+        }) => {
+            assert_eq!(code, ErrorCode::NotLeader);
+            assert_eq!(
+                leader_hint,
+                Some(LeaderHint {
+                    leader_id: 2,
+                    address: "127.0.0.1:9082".to_string(),
+                })
+            );
+            assert_eq!(retry_after_ms, Some(100));
+        }
+        other => panic!("expected Network error with leader_hint, got {other:?}"),
     }
 }
 
@@ -212,10 +252,103 @@ fn test_into_read_results_with_error_code() {
     let result = response.into_read_results();
     assert!(result.is_err());
 
-    // Should fail at validate_error() before checking success_result
-    if let Err(ClientApiError::Business { code, .. }) = result {
+    // Should fail at validate_error() before checking success_result.
+    // NotLeader carries a leader_hint, so it must be ClientApiError::Network, not Business.
+    if let Err(ClientApiError::Network { code, .. }) = result {
         assert_eq!(code, ErrorCode::NotLeader);
     } else {
-        panic!("Expected Business error with NotLeader code");
+        panic!("Expected Network error with NotLeader code");
+    }
+}
+
+// --- into_scan_results tests ---
+//
+// Mirrors into_write_result/into_read_results above — into_scan_results had
+// zero direct tests before (only exercised indirectly via grpc_client_test.rs
+// success-path tests), unlike its siblings which each have a full set here.
+
+#[test]
+fn test_into_scan_results_success() {
+    use d_engine_proto::client::KvEntry as ProtoKvEntry;
+    use d_engine_proto::client::ScanResults as ProtoScanResults;
+
+    let response = ClientResponse {
+        error: ErrorCode::Success as i32,
+        metadata: None,
+        success_result: Some(SuccessResult::ScanData(ProtoScanResults {
+            entries: vec![ProtoKvEntry {
+                key: Bytes::from("/services/node1"),
+                value: Bytes::from("10.0.0.1"),
+            }],
+            revision: 7,
+        })),
+    };
+
+    let scan = response.into_scan_results().unwrap();
+    assert_eq!(scan.revision, 7);
+    assert_eq!(
+        scan.entries,
+        vec![(Bytes::from("/services/node1"), Bytes::from("10.0.0.1"))]
+    );
+}
+
+#[test]
+fn test_into_scan_results_wrong_variant_write_result() {
+    let response = ClientResponse {
+        error: ErrorCode::Success as i32,
+        metadata: None,
+        success_result: Some(SuccessResult::WriteResult(WriteResult { succeeded: true })),
+    };
+
+    let result = response.into_scan_results();
+    assert!(result.is_err());
+
+    if let Err(ClientApiError::Protocol { code, message, .. }) = result {
+        assert_eq!(code, ErrorCode::InvalidResponse);
+        assert!(message.contains("expected ScanData"));
+        assert!(message.contains("found WriteResult"));
+    } else {
+        panic!("Expected Protocol error");
+    }
+}
+
+#[test]
+fn test_into_scan_results_none_variant() {
+    let response = ClientResponse {
+        error: ErrorCode::Success as i32,
+        metadata: None,
+        success_result: None,
+    };
+
+    let result = response.into_scan_results();
+    assert!(result.is_err());
+
+    if let Err(ClientApiError::Protocol { code, message, .. }) = result {
+        assert_eq!(code, ErrorCode::InvalidResponse);
+        assert!(message.contains("expected ScanData"));
+        assert!(message.contains("found None"));
+    } else {
+        panic!("Expected Protocol error");
+    }
+}
+
+/// #425: scan must fail at validate_error() before ever touching success_result,
+/// and NotLeader must map to Network (leader_hint-capable), not Business —
+/// same contract already proven for write/read, now proven for scan too.
+#[test]
+fn test_into_scan_results_with_error_code() {
+    let response = ClientResponse {
+        error: ErrorCode::NotLeader as i32,
+        metadata: None,
+        success_result: None,
+    };
+
+    let result = response.into_scan_results();
+    assert!(result.is_err());
+
+    if let Err(ClientApiError::Network { code, .. }) = result {
+        assert_eq!(code, ErrorCode::NotLeader);
+    } else {
+        panic!("Expected Network error with NotLeader code");
     }
 }

--- a/d-engine-core/src/client/client_api.rs
+++ b/d-engine-core/src/client/client_api.rs
@@ -26,9 +26,9 @@
 //! ```
 
 use crate::BatchOp;
-use crate::ScanResult;
 use crate::client::client_api_error::ClientApiResult;
 use crate::config::ReadConsistencyPolicy;
+use crate::types::ScanResults;
 use bytes::Bytes;
 
 /// Unified key-value store interface implemented by `EmbeddedClient` and `GrpcClient`.
@@ -57,8 +57,9 @@ pub trait ClientApi: Send + Sync {
     ///
     /// # Errors
     ///
-    /// - [`crate::client::client_api_error::ClientApiError::Network`] if node is shutting down or timeout occurs
-    /// - [`crate::client::client_api_error::ClientApiError::Business`] for server-side errors (e.g., not leader)
+    /// - [`crate::client::client_api_error::ClientApiError::Network`] if node is shutting down, timeout
+    ///   occurs, or the node is not leader (carries `leader_hint` for redirect)
+    /// - [`crate::client::client_api_error::ClientApiError::Business`] for other server-side errors
     ///
     /// # Example
     ///
@@ -126,6 +127,13 @@ pub trait ClientApi: Send + Sync {
     ///
     /// Uses linearizable reads by default, ensuring the returned value
     /// reflects all previously committed writes.
+    ///
+    /// # Future direction
+    /// Any TTL-expiry filtering (as noted below) is an application-specific
+    /// semantic layered on top of a generic read, not a consensus concern.
+    /// See d-lmdb's `wire::Value` envelope + `decode_live_payload`, which
+    /// implements TTL entirely outside d-engine. Don't build long-term
+    /// architecture around this method owning TTL semantics.
     ///
     /// # Arguments
     ///
@@ -393,6 +401,14 @@ pub trait ClientApi: Send + Sync {
     /// Linearizable by default — must see the latest committed state to avoid
     /// silent gaps when used for watch reconnection.
     ///
+    /// # Future direction
+    /// d-engine intends to stop growing built-in read operations like this.
+    /// Reads (get/scan/range) are an application/storage-engine concern, not
+    /// a consensus concern — d-engine's job is replicating the write path and
+    /// exposing leadership/lease primitives, not owning the read API surface.
+    /// Don't build long-term architecture around this method continuing to
+    /// exist here.
+    ///
     /// # Example
     ///
     /// ```rust,ignore
@@ -405,5 +421,5 @@ pub trait ClientApi: Send + Sync {
     async fn scan_prefix(
         &self,
         prefix: impl AsRef<[u8]> + Send,
-    ) -> ClientApiResult<ScanResult>;
+    ) -> ClientApiResult<ScanResults>;
 }

--- a/d-engine-core/src/client/client_api_error.rs
+++ b/d-engine-core/src/client/client_api_error.rs
@@ -154,6 +154,10 @@ impl From<Status> for ClientApiError {
             },
 
             Code::FailedPrecondition => {
+                // The `Some(leader)` branch below is dead today: no server code ever
+                // sets the `x-raft-leader` metadata header this reads, so this always
+                // falls through to the `else`. See parse_leader_from_metadata and
+                // decisions/014.
                 if let Some(leader) = parse_leader_from_metadata(&status) {
                     Self::Network {
                         code: ErrorCode::LeaderChanged,
@@ -176,6 +180,10 @@ impl From<Status> for ClientApiError {
                 required_action: None,
             },
 
+            // Dead branch today: the only `Status::permission_denied(...)` constructors
+            // in the codebase (follower/candidate/learner/leader_state.rs) guard internal
+            // Raft-to-Raft role violations on the `InboundEvent` channel — never the
+            // client-facing path that reaches this conversion. See decisions/014.
             Code::PermissionDenied => Self::Business {
                 code: ErrorCode::NotLeader,
                 message,
@@ -191,6 +199,9 @@ impl From<Status> for ClientApiError {
     }
 }
 
+/// Reads the `x-raft-leader` gRPC metadata header. Confirmed dead today: no
+/// server code in this repo ever sets this header, so callers of this fn
+/// never observe `Some(_)`. See decisions/014.
 fn parse_leader_from_metadata(status: &Status) -> Option<LeaderHint> {
     status
         .metadata()
@@ -242,11 +253,16 @@ impl From<ErrorCode> for ClientApiError {
                 retry_after_ms: None,
                 leader_hint: None,
             },
+            // Dead today: no business logic ever constructs a `ClientResponse` with
+            // `error: ErrorCode::LeaderChanged` — the real NotLeader-redirect path
+            // (create_not_leader_response) always uses `ErrorCode::NotLeader`. The
+            // only producer of this variant is the equally-dead Code::FailedPrecondition
+            // + x-raft-leader branch above. See decisions/014.
             ErrorCode::LeaderChanged => ClientApiError::Network {
                 code,
                 message: "Leader changed".to_string(),
                 retry_after_ms: Some(100), // suggest immediate retry
-                leader_hint: None,         // Note: This would ideally be populated from context
+                leader_hint: None,
             },
             ErrorCode::JoinError => ClientApiError::Network {
                 code,
@@ -290,10 +306,11 @@ impl From<ErrorCode> for ClientApiError {
             },
 
             // Business logic errors
-            ErrorCode::NotLeader => ClientApiError::Business {
+            ErrorCode::NotLeader => ClientApiError::Network {
                 code,
                 message: "Not leader".to_string(),
-                required_action: Some("redirect to leader".to_string()),
+                retry_after_ms: Some(100), // suggest quick retry
+                leader_hint: None, // populated by ClientResponseExt::validate_error() when ErrorMetadata is available
             },
             ErrorCode::StaleOperation => ClientApiError::Business {
                 code,

--- a/d-engine-core/src/client/client_api_error_test.rs
+++ b/d-engine-core/src/client/client_api_error_test.rs
@@ -83,13 +83,24 @@ mod client_api_error_tests {
         assert!(matches!(error, ClientApiError::Network { .. }));
     }
 
+    /// Test: NotLeader is redirectable (carries leader_hint when available), so
+    /// it must be ClientApiError::Network, not Business — Business has no
+    /// leader_hint field. The bare `From<ErrorCode>` conversion has no
+    /// ClientResponse.metadata to read, so leader_hint is None here; a
+    /// populated hint only comes from `ClientResponseExt::validate_error()`.
+    #[test]
+    fn test_not_leader_is_network_error() {
+        let error: ClientApiError = ErrorCode::NotLeader.into();
+        assert_eq!(error.code(), ErrorCode::NotLeader);
+        match error {
+            ClientApiError::Network { leader_hint, .. } => assert_eq!(leader_hint, None),
+            _ => panic!("expected Network error"),
+        }
+    }
+
     /// Test: Business logic error variants
     #[test]
     fn test_business_errors() {
-        let error: ClientApiError = ErrorCode::NotLeader.into();
-        assert_eq!(error.code(), ErrorCode::NotLeader);
-        assert!(matches!(error, ClientApiError::Business { .. }));
-
         let error: ClientApiError = ErrorCode::InvalidRequest.into();
         assert_eq!(error.code(), ErrorCode::InvalidRequest);
         assert!(matches!(error, ClientApiError::Business { .. }));

--- a/d-engine-core/src/client/mod.rs
+++ b/d-engine-core/src/client/mod.rs
@@ -11,7 +11,7 @@ pub use client_api::ClientApi;
 pub use client_api_error::{ClientApiError, ClientApiResult};
 pub use types::{
     ClientReadRequest, ClientResponse, ClientResponsePayload, ClientWriteRequest, ErrorCode,
-    KvEntry, LeaderHint, ReadResults, WriteResult,
+    KvEntry, LeaderHint, ReadResults, ScanResults, WriteResult,
 };
 // ReadConsistencyPolicy lives in config but is part of the public client API surface.
 pub use crate::config::ReadConsistencyPolicy;

--- a/d-engine-core/src/client/types.rs
+++ b/d-engine-core/src/client/types.rs
@@ -62,6 +62,7 @@ pub struct ClientResponse {
 pub enum ClientResponsePayload {
     Write(WriteResult),
     Read(ReadResults),
+    Scan(ScanResults),
 }
 
 /// Result of a successful write operation.
@@ -74,6 +75,12 @@ pub struct WriteResult {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ReadResults {
     pub entries: Vec<KvEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ScanResults {
+    pub entries: Vec<(Bytes, Bytes)>,
+    pub revision: u64,
 }
 
 /// A single key-value pair returned in a read response.
@@ -200,6 +207,22 @@ impl ClientResponse {
             leader_hint: None,
             retry_after_ms: None,
             result: Some(ClientResponsePayload::Read(ReadResults { entries })),
+        }
+    }
+
+    #[inline]
+    pub fn scan_results(
+        entries: Vec<(Bytes, Bytes)>,
+        revision: u64,
+    ) -> Self {
+        Self {
+            error: ErrorCode::Success,
+            leader_hint: None,
+            retry_after_ms: None,
+            result: Some(ClientResponsePayload::Scan(ScanResults {
+                entries,
+                revision,
+            })),
         }
     }
 

--- a/d-engine-core/src/commit_handler/default_commit_handler.rs
+++ b/d-engine-core/src/commit_handler/default_commit_handler.rs
@@ -250,7 +250,7 @@ where
             }
 
             // 2. CRITICAL: Barrier point
-            self.membership.notify_config_applied(entry.index).await;
+            self.membership.notify_config_applied(entry.index);
 
             // 2.5. Notify leader to refresh cluster metadata cache
             // This must happen AFTER membership is applied

--- a/d-engine-core/src/election/election_handler.rs
+++ b/d-engine-core/src/election/election_handler.rs
@@ -49,7 +49,7 @@ where
         debug!("broadcast_vote_requests...");
 
         // Single-node cluster: no peers to vote, automatically win election
-        if membership.is_single_node_cluster().await {
+        if membership.is_single_node_cluster() {
             debug!(
                 "Single-node cluster detected (node_id={}): automatically winning election",
                 self.my_id
@@ -57,7 +57,7 @@ where
             return Ok(());
         }
 
-        let members = membership.voters().await;
+        let members = membership.voters();
         if members.is_empty() {
             error!("No voting members found for node {}", self.my_id);
             return Err(ElectionError::NoVotingMemberFound {

--- a/d-engine-core/src/event.rs
+++ b/d-engine-core/src/event.rs
@@ -23,7 +23,6 @@ use tonic::Status;
 use crate::ApplyResult;
 use crate::MaybeCloneOneshotSender;
 use crate::Result;
-use crate::ScanResult;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct NewCommitData {
@@ -46,7 +45,7 @@ pub enum ClientCmd {
     ),
     Scan(
         bytes::Bytes,
-        MaybeCloneOneshotSender<std::result::Result<ScanResult, Status>>,
+        MaybeCloneOneshotSender<std::result::Result<ClientResponse, Status>>,
     ),
 }
 

--- a/d-engine-core/src/membership.rs
+++ b/d-engine-core/src/membership.rs
@@ -38,16 +38,15 @@ where
     T: TypeConfig,
 {
     /// All nodes (including itself)
-    #[allow(unused)]
-    async fn members(&self) -> Vec<NodeMeta>;
+    fn members(&self) -> Vec<NodeMeta>;
 
     /// All non-self nodes (including Syncing and Active)
     /// Note:
     /// Joining node has not start its inbound event processing engine yet.
-    async fn replication_peers(&self) -> Vec<NodeMeta>;
+    fn replication_peers(&self) -> Vec<NodeMeta>;
 
     /// All non-self nodes in Active state
-    async fn voters(&self) -> Vec<NodeMeta>;
+    fn voters(&self) -> Vec<NodeMeta>;
 
     /// Get the initial cluster size from configuration
     ///
@@ -63,7 +62,7 @@ where
     /// This method is safe to use for cluster topology decisions as it's based on
     /// immutable configuration rather than runtime state that could be affected by
     /// network partitions or bugs.
-    async fn initial_cluster_size(&self) -> usize;
+    fn initial_cluster_size(&self) -> usize;
 
     /// Check if this is a single-node cluster
     ///
@@ -79,25 +78,24 @@ where
     ///
     /// # Safety
     /// Safe for all cluster topology decisions as it's based on immutable configuration.
-    async fn is_single_node_cluster(&self) -> bool {
-        self.initial_cluster_size().await == 1
+    fn is_single_node_cluster(&self) -> bool {
+        self.initial_cluster_size() == 1
     }
 
     /// All pending active nodes in Active state
-    #[allow(unused)]
-    async fn nodes_with_status(
+    fn nodes_with_status(
         &self,
         status: NodeStatus,
     ) -> Vec<NodeMeta>;
 
-    async fn get_node_status(
+    fn get_node_status(
         &self,
         node_id: u32,
     ) -> Option<NodeStatus>;
 
     async fn check_cluster_is_ready(&self) -> Result<()>;
 
-    async fn get_peers_id_with_condition<F>(
+    fn get_peers_id_with_condition<F>(
         &self,
         condition: F,
     ) -> Vec<u32>
@@ -108,7 +106,7 @@ where
     ///
     /// # Parameters
     /// - `current_leader_id`: Optional current leader ID from runtime state
-    async fn retrieve_cluster_membership_config(
+    fn retrieve_cluster_membership_config(
         &self,
         current_leader_id: Option<u32>,
     ) -> ClusterMembership;
@@ -123,7 +121,7 @@ where
         cluster_conf_change_req: &ClusterConfChangeRequest,
     ) -> Result<ClusterConfUpdateResponse>;
 
-    async fn get_cluster_conf_version(&self) -> u64;
+    fn get_cluster_conf_version(&self) -> u64;
 
     async fn update_conf_version(
         &self,
@@ -156,12 +154,12 @@ where
     ) -> Result<()>;
 
     /// Check if the node already exists
-    async fn contains_node(
+    fn contains_node(
         &self,
         node_id: u32,
     ) -> bool;
 
-    async fn retrieve_node_meta(
+    fn retrieve_node_meta(
         &self,
         node_id: u32,
     ) -> Option<NodeMeta>;
@@ -173,15 +171,13 @@ where
     ) -> Result<()>;
 
     /// Forcefully remove faulty nodes
-    #[allow(unused)]
     async fn force_remove_node(
         &self,
         node_id: u32,
     ) -> Result<()>;
 
     /// Get all node status
-    #[allow(unused)]
-    async fn get_all_nodes(&self) -> Vec<NodeMeta>;
+    fn get_all_nodes(&self) -> Vec<NodeMeta>;
 
     /// Pre-warms connection cache for all replication peers
     async fn pre_warm_connections(&self) -> Result<()>;
@@ -192,7 +188,7 @@ where
         conn_type: ConnectionType,
     ) -> Option<Channel>;
 
-    async fn get_address(
+    fn get_address(
         &self,
         node_id: u32,
     ) -> Option<String>;
@@ -203,7 +199,7 @@ where
         change: MembershipChange,
     ) -> Result<()>;
 
-    async fn notify_config_applied(
+    fn notify_config_applied(
         &self,
         index: u64,
     );

--- a/d-engine-core/src/raft.rs
+++ b/d-engine-core/src/raft.rs
@@ -540,7 +540,7 @@ where
                     }),
                 )?;
 
-                let peer_ids = self.ctx.membership().get_peers_id_with_condition(|_| true).await;
+                let peer_ids = self.ctx.membership().get_peers_id_with_condition(|_| true);
 
                 self.role.init_peers_next_index_and_match_index(
                     self.ctx.raft_log().last_entry_id(),

--- a/d-engine-core/src/raft_role/candidate_state.rs
+++ b/d-engine-core/src/raft_role/candidate_state.rs
@@ -282,8 +282,7 @@ impl<T: TypeConfig> RaftRoleState for CandidateState<T> {
             InboundEvent::ClusterConf(_metadata_request, sender) => {
                 let cluster_conf = ctx
                     .membership()
-                    .retrieve_cluster_membership_config(self.shared_state().current_leader())
-                    .await;
+                    .retrieve_cluster_membership_config(self.shared_state().current_leader());
                 debug!("Candidate receive ClusterConf: {:?}", &cluster_conf);
 
                 if let Err(e) = sender.send(Ok(cluster_conf)) {
@@ -296,7 +295,7 @@ impl<T: TypeConfig> RaftRoleState for CandidateState<T> {
             }
 
             InboundEvent::ClusterConfUpdate(cluste_conf_change_request, sender) => {
-                let current_conf_version = ctx.membership().get_cluster_conf_version().await;
+                let current_conf_version = ctx.membership().get_cluster_conf_version();
 
                 let current_leader_id = self.shared_state().current_leader();
 

--- a/d-engine-core/src/raft_role/candidate_state_test.rs
+++ b/d-engine-core/src/raft_role/candidate_state_test.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::MockRaftLog;
 use crate::client::ClientReadRequest;
+use crate::client::ClientResponse;
 use crate::client::ClientWriteRequest;
 use crate::client::ErrorCode;
 use crate::config::ReadConsistencyPolicy;
@@ -1189,10 +1190,12 @@ async fn test_handle_client_write_returns_not_leader() {
     state.push_client_cmd(cmd, &context);
 
     let result = resp_rx.recv().await.expect("channel should not be closed");
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    assert_eq!(err.code(), tonic::Code::FailedPrecondition);
-    assert!(err.message().contains("Not leader"));
+    match result {
+        Ok(ClientResponse { error, .. }) => assert_eq!(error, ErrorCode::NotLeader),
+        Err(status) => panic!(
+            "expected Ok(ClientResponse {{ error: NotLeader, .. }}), got bare Err(Status): {status:?}"
+        ),
+    }
 }
 
 /// Test: send_replay_inbound_event sends correct events
@@ -1423,12 +1426,13 @@ mod handle_client_read_request {
         state.push_client_cmd(cmd, &context);
 
         // MaybeCloneOneshot in test mode sends values through broadcast channel
-        // The Status error is sent as a value, not as channel error
         let result = resp_rx.recv().await.expect("channel should not be closed");
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
-        assert!(err.message().contains("Not leader"));
+        match result {
+            Ok(ClientResponse { error, .. }) => assert_eq!(error, ErrorCode::NotLeader),
+            Err(status) => panic!(
+                "expected Ok(ClientResponse {{ error: NotLeader, .. }}), got bare Err(Status): {status:?}"
+            ),
+        }
     }
 
     /// Test: ClientReadRequest with EventualConsistency succeeds

--- a/d-engine-core/src/raft_role/follower_state.rs
+++ b/d-engine-core/src/raft_role/follower_state.rs
@@ -267,8 +267,7 @@ impl<T: TypeConfig> RaftRoleState for FollowerState<T> {
             InboundEvent::ClusterConf(_metadata_request, sender) => {
                 let cluster_conf = ctx
                     .membership()
-                    .retrieve_cluster_membership_config(self.shared_state().current_leader())
-                    .await;
+                    .retrieve_cluster_membership_config(self.shared_state().current_leader());
                 debug!("Follower receive ClusterConf: {:?}", &cluster_conf);
 
                 sender.send(Ok(cluster_conf)).map_err(|e| {
@@ -278,7 +277,7 @@ impl<T: TypeConfig> RaftRoleState for FollowerState<T> {
             }
 
             InboundEvent::ClusterConfUpdate(cluste_conf_change_request, sender) => {
-                let current_conf_version = ctx.membership().get_cluster_conf_version().await;
+                let current_conf_version = ctx.membership().get_cluster_conf_version();
 
                 let current_leader_id = self.shared_state().current_leader();
 
@@ -414,7 +413,7 @@ impl<T: TypeConfig> RaftRoleState for FollowerState<T> {
             InboundEvent::DiscoverLeader(request, sender) => {
                 debug!(?request, "Follower::InboundEvent::DiscoverLeader");
                 let response = match self.shared_state().current_leader() {
-                    Some(leader_id) => match ctx.membership().retrieve_node_meta(leader_id).await {
+                    Some(leader_id) => match ctx.membership().retrieve_node_meta(leader_id) {
                         Some(meta) => Ok(LeaderDiscoveryResponse {
                             leader_id,
                             leader_address: meta.address,

--- a/d-engine-core/src/raft_role/follower_state_test.rs
+++ b/d-engine-core/src/raft_role/follower_state_test.rs
@@ -1,6 +1,8 @@
 use crate::client::ClientReadRequest;
+use crate::client::ClientResponse;
 use crate::client::ClientWriteRequest;
 use crate::client::ErrorCode;
+use crate::client::LeaderHint;
 use crate::config::ReadConsistencyPolicy;
 use d_engine_proto::common::LogId;
 use d_engine_proto::common::NodeRole;
@@ -38,6 +40,7 @@ use crate::MockReplicationCore;
 use crate::MockStateMachineHandler;
 use crate::NetworkError;
 use crate::NewCommitData;
+use crate::RaftContext;
 use crate::RaftLog;
 use crate::RaftOneshot;
 use crate::StateUpdate;
@@ -49,6 +52,7 @@ use crate::raft_role::learner_state::LearnerState;
 use crate::raft_role::role_state::RaftRoleState;
 use crate::test_utils::mock::MockBuilder;
 use crate::test_utils::mock::MockTypeConfig;
+use crate::test_utils::mock::mock_membership;
 use crate::test_utils::mock::mock_raft_context;
 use crate::test_utils::mock::mock_raft_context_with_temp;
 use crate::test_utils::mock::mock_raft_log;
@@ -61,6 +65,41 @@ use tokio::sync::{mpsc, watch};
 // ============================================================================
 // Helper Functions
 // ============================================================================
+
+/// Build a mock RaftContext whose `Membership::get_address` resolves only
+/// `known_id` -> `known_address`; any other id returns `None`.
+///
+/// `mock_raft_context_with_temp`'s `peers_meta_option` does NOT wire into
+/// `MockMembership` (it only sets `node_config.cluster.initial_cluster`, a
+/// config field `MockMembership` never reads) — tests that need
+/// `get_address` to resolve must configure it explicitly via
+/// `MockBuilder::with_membership`, which is what this helper does.
+fn mock_context_with_leader_address(
+    graceful_rx: watch::Receiver<()>,
+    known_id: u32,
+    known_address: &str,
+) -> (RaftContext<MockTypeConfig>, tempfile::TempDir) {
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let mut node_config = node_config(temp_dir.path().to_str().unwrap());
+    node_config.raft.batching.max_batch_size = 1;
+    node_config.retry.auto_discovery.timeout_ms = 10;
+
+    let known_address = known_address.to_string();
+    let mut membership = mock_membership();
+    membership.expect_get_address().returning(move |id| {
+        if id == known_id {
+            Some(known_address.clone())
+        } else {
+            None
+        }
+    });
+
+    let context = MockBuilder::new(graceful_rx)
+        .with_node_config(node_config)
+        .with_membership(membership)
+        .build_context();
+    (context, temp_dir)
+}
 
 fn create_vote_request_event(
     term: u64,
@@ -1468,24 +1507,25 @@ async fn test_handle_cluster_conf_update_when_leader_unknown() {
 ///
 /// Scenario:
 /// - Follower receives ClientWriteRequest (write must go to leader)
-/// - Follower is not the leader
+/// - Follower is not the leader, but knows who is (id + address in membership)
 ///
 /// Expected:
-/// - Returns response with error_code = NOT_LEADER
-/// - handle_inbound_event returns Ok(())
+/// - Returns Ok(ClientResponse) with error = NotLeader
+/// - `leader_hint` is populated so the caller can actually redirect, not just
+///   told "not leader" with nowhere to go
 /// - No state changes
 ///
 /// This validates the core Raft rule: Only leader can process writes.
-/// Follower must redirect client to leader.
 ///
 /// Original: test_handle_inbound_event_case5
 #[tokio::test]
 async fn test_handle_client_write_request_redirects_to_leader() {
     let (_graceful_tx, graceful_rx) = watch::channel(());
-    let (context, _temp_dir) = mock_raft_context_with_temp(graceful_rx, None);
+    let (context, _temp_dir) = mock_context_with_leader_address(graceful_rx, 2, "127.0.0.1:9082");
 
     let mut state =
         FollowerState::<MockTypeConfig>::new(1, context.node_config.clone(), None, None);
+    state.shared_state().set_current_leader(2);
 
     let (resp_tx, mut resp_rx) = MaybeCloneOneshot::new();
     let cmd = ClientCmd::Propose(
@@ -1501,19 +1541,93 @@ async fn test_handle_client_write_request_redirects_to_leader() {
     // Action: Handle ClientWriteRequest
     state.push_client_cmd(cmd, &context);
 
-    // Verify: Response with NOT_LEADER error
+    // Verify: NOT_LEADER response, structured so the caller can redirect
     let result = resp_rx.recv().await.expect("channel should not be closed");
-    assert!(result.is_err(), "Should return NOT_LEADER error");
-    let err = result.unwrap_err();
-    assert_eq!(err.code(), tonic::Code::FailedPrecondition);
-    assert!(err.message().contains("Not leader"));
+    match result {
+        Ok(ClientResponse {
+            error, leader_hint, ..
+        }) => {
+            assert_eq!(error, ErrorCode::NotLeader);
+            assert_eq!(
+                leader_hint,
+                Some(LeaderHint {
+                    leader_id: 2,
+                    address: "127.0.0.1:9082".to_string(),
+                }),
+                "must carry the leader's id and address so the caller can redirect"
+            );
+        }
+        Err(status) => panic!(
+            "expected Ok(ClientResponse {{ error: NotLeader, leader_hint: Some(_) }}), got bare Err(Status): {status:?}"
+        ),
+    }
+}
+
+// ============================================================================
+// create_not_leader_response() Tests
+// ============================================================================
+
+/// Leader known and its address is in cluster membership -> hint populated.
+#[tokio::test]
+async fn test_create_not_leader_response_returns_hint_when_leader_address_known() {
+    let (_graceful_tx, graceful_rx) = watch::channel(());
+    let (context, _temp_dir) = mock_context_with_leader_address(graceful_rx, 2, "127.0.0.1:9082");
+
+    let state = FollowerState::<MockTypeConfig>::new(1, context.node_config.clone(), None, None);
+    state.shared_state().set_current_leader(2);
+
+    let response = state.create_not_leader_response(&context);
+
+    assert_eq!(response.error, ErrorCode::NotLeader);
+    assert_eq!(
+        response.leader_hint,
+        Some(LeaderHint {
+            leader_id: 2,
+            address: "127.0.0.1:9082".to_string(),
+        }),
+        "must return the leader's id and address so the caller can redirect"
+    );
+}
+
+/// Leader id known but missing from membership (stale view) -> no hint, not a crash.
+#[tokio::test]
+async fn test_create_not_leader_response_returns_no_hint_when_leader_address_unknown() {
+    let (_graceful_tx, graceful_rx) = watch::channel(());
+    // Membership only knows about node 2 — id 99 (set as leader below) resolves to None.
+    let (context, _temp_dir) = mock_context_with_leader_address(graceful_rx, 2, "127.0.0.1:9082");
+
+    let state = FollowerState::<MockTypeConfig>::new(1, context.node_config.clone(), None, None);
+    state.shared_state().set_current_leader(99); // no membership entry for id 99
+
+    let response = state.create_not_leader_response(&context);
+
+    assert_eq!(response.error, ErrorCode::NotLeader);
+    assert_eq!(
+        response.leader_hint, None,
+        "must degrade to no hint, not panic, when the known leader id isn't in membership"
+    );
+}
+
+/// No leader known at all (e.g. mid-election) -> no hint.
+#[tokio::test]
+async fn test_create_not_leader_response_returns_no_hint_when_leader_unknown() {
+    let (_graceful_tx, graceful_rx) = watch::channel(());
+    let (context, _temp_dir) = mock_raft_context_with_temp(graceful_rx, None);
+
+    let state = FollowerState::<MockTypeConfig>::new(1, context.node_config.clone(), None, None);
+    // current_leader() defaults to None; not set here.
+
+    let response = state.create_not_leader_response(&context);
+
+    assert_eq!(response.error, ErrorCode::NotLeader);
+    assert_eq!(response.leader_hint, None);
 }
 
 /// Test: FollowerState rejects ClientCmd::Scan with NotLeader error
 ///
 /// Scan reads require linearizable prefix enumeration from the leader.
-/// Followers must reject immediately with FailedPrecondition so the client
-/// can redirect to the current leader.
+/// Followers must reject with Ok(ClientResponse{ error: NotLeader, .. }), same
+/// as Propose/Read, so the client can redirect to the current leader.
 #[tokio::test]
 async fn test_scan_cmd_follower_rejects_with_not_leader() {
     use bytes::Bytes;
@@ -1530,10 +1644,14 @@ async fn test_scan_cmd_follower_rejects_with_not_leader() {
     state.push_client_cmd(cmd, &context);
 
     let result = resp_rx.recv().await.expect("channel should not be closed");
-    assert!(result.is_err(), "Scan on follower should return error");
-    let err = result.unwrap_err();
-    assert_eq!(err.code(), tonic::Code::FailedPrecondition);
-    assert!(err.message().contains("Not leader"));
+    match result {
+        Ok(ClientResponse { error, .. }) => {
+            assert_eq!(error, ErrorCode::NotLeader);
+        }
+        Err(status) => panic!(
+            "expected Ok(ClientResponse {{ error: NotLeader, .. }}), got bare Err(Status): {status:?}"
+        ),
+    }
 }
 
 /// Test: FollowerState rejects ClientReadRequest with LinearizableRead policy
@@ -1572,10 +1690,14 @@ async fn test_handle_client_read_request_linearizable_redirects_to_leader() {
 
     // Verify: Response with NOT_LEADER error
     let result = resp_rx.recv().await.expect("channel should not be closed");
-    assert!(result.is_err(), "Should return NOT_LEADER error");
-    let err = result.unwrap_err();
-    assert_eq!(err.code(), tonic::Code::FailedPrecondition);
-    assert!(err.message().contains("Not leader"));
+    match result {
+        Ok(ClientResponse { error, .. }) => {
+            assert_eq!(error, ErrorCode::NotLeader);
+        }
+        Err(status) => panic!(
+            "expected Ok(ClientResponse {{ error: NotLeader, .. }}), got bare Err(Status): {status:?}"
+        ),
+    }
 }
 
 /// Test: FollowerState handles ClientReadRequest with EventualConsistency policy
@@ -2129,10 +2251,18 @@ mod handle_client_read_request {
         state.push_client_cmd(cmd, &context);
 
         let result = resp_rx.recv().await.expect("channel should not be closed");
-        assert!(result.is_err(), "LeaseRead should be rejected by follower");
-        let err = result.unwrap_err();
-        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
-        assert!(err.message().contains("Not leader"));
+        match result {
+            Ok(ClientResponse { error, .. }) => {
+                assert_eq!(
+                    error,
+                    ErrorCode::NotLeader,
+                    "LeaseRead should be rejected by follower"
+                );
+            }
+            Err(status) => panic!(
+                "expected Ok(ClientResponse {{ error: NotLeader, .. }}), got bare Err(Status): {status:?}"
+            ),
+        }
     }
 
     /// Test: Follower uses server default policy (LinearizableRead)
@@ -2175,13 +2305,18 @@ mod handle_client_read_request {
         state.push_client_cmd(cmd, &context);
 
         let result = resp_rx.recv().await.expect("channel should not be closed");
-        assert!(
-            result.is_err(),
-            "Default LinearizableRead should be rejected by follower"
-        );
-        let err = result.unwrap_err();
-        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
-        assert!(err.message().contains("Not leader"));
+        match result {
+            Ok(ClientResponse { error, .. }) => {
+                assert_eq!(
+                    error,
+                    ErrorCode::NotLeader,
+                    "Default LinearizableRead should be rejected by follower"
+                );
+            }
+            Err(status) => panic!(
+                "expected Ok(ClientResponse {{ error: NotLeader, .. }}), got bare Err(Status): {status:?}"
+            ),
+        }
     }
 
     /// Test: Follower serves EventualConsistency reads
@@ -2327,13 +2462,18 @@ mod handle_client_read_request {
 
         // Follower must reject: server default is LinearizableRead which requires leader
         let result = resp_rx.recv().await.expect("channel should not be closed");
-        assert!(
-            result.is_err(),
-            "Follower must reject LinearizableRead (requires leader)"
-        );
-        let err = result.unwrap_err();
-        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
-        assert!(err.message().contains("Not leader"));
+        match result {
+            Ok(ClientResponse { error, .. }) => {
+                assert_eq!(
+                    error,
+                    ErrorCode::NotLeader,
+                    "Follower must reject LinearizableRead (requires leader)"
+                );
+            }
+            Err(status) => panic!(
+                "expected Ok(ClientResponse {{ error: NotLeader, .. }}), got bare Err(Status): {status:?}"
+            ),
+        }
     }
 }
 
@@ -2629,14 +2769,11 @@ async fn test_follower_rejects_strong_consistency_reads() {
         );
 
         // Verify: Response is NOT_LEADER error
-        if let Ok(Err(err)) = result {
-            let err_str = format!("{err:?}");
-            assert!(
-                err_str.contains("Not leader")
-                    || err_str.contains("NotLeader")
-                    || err_str.contains("NOT_LEADER")
-                    || err_str.contains("FailedPrecondition"),
-                "Expected NOT_LEADER error for Lease read, got: {err:?}"
+        if let Ok(Ok(ClientResponse { error, .. })) = result {
+            assert_eq!(
+                error,
+                ErrorCode::NotLeader,
+                "Expected NOT_LEADER error for Lease read"
             );
         } else {
             panic!("Lease read to Follower should return NOT_LEADER error, got: {result:?}");
@@ -2669,14 +2806,11 @@ async fn test_follower_rejects_strong_consistency_reads() {
         );
 
         // Verify: Response is NOT_LEADER error
-        if let Ok(Err(err)) = result {
-            let err_str = format!("{err:?}");
-            assert!(
-                err_str.contains("Not leader")
-                    || err_str.contains("NotLeader")
-                    || err_str.contains("NOT_LEADER")
-                    || err_str.contains("FailedPrecondition"),
-                "Expected NOT_LEADER error for Linear read, got: {err:?}"
+        if let Ok(Ok(ClientResponse { error, .. })) = result {
+            assert_eq!(
+                error,
+                ErrorCode::NotLeader,
+                "Expected NOT_LEADER error for Linear read"
             );
         } else {
             panic!("Linear read to Follower should return NOT_LEADER error, got: {result:?}");

--- a/d-engine-core/src/raft_role/leader_state.rs
+++ b/d-engine-core/src/raft_role/leader_state.rs
@@ -565,11 +565,11 @@ impl<T: TypeConfig> RaftRoleState for LeaderState<T> {
         membership: &Arc<T::M>,
     ) -> Result<()> {
         // Calculate total voter count including self as leader
-        let voters = membership.voters().await;
+        let voters = membership.voters();
         let total_voters = voters.len() + 1; // +1 for leader (self)
 
         // Get all replication targets (voters + learners, excluding self)
-        let replication_targets = membership.replication_peers().await;
+        let replication_targets = membership.replication_peers();
 
         // Single-voter cluster: only this node is a voter (quorum = 1)
         let single_voter = total_voters == 1;
@@ -736,6 +736,24 @@ impl<T: TypeConfig> RaftRoleState for LeaderState<T> {
         Ok(())
     }
 
+    /// Drains all buffered/pending client requests on role change (stepdown).
+    ///
+    /// # Note (ticket #425)
+    /// None of the drains below — read queues or `propose_buffer` alike —
+    /// return `leader_hint`. This whole function runs while role is still
+    /// Leader and `current_leader()` hasn't been updated to the new leader yet
+    /// (that happens after, via `notify_leader_change`), so any hint built
+    /// here would be stale/wrong no matter which queue it's for — this is one
+    /// reason applying uniformly to the whole function, not a per-queue
+    /// decision. Unlike client-initiated NotLeader rejections
+    /// (`create_not_leader_response`), this is the node clearing its own
+    /// pending requests during a role-transition window with uncertain leader
+    /// identity, not a stable node redirecting a live request.
+    ///
+    /// TODO: most `BecomeFollower` triggers pass `leader_id: None` anyway
+    /// (e.g. a higher-term RequestVote doesn't guarantee that candidate wins) —
+    /// if revisited, verify the real leader_id is reliably known before adding
+    /// a hint anywhere in this function.
     fn drain_read_buffer(&mut self) -> Result<()> {
         // Drain linearizable read buffer
         let batch = self.linearizable_read_buffer.take_all();
@@ -923,8 +941,12 @@ impl<T: TypeConfig> RaftRoleState for LeaderState<T> {
                 }
             }
             ClientCmd::Scan(prefix, sender) => {
-                let result = ctx.state_machine().scan_prefix(&prefix);
-                let _ = sender.send(result.map_err(|e| Status::internal(e.to_string())));
+                let response = ctx
+                    .state_machine()
+                    .scan_prefix(&prefix)
+                    .map(|sr| ClientResponse::scan_results(sr.entries, sr.revision))
+                    .map_err(|e| Status::internal(e.to_string()));
+                let _ = sender.send(response);
             }
         }
     }
@@ -1028,7 +1050,7 @@ impl<T: TypeConfig> RaftRoleState for LeaderState<T> {
                 // `Option::and` returns None if noop_log_id is None, Some(id) otherwise.
                 let current_leader = self.noop_log_id.and(self.shared_state().current_leader());
                 let cluster_conf =
-                    ctx.membership().retrieve_cluster_membership_config(current_leader).await;
+                    ctx.membership().retrieve_cluster_membership_config(current_leader);
                 debug!("Leader receive ClusterConf: {:?}", &cluster_conf);
                 if let Err(e) = sender.send(Ok(cluster_conf)) {
                     // Receiver timed out and dropped — this is normal, do not crash the node
@@ -1040,7 +1062,7 @@ impl<T: TypeConfig> RaftRoleState for LeaderState<T> {
             }
 
             InboundEvent::ClusterConfUpdate(cluste_conf_change_request, sender) => {
-                let current_conf_version = ctx.membership().get_cluster_conf_version().await;
+                let current_conf_version = ctx.membership().get_cluster_conf_version();
                 debug!(%current_conf_version, ?cluste_conf_change_request,
                     "handle_inbound_event::InboundEvent::ClusterConfUpdate",
                 );
@@ -1145,7 +1167,7 @@ impl<T: TypeConfig> RaftRoleState for LeaderState<T> {
             InboundEvent::DiscoverLeader(request, sender) => {
                 debug!(?request, "Leader::InboundEvent::DiscoverLeader");
 
-                if let Some(meta) = ctx.membership().retrieve_node_meta(my_id).await {
+                if let Some(meta) = ctx.membership().retrieve_node_meta(my_id) {
                     let response = LeaderDiscoveryResponse {
                         leader_id: my_id,
                         leader_address: meta.address,
@@ -1715,9 +1737,9 @@ impl<T: TypeConfig> RaftRoleState for LeaderState<T> {
 
         // Step 2: Get current voter count (including self as leader)
         let membership = ctx.membership();
-        let current_voters = membership.voters().await.len() + 1; // +1 for self (leader)
+        let current_voters = membership.voters().len() + 1; // +1 for self (leader)
         debug!(
-            "[Leader {}] 📊 current_voters: {}, pending: {}",
+            "[Leader {}] current_voters: {}, pending: {}",
             self.node_id(),
             current_voters,
             self.pending_promotions.len()
@@ -1778,7 +1800,7 @@ impl<T: TypeConfig> RaftRoleState for LeaderState<T> {
 
             info!(
                 "Promotion successful. Cluster members: {:?}",
-                membership.voters().await
+                membership.voters()
             );
         }
 
@@ -2398,11 +2420,11 @@ impl<T: TypeConfig> LeaderState<T> {
         membership: &Arc<T::M>,
     ) -> Result<()> {
         // Calculate total voter count including self as leader
-        let voters = membership.voters().await;
+        let voters = membership.voters();
         let total_voters = voters.len() + 1; // +1 for leader (self)
 
         // Get all replication targets (voters + learners, excluding self)
-        let replication_targets = membership.replication_peers().await;
+        let replication_targets = membership.replication_peers();
 
         // Single-voter cluster: only this node is a voter (quorum = 1)
         let single_voter = total_voters == 1;
@@ -2693,7 +2715,7 @@ impl<T: TypeConfig> LeaderState<T> {
                 node_id, match_index_opt
             );
 
-            if !membership.contains_node(node_id).await {
+            if !membership.contains_node(node_id) {
                 trace!(
                     "[FIND-PROMOTABLE-LOOP] ❌ Learner {} NOT in membership, skipping",
                     node_id
@@ -2725,8 +2747,7 @@ impl<T: TypeConfig> LeaderState<T> {
 
             trace!("[FIND-PROMOTABLE-LOOP] ✅ Learner {} IS caught up", node_id);
 
-            let node_status =
-                membership.get_node_status(node_id).await.unwrap_or(NodeStatus::ReadOnly);
+            let node_status = membership.get_node_status(node_id).unwrap_or(NodeStatus::ReadOnly);
             if !node_status.is_promotable() {
                 debug!(
                     ?node_id,
@@ -2907,7 +2928,7 @@ impl<T: TypeConfig> LeaderState<T> {
 
         // 1. Validate join request
         debug!("1. Validate join request");
-        if membership.contains_node(node_id).await {
+        if membership.contains_node(node_id) {
             let error_msg = format!("Node {node_id} already exists in cluster");
             warn!(%error_msg);
             return self.send_join_error(sender, MembershipError::NodeAlreadyExists(node_id)).await;
@@ -2989,10 +3010,9 @@ impl<T: TypeConfig> LeaderState<T> {
             error: String::new(),
             config: Some(
                 ctx.membership()
-                    .retrieve_cluster_membership_config(self.shared_state().current_leader())
-                    .await,
+                    .retrieve_cluster_membership_config(self.shared_state().current_leader()),
             ),
-            config_version: ctx.membership().get_cluster_conf_version().await,
+            config_version: ctx.membership().get_cluster_conf_version(),
             snapshot_metadata,
             leader_id: self.node_id(),
         };
@@ -3498,7 +3518,7 @@ impl<T: TypeConfig> LeaderState<T> {
         _internal_event_tx: &mpsc::UnboundedSender<InternalEvent>,
         ctx: &RaftContext<T>,
     ) -> Result<()> {
-        let status = ctx.membership().get_node_status(node_id).await;
+        let status = ctx.membership().get_node_status(node_id);
 
         if status.is_none() {
             debug!(node_id, "Zombie signal ignored: node not in cluster");

--- a/d-engine-core/src/raft_role/leader_state_test/buffer_cleanup_test.rs
+++ b/d-engine-core/src/raft_role/leader_state_test/buffer_cleanup_test.rs
@@ -4,8 +4,11 @@ use crate::MaybeCloneOneshot;
 use crate::MockBuilder;
 use crate::RaftOneshot;
 use crate::RaftRole;
+use crate::client::ClientResponse;
 use crate::client::ClientWriteRequest;
+use crate::client::ErrorCode;
 use crate::raft_role::role_state::RaftRoleState;
+use crate::test_utils::mock::mock_membership;
 use bytes::Bytes;
 use d_engine_proto::client::WriteCommand;
 use prost::Message;
@@ -33,7 +36,22 @@ use tokio::sync::watch;
 #[tokio::test]
 async fn test_leader_stepdown_clears_pending_write_buffer() {
     let (_graceful_tx, graceful_rx) = watch::channel(());
-    let mut raft = MockBuilder::new(graceful_rx).build_raft();
+    // propose_buffer's drain-on-stepdown (this test's main flow) intentionally
+    // does NOT call get_address — see decisions/013 (#425). The stub below is
+    // for a different call site: the fresh write sent to the settled Follower
+    // further down, which goes through push_client_cmd's default rejection
+    // (create_not_leader_response) and does call Membership::get_address(..).
+    // mock_membership() has no default stub for that, so a catch-all is added
+    // to avoid a panic regardless of which node id ends up queried.
+    let mut membership = mock_membership();
+    membership.expect_get_address().returning(|id| {
+        if id == 2 {
+            Some("127.0.0.1:9082".to_string())
+        } else {
+            None
+        }
+    });
+    let mut raft = MockBuilder::new(graceful_rx).with_membership(membership).build_raft();
 
     // Setup mocks
     let mut raft_log = crate::MockRaftLog::new();
@@ -116,20 +134,16 @@ async fn test_leader_stepdown_clears_pending_write_buffer() {
         let result = tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv()).await;
 
         match result {
-            Ok(Ok(Err(err))) => {
-                // Expected: Client receives NOT_LEADER error
-                let err_str = format!("{err:?}");
-                assert!(
-                    err_str.contains("Not leader")
-                        || err_str.contains("NotLeader")
-                        || err_str.contains("NOT_LEADER")
-                        || err_str.contains("FailedPrecondition"),
-                    "Write {i} should return NOT_LEADER error, got: {err:?}"
-                );
+            Ok(Ok(Err(status))) => {
+                // Expected: propose_buffer's stepdown drain rejects with a bare
+                // Status, no leader_hint — see decisions/013 (#425) for why
+                // this path intentionally differs from create_not_leader_response.
+                assert_eq!(status.code(), tonic::Code::FailedPrecondition);
+                assert!(status.message().contains("Not leader"));
                 notified_errors += 1;
             }
-            Ok(Ok(Ok(_))) => {
-                panic!("Write {i} should not succeed after stepdown");
+            Ok(Ok(Ok(response))) => {
+                panic!("Write {i} should not succeed after stepdown, got: {response:?}");
             }
             Ok(Err(_)) => {
                 // Channel closed - buffer was dropped without explicit notification
@@ -173,17 +187,15 @@ async fn test_leader_stepdown_clears_pending_write_buffer() {
                 .expect("Timed out waiting for Follower rejection response");
         assert!(result.is_ok(), "Should receive response");
 
-        if let Ok(Err(err)) = result {
-            let err_str = format!("{err:?}");
-            assert!(
-                err_str.contains("Not leader")
-                    || err_str.contains("NotLeader")
-                    || err_str.contains("NOT_LEADER")
-                    || err_str.contains("FailedPrecondition"),
-                "New write should return NOT_LEADER, got: {err:?}"
-            );
-        } else {
-            panic!("New write to Follower should return NOT_LEADER error");
+        match result {
+            Ok(Ok(ClientResponse { error, .. })) => {
+                assert_eq!(
+                    error,
+                    ErrorCode::NotLeader,
+                    "New write should return NOT_LEADER"
+                );
+            }
+            other => panic!("New write to Follower should return NOT_LEADER error, got: {other:?}"),
         }
     } else {
         panic!("Expected Follower state");

--- a/d-engine-core/src/raft_role/leader_state_test/client_read_test.rs
+++ b/d-engine-core/src/raft_role/leader_state_test/client_read_test.rs
@@ -2,10 +2,12 @@ use crate::ClientCmd;
 use crate::MockMembership;
 use crate::MockStateMachineHandler;
 use crate::ReadConsistencyPolicy;
-use crate::client::{ClientReadRequest, ErrorCode};
+use crate::ScanResult;
+use crate::client::{ClientReadRequest, ClientResponsePayload, ErrorCode};
 use crate::convert::safe_kv_bytes;
 use crate::maybe_clone_oneshot::MaybeCloneOneshot;
 use crate::maybe_clone_oneshot::RaftOneshot;
+use crate::mock_state_machine;
 use crate::raft_role::leader_state::LeaderState;
 use crate::raft_role::role_state::RaftRoleState;
 use crate::test_utils::MockBuilder;
@@ -2223,9 +2225,6 @@ async fn test_linearizable_read_served_without_quorum_in_minority_partition() {
 #[tokio::test]
 #[traced_test]
 async fn test_scan_cmd_leader_delivers_result() {
-    use crate::ScanResult;
-    use crate::test_utils::mock_state_machine;
-
     let mut sm = mock_state_machine();
     sm.expect_scan_prefix().returning(|_prefix| {
         Ok(ScanResult {
@@ -2249,8 +2248,13 @@ async fn test_scan_cmd_leader_delivers_result() {
     );
 
     let result = resp_rx.recv().await.expect("channel not closed").expect("scan succeeded");
-    assert_eq!(result.revision, 42);
-    assert!(result.entries.is_empty());
+    match result.result {
+        Some(ClientResponsePayload::Scan(scan_result)) => {
+            assert_eq!(scan_result.revision, 42);
+            assert!(scan_result.entries.is_empty());
+        }
+        other => panic!("expected Scan payload, got {other:?}"),
+    }
 }
 
 /// Test: LeaderState::push_client_cmd with ClientCmd::Scan propagates state-

--- a/d-engine-core/src/raft_role/learner_state.rs
+++ b/d-engine-core/src/raft_role/learner_state.rs
@@ -240,7 +240,7 @@ impl<T: TypeConfig> RaftRoleState for LearnerState<T> {
             }
 
             InboundEvent::ClusterConfUpdate(cluste_conf_change_request, sender) => {
-                let current_conf_version = ctx.membership().get_cluster_conf_version().await;
+                let current_conf_version = ctx.membership().get_cluster_conf_version();
 
                 let current_leader_id = self.shared_state().current_leader();
 
@@ -577,7 +577,7 @@ impl<T: TypeConfig> RaftRoleState for LearnerState<T> {
     ) -> Result<()> {
         // Check if this learner has been promoted to Voter
         let my_id = self.node_id();
-        let node_meta = ctx.membership().retrieve_node_meta(my_id).await;
+        let node_meta = ctx.membership().retrieve_node_meta(my_id);
 
         if let Some(meta) = node_meta {
             // Check if role is Voter (any role except LEARNER)

--- a/d-engine-core/src/raft_role/learner_state_test.rs
+++ b/d-engine-core/src/raft_role/learner_state_test.rs
@@ -9,8 +9,10 @@ use crate::MockStateMachineHandler;
 use crate::NewCommitData;
 use crate::RaftOneshot;
 use crate::client::ClientReadRequest;
+use crate::client::ClientResponse;
 use crate::client::ClientResponsePayload;
 use crate::client::ClientWriteRequest;
+use crate::client::ErrorCode;
 use crate::client::KvEntry;
 use crate::config::ReadConsistencyPolicy;
 use crate::raft_role::candidate_state::CandidateState;
@@ -517,10 +519,12 @@ async fn test_learner_rejects_client_write_request() {
     state.push_client_cmd(cmd, &context);
 
     let result = resp_rx.recv().await.expect("channel should not be closed");
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    assert_eq!(err.code(), tonic::Code::FailedPrecondition);
-    assert!(err.message().contains("Not leader"));
+    match result {
+        Ok(ClientResponse { error, .. }) => assert_eq!(error, ErrorCode::NotLeader),
+        Err(status) => panic!(
+            "expected Ok(ClientResponse {{ error: NotLeader, .. }}), got bare Err(Status): {status:?}"
+        ),
+    }
 }
 
 /// Test: LearnerState rejects ClientReadRequest
@@ -553,10 +557,12 @@ async fn test_learner_rejects_client_read_request() {
     state.push_client_cmd(cmd, &context);
 
     let result = resp_rx.recv().await.expect("channel should not be closed");
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    assert_eq!(err.code(), tonic::Code::FailedPrecondition);
-    assert!(err.message().contains("Not leader"));
+    match result {
+        Ok(ClientResponse { error, .. }) => assert_eq!(error, ErrorCode::NotLeader),
+        Err(status) => panic!(
+            "expected Ok(ClientResponse {{ error: NotLeader, .. }}), got bare Err(Status): {status:?}"
+        ),
+    }
 }
 ///
 /// Original: test_handle_inbound_event_case10

--- a/d-engine-core/src/raft_role/role_state.rs
+++ b/d-engine-core/src/raft_role/role_state.rs
@@ -334,11 +334,12 @@ pub trait RaftRoleState: Send + Sync + 'static {
         match cmd {
             ClientCmd::Propose(_, sender) => {
                 // Writes always require leader - reject immediately
-                let status = tonic::Status::failed_precondition("Not leader");
-                let _ = sender.send(Err(status));
+                let _ = sender.send(Ok(self.create_not_leader_response(ctx)));
             }
             ClientCmd::Scan(_, sender) => {
-                let _ = sender.send(Err(tonic::Status::failed_precondition("Not leader")));
+                // Scan requires leader (linearizable by default); reply with
+                // NotLeader + best-effort leader hint for redirect, same as Propose/Read.
+                let _ = sender.send(Ok(self.create_not_leader_response(ctx)));
             }
             ClientCmd::Read(req, sender) => {
                 // Determine effective read policy, mirroring leader_state logic:
@@ -353,8 +354,7 @@ pub trait RaftRoleState: Send + Sync + 'static {
                         }
                         _ => {
                             // Linear/Lease requires leader
-                            let _ =
-                                sender.send(Err(tonic::Status::failed_precondition("Not leader")));
+                            let _ = sender.send(Ok(self.create_not_leader_response(ctx)));
                             return;
                         }
                     }
@@ -369,7 +369,7 @@ pub trait RaftRoleState: Send + Sync + 'static {
                     }
                     _ => {
                         // Linear/Lease requires leader
-                        let _ = sender.send(Err(tonic::Status::failed_precondition("Not leader")));
+                        let _ = sender.send(Ok(self.create_not_leader_response(ctx)));
                     }
                 }
             }
@@ -461,7 +461,7 @@ pub trait RaftRoleState: Send + Sync + 'static {
     ///
     /// # Returns
     /// ClientResponse with NOT_LEADER error code and optional leader metadata
-    async fn create_not_leader_response(
+    fn create_not_leader_response(
         &self,
         ctx: &RaftContext<Self::T>,
     ) -> ClientResponse {
@@ -469,13 +469,12 @@ pub trait RaftRoleState: Send + Sync + 'static {
 
         if let Some(lid) = leader_id {
             // Get leader address from membership
-            let members = ctx.membership().members().await;
-            let leader_node = members.iter().find(|n| n.id == lid);
+            let leader_node = ctx.membership().get_address(lid);
 
-            if let Some(leader) = leader_node {
+            if let Some(address) = leader_node {
                 return ClientResponse::not_leader(Some(LeaderHint {
                     leader_id: lid,
-                    address: leader.address.clone(),
+                    address,
                 }));
             }
         }

--- a/d-engine-core/src/storage/state_machine.rs
+++ b/d-engine-core/src/storage/state_machine.rs
@@ -2,6 +2,8 @@
 //!
 //! See the [server customization guide](https://github.com/deventlab/d-engine/blob/master/d-engine/src/docs/server_guide/customize-state-machine.md) for details.
 
+use crate::Error;
+use crate::StorageError;
 use async_trait::async_trait;
 use bytes::Bytes;
 use d_engine_proto::common::LogId;
@@ -10,9 +12,6 @@ use d_engine_proto::server::storage::SnapshotMetadata;
 use crate::ApplyEntry;
 #[cfg(any(test, feature = "__test_support"))]
 use mockall::automock;
-
-use crate::Error;
-use crate::StorageError;
 
 /// All `(key, value)` pairs returned by a prefix scan, plus the revision anchor.
 ///

--- a/d-engine-core/src/test_utils/mock/mock_rpc.rs
+++ b/d-engine-core/src/test_utils/mock/mock_rpc.rs
@@ -5,7 +5,6 @@ use d_engine_proto::client::ClientResponse;
 use d_engine_proto::client::ClientWriteRequest;
 use d_engine_proto::client::MembershipSnapshot as ProtoMembershipSnapshot;
 use d_engine_proto::client::ScanRequest;
-use d_engine_proto::client::ScanResponse;
 use d_engine_proto::client::WatchMembershipRequest;
 use d_engine_proto::client::WatchRequest;
 use d_engine_proto::client::WatchResponse;
@@ -220,7 +219,7 @@ impl RaftClientService for MockRpcService {
     async fn handle_client_scan(
         &self,
         _request: tonic::Request<ScanRequest>,
-    ) -> std::result::Result<tonic::Response<ScanResponse>, tonic::Status> {
+    ) -> std::result::Result<tonic::Response<ClientResponse>, tonic::Status> {
         Err(tonic::Status::unimplemented("not used in mock"))
     }
 }

--- a/d-engine-core/src/utils/cluster_printer.rs
+++ b/d-engine-core/src/utils/cluster_printer.rs
@@ -90,7 +90,7 @@ pub fn status_name(status: i32) -> &'static str {
 /// ================================================================================
 /// ```
 pub async fn print_cluster_membership_table<T: TypeConfig, M: Membership<T>>(membership: &M) {
-    let members = membership.get_all_nodes().await;
+    let members = membership.get_all_nodes();
 
     println!("\n{}", "=".repeat(80));
     println!("  CLUSTER MEMBERSHIP:");

--- a/d-engine-proto/proto/client/client_api.proto
+++ b/d-engine-proto/proto/client/client_api.proto
@@ -96,9 +96,10 @@ message ClientResponse {
   oneof success_result {
     WriteResult write_result = 2;
     ReadResults read_data = 3;
+    ScanResults scan_data = 4;
   }
 
-  d_engine.error.ErrorMetadata metadata = 4;
+  d_engine.error.ErrorMetadata metadata = 5;
 }
 
 message ClientResult { // Renamed from ClientGetResult
@@ -126,8 +127,8 @@ message ScanRequest {
   bytes prefix = 2;
 }
 
-// Response from a prefix scan.
-message ScanResponse {
+// Payload carried in a successful ClientResponse for a prefix scan.
+message ScanResults {
   // All (key, value) pairs whose key starts with the requested prefix.
   repeated KvEntry entries = 1;
 
@@ -223,7 +224,7 @@ message WatchResponse {
 service RaftClientService {
   rpc HandleClientWrite(ClientWriteRequest) returns (ClientResponse);
   rpc HandleClientRead(ClientReadRequest) returns (ClientResponse);
-  rpc HandleClientScan(ScanRequest) returns (ScanResponse);
+  rpc HandleClientScan(ScanRequest) returns (ClientResponse);
 
   // Watch for changes to a specific key.
   //

--- a/d-engine-proto/src/generated/d_engine.client.rs
+++ b/d-engine-proto/src/generated/d_engine.client.rs
@@ -112,9 +112,9 @@ pub struct WriteResult {
 pub struct ClientResponse {
     #[prost(enumeration = "super::error::ErrorCode", tag = "1")]
     pub error: i32,
-    #[prost(message, optional, tag = "4")]
+    #[prost(message, optional, tag = "5")]
     pub metadata: ::core::option::Option<super::error::ErrorMetadata>,
-    #[prost(oneof = "client_response::SuccessResult", tags = "2, 3")]
+    #[prost(oneof = "client_response::SuccessResult", tags = "2, 3, 4")]
     pub success_result: ::core::option::Option<client_response::SuccessResult>,
 }
 /// Nested message and enum types in `ClientResponse`.
@@ -126,6 +126,8 @@ pub mod client_response {
         WriteResult(super::WriteResult),
         #[prost(message, tag = "3")]
         ReadData(super::ReadResults),
+        #[prost(message, tag = "4")]
+        ScanData(super::ScanResults),
     }
 }
 /// Renamed from ClientGetResult
@@ -164,10 +166,10 @@ pub struct ScanRequest {
     #[prost(bytes = "bytes", tag = "2")]
     pub prefix: ::prost::bytes::Bytes,
 }
-/// Response from a prefix scan.
+/// Payload carried in a successful ClientResponse for a prefix scan.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ScanResponse {
+pub struct ScanResults {
     /// All (key, value) pairs whose key starts with the requested prefix.
     #[prost(message, repeated, tag = "1")]
     pub entries: ::prost::alloc::vec::Vec<KvEntry>,
@@ -488,7 +490,7 @@ pub mod raft_client_service_client {
         pub async fn handle_client_scan(
             &mut self,
             request: impl tonic::IntoRequest<super::ScanRequest>,
-        ) -> std::result::Result<tonic::Response<super::ScanResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ClientResponse>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -615,7 +617,7 @@ pub mod raft_client_service_server {
         async fn handle_client_scan(
             &self,
             request: tonic::Request<super::ScanRequest>,
-        ) -> std::result::Result<tonic::Response<super::ScanResponse>, tonic::Status>;
+        ) -> std::result::Result<tonic::Response<super::ClientResponse>, tonic::Status>;
         /// Server streaming response type for the Watch method.
         type WatchStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::WatchResponse, tonic::Status>,
@@ -846,7 +848,7 @@ pub mod raft_client_service_server {
                         T: RaftClientService,
                     > tonic::server::UnaryService<super::ScanRequest>
                     for HandleClientScanSvc<T> {
-                        type Response = super::ScanResponse;
+                        type Response = super::ClientResponse;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,

--- a/d-engine-server/src/api/embedded_client.rs
+++ b/d-engine-server/src/api/embedded_client.rs
@@ -27,7 +27,6 @@ use d_engine_core::BatchOp;
 use d_engine_core::InboundEvent;
 use d_engine_core::MaybeCloneOneshot;
 use d_engine_core::RaftOneshot;
-use d_engine_core::ScanResult;
 use d_engine_core::TypeConfig;
 use d_engine_core::client::ClientApi;
 use d_engine_core::client::ClientApiError;
@@ -36,6 +35,7 @@ use d_engine_core::client::ClientResponsePayload;
 use d_engine_core::client::ClientWriteRequest;
 use d_engine_core::client::ErrorCode;
 use d_engine_core::config::ReadConsistencyPolicy;
+use d_engine_core::types::ScanResults;
 #[cfg(feature = "watch")]
 use d_engine_core::watch::WatchRegistry;
 #[cfg(feature = "watch")]
@@ -503,7 +503,7 @@ impl<T: TypeConfig> EmbeddedClient<T> {
     pub async fn scan_prefix(
         &self,
         prefix: impl AsRef<[u8]>,
-    ) -> ClientApiResult<ScanResult> {
+    ) -> ClientApiResult<ScanResults> {
         let (resp_tx, resp_rx) = MaybeCloneOneshot::new();
 
         self.read_handle
@@ -520,7 +520,23 @@ impl<T: TypeConfig> EmbeddedClient<T> {
             .map_err(|_| timeout_error(self.timeout))?
             .map_err(|_| channel_closed_error())?;
 
-        result.map_err(|status| server_error(format!("RPC error: {}", status.message())))
+        let response =
+            result.map_err(|status| server_error(format!("RPC error: {}", status.message())))?;
+
+        if response.error != ErrorCode::Success {
+            return Err(map_error_response(
+                response.error,
+                response.leader_hint,
+                response.retry_after_ms,
+            ));
+        }
+
+        match response.result {
+            Some(ClientResponsePayload::Scan(scan_results)) => Ok(scan_results),
+            other => Err(server_error(format!(
+                "Unexpected response type for scan operation: expected Scan, found {other:?}"
+            ))),
+        }
     }
 
     /// Internal helper: Get cluster membership via ClusterConf event
@@ -782,7 +798,7 @@ impl<T: TypeConfig> ClientApi for EmbeddedClient<T> {
     async fn scan_prefix(
         &self,
         prefix: impl AsRef<[u8]> + Send,
-    ) -> ClientApiResult<ScanResult> {
+    ) -> ClientApiResult<ScanResults> {
         self.scan_prefix(prefix).await
     }
 }

--- a/d-engine-server/src/api/embedded_client_test/embedded_client_test.rs
+++ b/d-engine-server/src/api/embedded_client_test/embedded_client_test.rs
@@ -126,7 +126,8 @@ db_root_dir = "{}"
 single_node = true
 
 [raft]
-general_raft_timeout_duration_in_ms = 100
+# Generous on purpose: tests here check correctness, not speed.
+general_raft_timeout_duration_in_ms = 2000
 
 [raft.commit_handler]
 batch_size_threshold = 1

--- a/d-engine-server/src/api/embedded_client_test/embedded_client_test.rs
+++ b/d-engine-server/src/api/embedded_client_test/embedded_client_test.rs
@@ -380,3 +380,98 @@ max_batch_size = 1
         }
     } // scan_prefix_operations
 } // integration_tests
+
+// =============================================================================
+// scan_prefix() error-handling unit tests (no real engine needed)
+// =============================================================================
+//
+// EmbeddedClient::scan_prefix() only touches cmd_tx (never sm/lease), so these
+// wire a bare mpsc channel directly instead of booting a real engine — that's
+// also the only way to force a NotLeader response, since a real single-node
+// engine (used by `integration_tests` above) is always its own leader.
+mod scan_prefix_error_handling {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use d_engine_core::ClientCmd;
+    use d_engine_core::MockStateMachine;
+    use d_engine_core::MockTypeConfig;
+    use d_engine_core::ReadLease;
+    use d_engine_core::client::ClientApiError;
+    use d_engine_core::client::ClientResponse;
+    use d_engine_core::client::ErrorCode;
+    use d_engine_core::client::LeaderHint;
+    use tokio::sync::mpsc;
+
+    use crate::api::embedded_client::EmbeddedClient;
+    use crate::api::embedded_read_handle::EmbeddedReadHandle;
+
+    /// Build a client wired to a manually-controlled cmd channel. sm/lease are
+    /// unused by scan_prefix (it only goes through cmd_tx), so bare stand-ins suffice.
+    fn make_client(cmd_tx: mpsc::Sender<ClientCmd>) -> EmbeddedClient<MockTypeConfig> {
+        let (event_tx, _event_rx) = mpsc::channel(1);
+        let read_handle = EmbeddedReadHandle::new(
+            Arc::new(MockStateMachine::new()),
+            Arc::new(ReadLease::new()),
+            cmd_tx,
+        );
+        EmbeddedClient::new_internal(event_tx, read_handle, 1, Duration::from_millis(200))
+    }
+
+    /// #425: scan_prefix on a non-leader node must surface the real leader's
+    /// address, not just a bare error — same guarantee already proven for
+    /// put()/get(), now proven for scan() too.
+    #[tokio::test]
+    async fn test_scan_prefix_not_leader_carries_leader_hint() {
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(1);
+        tokio::spawn(async move {
+            if let Some(ClientCmd::Scan(_, resp_tx)) = cmd_rx.recv().await {
+                let _ = resp_tx.send(Ok(ClientResponse::not_leader(Some(LeaderHint {
+                    leader_id: 2,
+                    address: "http://127.0.0.1:9082".into(),
+                }))));
+            }
+        });
+        let client = make_client(cmd_tx);
+
+        let result = client.scan_prefix(b"/services/").await;
+
+        match result {
+            Err(ClientApiError::Network {
+                code: ErrorCode::NotLeader,
+                leader_hint,
+                ..
+            }) => {
+                assert_eq!(
+                    leader_hint,
+                    Some(LeaderHint {
+                        leader_id: 2,
+                        address: "http://127.0.0.1:9082".into(),
+                    }),
+                    "scan_prefix must surface the real leader's address on redirect"
+                );
+            }
+            other => panic!("expected Network{{NotLeader, leader_hint}}, got: {other:?}"),
+        }
+    }
+
+    /// Defensive: a Scan response carrying the wrong payload variant (e.g. Read)
+    /// must error cleanly instead of silently misinterpreting data or panicking.
+    #[tokio::test]
+    async fn test_scan_prefix_wrong_payload_type_errors_cleanly() {
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(1);
+        tokio::spawn(async move {
+            if let Some(ClientCmd::Scan(_, resp_tx)) = cmd_rx.recv().await {
+                let _ = resp_tx.send(Ok(ClientResponse::read_results(vec![])));
+            }
+        });
+        let client = make_client(cmd_tx);
+
+        let result = client.scan_prefix(b"/services/").await;
+
+        assert!(
+            result.is_err(),
+            "wrong payload type must error, not silently succeed with empty/wrong data"
+        );
+    }
+} // scan_prefix_error_handling

--- a/d-engine-server/src/api/standalone_read_handle.rs
+++ b/d-engine-server/src/api/standalone_read_handle.rs
@@ -102,6 +102,11 @@ pub(crate) fn extract_read_payload(
             message: "expected ReadData payload, got WriteResult".to_string(),
             supported_versions: None,
         }),
+        Some(ClientResponsePayload::Scan(_)) => Err(ClientApiError::Protocol {
+            code: ErrorCode::InvalidResponse,
+            message: "expected ReadData payload, got ScanResults".to_string(),
+            supported_versions: None,
+        }),
         None => Err(ClientApiError::Protocol {
             code: ErrorCode::InvalidResponse,
             message: "expected ReadData payload, got None".to_string(),

--- a/d-engine-server/src/api/standalone_read_handle_test.rs
+++ b/d-engine-server/src/api/standalone_read_handle_test.rs
@@ -613,7 +613,7 @@ mod read_handle_tests {
 mod error_helper_tests {
     use bytes::Bytes;
     use d_engine_core::client::{ClientApiError, ClientResponsePayload, ErrorCode};
-    use d_engine_core::client::{KvEntry, LeaderHint, ReadResults};
+    use d_engine_core::client::{KvEntry, LeaderHint, ReadResults, ScanResults};
 
     use super::super::{extract_read_payload, map_error_response, not_leader_error};
 
@@ -716,6 +716,20 @@ mod error_helper_tests {
         let err = extract_read_payload(payload).unwrap_err();
         assert_eq!(err.code(), ErrorCode::InvalidResponse);
         assert!(err.message().contains("WriteResult"));
+    }
+
+    /// A Scan payload must never be silently treated as read data — it must be
+    /// rejected the same way Write/None are, not accidentally matched by a
+    /// catch-all and misread as an empty successful read.
+    #[test]
+    fn test_extract_read_payload_rejects_scan_payload() {
+        let payload = Some(ClientResponsePayload::Scan(ScanResults {
+            entries: vec![(Bytes::from("k"), Bytes::from("v"))],
+            revision: 1,
+        }));
+        let err = extract_read_payload(payload).unwrap_err();
+        assert_eq!(err.code(), ErrorCode::InvalidResponse);
+        assert!(err.message().contains("ScanResults"));
     }
 
     #[test]

--- a/d-engine-server/src/lib.rs
+++ b/d-engine-server/src/lib.rs
@@ -166,6 +166,9 @@ pub use api::EmbeddedClient;
 /// Use this to pattern-match error categories without inspecting message strings:
 /// `e.code() == ErrorCode::NotLeader`
 pub use d_engine_core::client::ErrorCode;
+/// Leader location hint, populated on `ErrorCode::NotLeader` so a client can
+/// retry against the right node without a blind broadcast.
+pub use d_engine_core::client::LeaderHint;
 /// Unified client operations trait (put/get/delete/CAS/watch).
 /// Re-exported here so embedded-mode users don't need a separate d-engine-client dependency.
 pub use d_engine_core::client::{ClientApi, ClientApiError, ClientApiResult};

--- a/d-engine-server/src/lib.rs
+++ b/d-engine-server/src/lib.rs
@@ -166,7 +166,7 @@ pub use api::EmbeddedClient;
 /// Use this to pattern-match error categories without inspecting message strings:
 /// `e.code() == ErrorCode::NotLeader`
 pub use d_engine_core::client::ErrorCode;
-/// Leader location hint, populated on `ErrorCode::NotLeader` so a client can
+/// Optional leader location hint on `ErrorCode::NotLeader`, so a client can
 /// retry against the right node without a blind broadcast.
 pub use d_engine_core::client::LeaderHint;
 /// Unified client operations trait (put/get/delete/CAS/watch).

--- a/d-engine-server/src/lib.rs
+++ b/d-engine-server/src/lib.rs
@@ -140,7 +140,12 @@ pub use d_engine_core::MetaStore;
 /// Unified result type (equivalent to Result<T, Error>)
 pub use d_engine_core::Result;
 /// Prefix scan result: matching entries + revision anchor for watch deduplication
+///
+/// Internal `StateMachine::scan_prefix()` trait return type. For the client-facing
+/// scan result returned by `EmbeddedClient::scan_prefix()`, see [`ScanResults`].
 pub use d_engine_core::ScanResult;
+/// Client-facing prefix scan result, returned by `EmbeddedClient::scan_prefix()`.
+pub use d_engine_core::ScanResults;
 /// Storage-specific error type
 pub use d_engine_core::StorageError;
 // Raft Node Config

--- a/d-engine-server/src/membership/membership_guard.rs
+++ b/d-engine-server/src/membership/membership_guard.rs
@@ -41,7 +41,7 @@ impl MembershipGuard {
     }
 
     /// Provides read access to the state
-    pub async fn blocking_read<R>(
+    pub fn blocking_read<R>(
         &self,
         f: impl FnOnce(&InnerState) -> R,
     ) -> R {
@@ -91,6 +91,6 @@ impl MembershipGuard {
         &self,
         node_id: u32,
     ) -> bool {
-        self.blocking_read(|state| state.nodes.contains_key(&node_id)).await
+        self.blocking_read(|state| state.nodes.contains_key(&node_id))
     }
 }

--- a/d-engine-server/src/membership/membership_guard_test.rs
+++ b/d-engine-server/src/membership/membership_guard_test.rs
@@ -24,14 +24,12 @@ async fn initial_state_correctly_set() {
     let nodes = vec![create_test_node(1), create_test_node(2)];
     let guard = MembershipGuard::new(nodes.clone(), 100);
 
-    guard
-        .blocking_read(|state| {
-            assert_eq!(state.nodes.len(), 2);
-            assert_eq!(state.nodes.get(&1).unwrap().address, "node-1.test:8080");
-            assert_eq!(state.nodes.get(&2).unwrap().address, "node-2.test:8080");
-            assert_eq!(state.cluster_conf_version, 100);
-        })
-        .await;
+    guard.blocking_read(|state| {
+        assert_eq!(state.nodes.len(), 2);
+        assert_eq!(state.nodes.get(&1).unwrap().address, "node-1.test:8080");
+        assert_eq!(state.nodes.get(&2).unwrap().address, "node-2.test:8080");
+        assert_eq!(state.cluster_conf_version, 100);
+    });
 }
 
 #[tokio::test]
@@ -39,9 +37,7 @@ async fn initial_state_correctly_set() {
 async fn blocking_read_access() {
     let guard = MembershipGuard::new(vec![create_test_node(1)], 1);
 
-    let result = guard
-        .blocking_read(|state| state.nodes.get(&1).map(|n| n.address.clone()))
-        .await;
+    let result = guard.blocking_read(|state| state.nodes.get(&1).map(|n| n.address.clone()));
 
     assert_eq!(result, Some("node-1.test:8080".to_string()));
 }
@@ -58,12 +54,10 @@ async fn blocking_write_updates_state() {
         })
         .await;
 
-    guard
-        .blocking_read(|state| {
-            assert_eq!(state.cluster_conf_version, 200);
-            assert_eq!(state.nodes.len(), 2);
-        })
-        .await;
+    guard.blocking_read(|state| {
+        assert_eq!(state.cluster_conf_version, 200);
+        assert_eq!(state.nodes.len(), 2);
+    });
 }
 
 #[tokio::test]
@@ -78,11 +72,9 @@ async fn update_node_success() {
         .await;
 
     assert!(result.is_ok());
-    guard
-        .blocking_read(|state| {
-            assert_eq!(state.nodes.get(&1).unwrap().address, "updated.test:9090");
-        })
-        .await;
+    guard.blocking_read(|state| {
+        assert_eq!(state.nodes.get(&1).unwrap().address, "updated.test:9090");
+    });
 }
 
 #[tokio::test]
@@ -186,7 +178,7 @@ async fn write_operations_are_serialized() {
     );
 
     // Verify final state
-    let version = guard.blocking_read(|state| state.cluster_conf_version).await;
+    let version = guard.blocking_read(|state| state.cluster_conf_version);
     assert_eq!(version, 3);
 }
 
@@ -220,11 +212,9 @@ async fn reads_are_not_blocked_by_writes() {
     // Time 100 reads during the write
     let start = std::time::Instant::now();
     for _ in 0..100 {
-        guard
-            .blocking_read(|state| {
-                assert_eq!(state.cluster_conf_version, 2);
-            })
-            .await;
+        guard.blocking_read(|state| {
+            assert_eq!(state.cluster_conf_version, 2);
+        });
     }
     let elapsed = start.elapsed();
 
@@ -238,6 +228,6 @@ async fn reads_are_not_blocked_by_writes() {
     );
 
     // Verify write completed
-    let version = guard.blocking_read(|state| state.cluster_conf_version).await;
+    let version = guard.blocking_read(|state| state.cluster_conf_version);
     assert_eq!(version, 2);
 }

--- a/d-engine-server/src/membership/raft_membership.rs
+++ b/d-engine-server/src/membership/raft_membership.rs
@@ -84,93 +84,78 @@ impl<T> Membership<T> for RaftMembership<T>
 where
     T: TypeConfig,
 {
-    async fn members(&self) -> Vec<NodeMeta> {
-        self.membership
-            .blocking_read(|guard| guard.nodes.values().cloned().collect())
-            .await
+    fn members(&self) -> Vec<NodeMeta> {
+        self.membership.blocking_read(|guard| guard.nodes.values().cloned().collect())
     }
 
-    async fn replication_peers(&self) -> Vec<NodeMeta> {
-        self.membership
-            .blocking_read(|guard| {
-                guard
-                    .nodes
-                    .values()
-                    .filter(|node| {
-                        node.id != self.node_id
-                            && (node.status == NodeStatus::Active as i32
-                                || node.status == NodeStatus::Promotable as i32
-                                || node.status == NodeStatus::ReadOnly as i32)
-                    })
-                    .cloned()
-                    .collect()
-            })
-            .await
+    fn replication_peers(&self) -> Vec<NodeMeta> {
+        self.membership.blocking_read(|guard| {
+            guard
+                .nodes
+                .values()
+                .filter(|node| {
+                    node.id != self.node_id
+                        && (node.status == NodeStatus::Active as i32
+                            || node.status == NodeStatus::Promotable as i32
+                            || node.status == NodeStatus::ReadOnly as i32)
+                })
+                .cloned()
+                .collect()
+        })
     }
 
-    async fn voters(&self) -> Vec<NodeMeta> {
-        self.membership
-            .blocking_read(|guard| {
-                guard
-                    .nodes
-                    .values()
-                    .filter(|node| {
-                        node.id != self.node_id && node.status == NodeStatus::Active as i32
-                    })
-                    .cloned()
-                    .collect()
-            })
-            .await
+    fn voters(&self) -> Vec<NodeMeta> {
+        self.membership.blocking_read(|guard| {
+            guard
+                .nodes
+                .values()
+                .filter(|node| node.id != self.node_id && node.status == NodeStatus::Active as i32)
+                .cloned()
+                .collect()
+        })
     }
 
-    async fn initial_cluster_size(&self) -> usize {
+    fn initial_cluster_size(&self) -> usize {
         self.initial_cluster_size
     }
 
-    async fn nodes_with_status(
+    fn nodes_with_status(
         &self,
         status: NodeStatus,
     ) -> Vec<NodeMeta> {
-        self.membership
-            .blocking_read(|guard| {
-                guard
-                    .nodes
-                    .values()
-                    .filter(|node| node.id != self.node_id && node.status == status as i32)
-                    .cloned()
-                    .collect()
-            })
-            .await
+        self.membership.blocking_read(|guard| {
+            guard
+                .nodes
+                .values()
+                .filter(|node| node.id != self.node_id && node.status == status as i32)
+                .cloned()
+                .collect()
+        })
     }
 
-    async fn get_node_status(
+    fn get_node_status(
         &self,
         node_id: u32,
     ) -> Option<NodeStatus> {
-        self.membership
-            .blocking_read(|guard| {
-                guard
-                    .nodes
-                    .get(&node_id)
-                    .and_then(|node| NodeStatus::try_from(node.status).ok())
-            })
-            .await
+        self.membership.blocking_read(|guard| {
+            guard
+                .nodes
+                .get(&node_id)
+                .and_then(|node| NodeStatus::try_from(node.status).ok())
+        })
     }
 
     async fn activate_node(
         &mut self,
         new_node_id: u32,
     ) -> Result<()> {
-        let current_voters = self
-            .membership
-            .blocking_read(|guard| {
-                guard
-                    .nodes
-                    .values()
-                    .filter(|node| node.status == NodeStatus::Active as i32)
-                    .count()
-            })
-            .await;
+        let current_voters = self.membership.blocking_read(|guard| {
+            guard
+                .nodes
+                .values()
+                .filter(|node| node.status == NodeStatus::Active as i32)
+                .count()
+        });
 
         ensure_safe_join(self.node_id, current_voters)?;
 
@@ -193,7 +178,7 @@ where
         let retry = self.config.retry.clone();
 
         let mut peer_ids = Vec::new();
-        for peer in self.voters().await {
+        for peer in self.voters() {
             let peer_id = peer.id;
             debug!("check_cluster_is_ready for peer: {}", peer_id);
             peer_ids.push(peer_id);
@@ -262,36 +247,32 @@ where
         }
     }
 
-    async fn get_peers_id_with_condition<F>(
+    fn get_peers_id_with_condition<F>(
         &self,
         condition: F,
     ) -> Vec<u32>
     where
         F: Fn(i32) -> bool + Send + Sync + 'static,
     {
-        self.membership
-            .blocking_read(|guard| {
-                guard
-                    .nodes
-                    .values()
-                    .filter(|node| condition(node.role))
-                    .map(|node| node.id)
-                    .collect()
-            })
-            .await
+        self.membership.blocking_read(|guard| {
+            guard
+                .nodes
+                .values()
+                .filter(|node| condition(node.role))
+                .map(|node| node.id)
+                .collect()
+        })
     }
 
-    async fn retrieve_cluster_membership_config(
+    fn retrieve_cluster_membership_config(
         &self,
         current_leader_id: Option<u32>,
     ) -> ClusterMembership {
-        self.membership
-            .blocking_read(|guard| ClusterMembership {
-                version: guard.cluster_conf_version,
-                nodes: guard.nodes.values().cloned().collect(),
-                current_leader_id,
-            })
-            .await
+        self.membership.blocking_read(|guard| ClusterMembership {
+            version: guard.cluster_conf_version,
+            nodes: guard.nodes.values().cloned().collect(),
+            current_leader_id,
+        })
     }
 
     async fn update_cluster_conf_from_leader(
@@ -327,7 +308,7 @@ where
             ));
         }
 
-        if self.get_cluster_conf_version().await > req.version {
+        if self.get_cluster_conf_version() > req.version {
             return Ok(ClusterConfUpdateResponse::version_conflict(
                 my_id,
                 my_current_term,
@@ -409,12 +390,12 @@ where
         Ok(ClusterConfUpdateResponse::success(
             my_id,
             my_current_term,
-            self.get_cluster_conf_version().await,
+            self.get_cluster_conf_version(),
         ))
     }
 
-    async fn get_cluster_conf_version(&self) -> u64 {
-        self.membership.blocking_read(|guard| guard.cluster_conf_version).await
+    fn get_cluster_conf_version(&self) -> u64 {
+        self.membership.blocking_read(|guard| guard.cluster_conf_version)
     }
 
     async fn update_conf_version(
@@ -532,28 +513,26 @@ where
             .await
     }
 
-    async fn contains_node(
+    fn contains_node(
         &self,
         node_id: u32,
     ) -> bool {
-        self.membership.blocking_read(|guard| guard.nodes.contains_key(&node_id)).await
+        self.membership.blocking_read(|guard| guard.nodes.contains_key(&node_id))
     }
 
-    async fn retrieve_node_meta(
+    fn retrieve_node_meta(
         &self,
         node_id: u32,
     ) -> Option<NodeMeta> {
-        self.membership.blocking_read(|guard| guard.nodes.get(&node_id).cloned()).await
+        self.membership.blocking_read(|guard| guard.nodes.get(&node_id).cloned())
     }
 
-    async fn get_all_nodes(&self) -> Vec<NodeMeta> {
-        self.membership
-            .blocking_read(|guard| guard.nodes.values().cloned().collect())
-            .await
+    fn get_all_nodes(&self) -> Vec<NodeMeta> {
+        self.membership.blocking_read(|guard| guard.nodes.values().cloned().collect())
     }
 
     async fn pre_warm_connections(&self) -> Result<()> {
-        let peers = self.replication_peers().await;
+        let peers = self.replication_peers();
 
         if peers.is_empty() {
             info!("No replication peers found");
@@ -603,7 +582,7 @@ where
         node_id: u32,
         conn_type: ConnectionType,
     ) -> Option<Channel> {
-        let addr = match self.get_address(node_id).await {
+        let addr = match self.get_address(node_id) {
             Some(addr) => addr,
             None => {
                 // Record failure if node address is missing
@@ -631,13 +610,12 @@ where
         }
     }
 
-    async fn get_address(
+    fn get_address(
         &self,
         node_id: u32,
     ) -> Option<String> {
         self.membership
             .blocking_read(|guard| guard.nodes.get(&node_id).map(|n| address_str(&n.address)))
-            .await
     }
 
     async fn apply_config_change(
@@ -708,29 +686,26 @@ where
         }
     }
 
-    async fn notify_config_applied(
+    fn notify_config_applied(
         &self,
         index: u64,
     ) {
-        let snapshot = self
-            .membership
-            .blocking_read(|guard| {
-                let mut members = BTreeSet::new();
-                let mut learners = BTreeSet::new();
-                for node in guard.nodes.values() {
-                    if node.role == Learner as i32 {
-                        learners.insert(node.id);
-                    } else {
-                        members.insert(node.id);
-                    }
+        let snapshot = self.membership.blocking_read(|guard| {
+            let mut members = BTreeSet::new();
+            let mut learners = BTreeSet::new();
+            for node in guard.nodes.values() {
+                if node.role == Learner as i32 {
+                    learners.insert(node.id);
+                } else {
+                    members.insert(node.id);
                 }
-                MembershipSnapshot {
-                    members,
-                    learners,
-                    committed_index: index,
-                }
-            })
-            .await;
+            }
+            MembershipSnapshot {
+                members,
+                learners,
+                committed_index: index,
+            }
+        });
         // send_replace never fails — silently drops the value if all receivers are gone.
         self.membership_notifier_tx.send_replace(snapshot);
         info!("Membership change committed at index {}", index);
@@ -746,7 +721,7 @@ where
             return Err(MembershipError::NotLearner.into());
         }
 
-        if !self.contains_node(node_id).await {
+        if !self.contains_node(node_id) {
             return Ok(());
         }
 
@@ -889,13 +864,11 @@ where
     }
 
     #[cfg(test)]
-    pub(crate) async fn get_role_by_node_id(
+    pub(crate) fn get_role_by_node_id(
         &self,
         node_id: u32,
     ) -> Option<i32> {
-        self.membership
-            .blocking_read(|guard| guard.nodes.get(&node_id).map(|n| n.role))
-            .await
+        self.membership.blocking_read(|guard| guard.nodes.get(&node_id).map(|n| n.role))
     }
 
     #[cfg(test)]

--- a/d-engine-server/src/membership/raft_membership_test.rs
+++ b/d-engine-server/src/membership/raft_membership_test.rs
@@ -92,7 +92,7 @@ async fn test_update_single_node_case1() {
     assert!(result.is_ok(), "Failed to update single node");
 
     // Verify node was updated
-    let node_status = membership.get_node_status(node_id).await.unwrap();
+    let node_status = membership.get_node_status(node_id).unwrap();
     assert_eq!(
         node_status,
         NodeStatus::Promotable,
@@ -118,7 +118,7 @@ async fn test_update_single_node_case2() {
     assert!(result.is_err(), "Should return error");
 
     // Verify node was created
-    assert!(membership.get_node_status(node_id).await.is_none());
+    assert!(membership.get_node_status(node_id).is_none());
 }
 
 #[tokio::test]
@@ -138,7 +138,7 @@ async fn test_update_multiple_nodes_case1() {
 
     // Verify all nodes were updated
     for node_id in nodes {
-        let node_status = membership.get_node_status(node_id).await.unwrap();
+        let node_status = membership.get_node_status(node_id).unwrap();
         assert_eq!(
             node_status,
             NodeStatus::Promotable,
@@ -163,7 +163,7 @@ async fn test_update_multiple_nodes_case2() {
     assert!(result.is_ok(), "Failed to update mixed nodes");
 
     // Verify existing node was updated
-    let node4_status = membership.get_node_status(4).await.unwrap();
+    let node4_status = membership.get_node_status(4).unwrap();
     assert_eq!(
         node4_status,
         NodeStatus::Promotable,
@@ -171,7 +171,7 @@ async fn test_update_multiple_nodes_case2() {
     );
 
     // Verify new nodes were created
-    assert!(!membership.contains_node(13).await, "New node should exist");
+    assert!(!membership.contains_node(13), "New node should exist");
 }
 
 #[tokio::test]
@@ -216,7 +216,7 @@ async fn test_replication_peers_case1() {
             initial_cluster,
             RaftNodeConfig::default(),
         );
-    assert_eq!(membership.replication_peers().await.len(), 4);
+    assert_eq!(membership.replication_peers().len(), 4);
 }
 
 /// Test: remove_node allows leader removal (Raft protocol compliance)
@@ -260,7 +260,7 @@ async fn test_remove_node_allows_leader_removal() {
         );
 
     // Verify node 1 exists
-    assert!(membership.contains_node(1).await);
+    assert!(membership.contains_node(1));
 
     // Remove leader node (should succeed per Raft protocol)
     let result = membership.remove_node(1).await;
@@ -270,10 +270,10 @@ async fn test_remove_node_allows_leader_removal() {
     );
 
     // Verify node 1 is removed from membership
-    assert!(!membership.contains_node(1).await);
+    assert!(!membership.contains_node(1));
 
     // Verify cluster still has 2 nodes
-    let members = membership.members().await;
+    let members = membership.members();
     assert_eq!(members.len(), 2);
     assert!(members.iter().all(|n| n.id != 1));
 }
@@ -321,7 +321,7 @@ async fn test_retrieve_cluster_membership_config() {
             RaftNodeConfig::default(),
         );
 
-    let r = membership.retrieve_cluster_membership_config(None).await;
+    let r = membership.retrieve_cluster_membership_config(None);
     assert_eq!(r.nodes.len(), 5);
     assert!(!r.nodes.iter().any(|n| n.role == Leader as i32));
 }
@@ -357,8 +357,8 @@ async fn test_update_cluster_conf_from_leader_case1() {
             .await
             .is_ok()
     );
-    assert!(membership.contains_node(3).await);
-    assert_eq!(membership.get_cluster_conf_version().await, 0); // Version from request
+    assert!(membership.contains_node(3));
+    assert_eq!(membership.get_cluster_conf_version(), 0); // Version from request
 }
 
 #[tokio::test]
@@ -396,8 +396,8 @@ async fn test_update_cluster_conf_from_leader_case2() {
             .await
             .is_ok()
     );
-    assert!(!membership.contains_node(3).await);
-    assert_eq!(membership.get_cluster_conf_version().await, 1);
+    assert!(!membership.contains_node(3));
+    assert_eq!(membership.get_cluster_conf_version(), 1);
 }
 
 #[tokio::test]
@@ -438,11 +438,8 @@ async fn test_update_cluster_conf_from_leader_case3() {
         .expect("should succeed");
 
     assert!(response.success);
-    assert_eq!(
-        membership.get_role_by_node_id(3).await.unwrap(),
-        Follower as i32
-    );
-    assert_eq!(membership.get_cluster_conf_version().await, 1);
+    assert_eq!(membership.get_role_by_node_id(3).unwrap(), Follower as i32);
+    assert_eq!(membership.get_cluster_conf_version(), 1);
 }
 
 #[tokio::test]
@@ -620,11 +617,11 @@ async fn test_batch_remove_nodes() {
 
     // Verify results
     assert!(response.success);
-    assert!(!membership.contains_node(3).await);
-    assert!(!membership.contains_node(4).await);
-    assert!(membership.contains_node(2).await);
-    assert!(membership.contains_node(5).await);
-    assert_eq!(membership.get_cluster_conf_version().await, 1);
+    assert!(!membership.contains_node(3));
+    assert!(!membership.contains_node(4));
+    assert!(membership.contains_node(2));
+    assert!(membership.contains_node(5));
+    assert_eq!(membership.get_cluster_conf_version(), 1);
 }
 
 #[tokio::test]
@@ -714,10 +711,10 @@ async fn test_apply_batch_remove_config_change() {
         .expect("Batch remove should succeed");
 
     // Verify nodes removed and version updated
-    assert!(!membership.contains_node(2).await);
-    assert!(!membership.contains_node(3).await);
-    assert!(membership.contains_node(4).await);
-    assert_eq!(membership.get_cluster_conf_version().await, 1);
+    assert!(!membership.contains_node(2));
+    assert!(!membership.contains_node(3));
+    assert!(membership.contains_node(4));
+    assert_eq!(membership.get_cluster_conf_version(), 1);
 }
 
 // Add to existing test series
@@ -767,10 +764,10 @@ async fn test_update_cluster_conf_from_leader_case7_batch_remove() {
         .expect("Batch remove should succeed");
 
     assert!(response.success);
-    assert!(!membership.contains_node(3).await);
-    assert!(!membership.contains_node(4).await);
-    assert!(membership.contains_node(2).await);
-    assert_eq!(membership.get_cluster_conf_version().await, 1);
+    assert!(!membership.contains_node(3));
+    assert!(!membership.contains_node(4));
+    assert!(membership.contains_node(2));
+    assert_eq!(membership.get_cluster_conf_version(), 1);
 }
 
 #[tokio::test]
@@ -797,7 +794,7 @@ async fn test_update_cluster_conf_from_leader_case8_batch_remove_nonexistent() {
         .expect("Should succeed with no-op");
 
     assert!(response.success);
-    assert_eq!(membership.get_cluster_conf_version().await, 0);
+    assert_eq!(membership.get_cluster_conf_version(), 0);
 }
 
 /// This test covers:
@@ -851,19 +848,18 @@ async fn test_get_peers_id_with_condition() {
 
     // Test 1: Filter followers and candidates
     let mut result = membership
-        .get_peers_id_with_condition(|role| role == Follower as i32 || role == Candidate as i32)
-        .await;
+        .get_peers_id_with_condition(|role| role == Follower as i32 || role == Candidate as i32);
     result.sort_unstable();
     let mut expect = vec![1, 3, 5];
     expect.sort_unstable();
     assert_eq!(result, expect, "Should return follower and candidate IDs");
 
     // Test 2: Filter leaders only
-    let result = membership.get_peers_id_with_condition(|role| role == Leader as i32).await;
+    let result = membership.get_peers_id_with_condition(|role| role == Leader as i32);
     assert_eq!(result, vec![6], "Should return leader ID only");
 
     // Test 3: Empty result case
-    let result = membership.get_peers_id_with_condition(|_| false).await;
+    let result = membership.get_peers_id_with_condition(|_| false);
     assert!(
         result.is_empty(),
         "Should return empty vector when no matches"
@@ -872,7 +868,7 @@ async fn test_get_peers_id_with_condition() {
     expect.sort_unstable();
 
     // Test 4: All items match
-    let mut result = membership.get_peers_id_with_condition(|_| true).await;
+    let mut result = membership.get_peers_id_with_condition(|_| true);
     result.sort_unstable();
     assert_eq!(
         result, expect,
@@ -1049,7 +1045,7 @@ mod add_learner_test {
             .await;
         assert!(result.is_ok(), "Should add learner successfully");
 
-        let replication_members = membership.members().await;
+        let replication_members = membership.members();
         assert_eq!(replication_members.len(), 1);
         assert_eq!(replication_members[0].id, 2);
         assert_eq!(replication_members[0].address, "127.0.0.1:1234");
@@ -1076,7 +1072,7 @@ mod add_learner_test {
             .await;
         assert!(result.is_err(), "Node is follower");
 
-        let replication_members = membership.members().await;
+        let replication_members = membership.members();
         assert_eq!(replication_members.len(), 1);
         assert_eq!(replication_members[0].id, 1);
         assert_eq!(replication_members[0].address, "127.0.0.1:0");
@@ -1407,7 +1403,7 @@ mod single_node_tests {
     async fn test_initial_cluster_size_single_node() {
         let membership = create_single_node_membership();
 
-        let size = membership.initial_cluster_size().await;
+        let size = membership.initial_cluster_size();
 
         assert_eq!(size, 1, "Single-node cluster should report size 1");
     }
@@ -1416,7 +1412,7 @@ mod single_node_tests {
     async fn test_initial_cluster_size_three_nodes() {
         let membership = create_three_node_membership();
 
-        let size = membership.initial_cluster_size().await;
+        let size = membership.initial_cluster_size();
 
         assert_eq!(size, 3, "Three-node cluster should report size 3");
     }
@@ -1425,7 +1421,7 @@ mod single_node_tests {
     async fn test_initial_cluster_size_five_nodes() {
         let membership = create_five_node_membership();
 
-        let size = membership.initial_cluster_size().await;
+        let size = membership.initial_cluster_size();
 
         assert_eq!(size, 5, "Five-node cluster should report size 5");
     }
@@ -1434,7 +1430,7 @@ mod single_node_tests {
     async fn test_is_single_node_cluster_true() {
         let membership = create_single_node_membership();
 
-        let is_single = membership.is_single_node_cluster().await;
+        let is_single = membership.is_single_node_cluster();
 
         assert!(is_single, "Single-node cluster should return true");
     }
@@ -1443,7 +1439,7 @@ mod single_node_tests {
     async fn test_is_single_node_cluster_false_three_nodes() {
         let membership = create_three_node_membership();
 
-        let is_single = membership.is_single_node_cluster().await;
+        let is_single = membership.is_single_node_cluster();
 
         assert!(!is_single, "Three-node cluster should return false");
     }
@@ -1452,7 +1448,7 @@ mod single_node_tests {
     async fn test_is_single_node_cluster_false_five_nodes() {
         let membership = create_five_node_membership();
 
-        let is_single = membership.is_single_node_cluster().await;
+        let is_single = membership.is_single_node_cluster();
 
         assert!(!is_single, "Five-node cluster should return false");
     }
@@ -1462,7 +1458,7 @@ mod single_node_tests {
         let membership = create_three_node_membership();
 
         // Initial size should be 3
-        assert_eq!(membership.initial_cluster_size().await, 3);
+        assert_eq!(membership.initial_cluster_size(), 3);
 
         // Add a learner (simulate cluster expansion)
         membership
@@ -1472,13 +1468,13 @@ mod single_node_tests {
 
         // Initial cluster size should still be 3 (immutable)
         assert_eq!(
-            membership.initial_cluster_size().await,
+            membership.initial_cluster_size(),
             3,
             "initial_cluster_size should remain unchanged after adding learner"
         );
 
         // Verify the learner was actually added
-        assert!(membership.contains_node(4).await, "Node 4 should exist");
+        assert!(membership.contains_node(4), "Node 4 should exist");
     }
 
     #[tokio::test]
@@ -1486,23 +1482,20 @@ mod single_node_tests {
         let membership = create_three_node_membership();
 
         // Initial size should be 3
-        assert_eq!(membership.initial_cluster_size().await, 3);
+        assert_eq!(membership.initial_cluster_size(), 3);
 
         // Remove node 3 (simulate node failure)
         membership.force_remove_node(3).await.expect("Should succeed");
 
         // Initial cluster size should still be 3 (immutable)
         assert_eq!(
-            membership.initial_cluster_size().await,
+            membership.initial_cluster_size(),
             3,
             "initial_cluster_size should remain unchanged after removing node"
         );
 
         // Verify node was actually removed
-        assert!(
-            !membership.contains_node(3).await,
-            "Node 3 should be removed"
-        );
+        assert!(!membership.contains_node(3), "Node 3 should be removed");
     }
 
     #[tokio::test]
@@ -1510,7 +1503,7 @@ mod single_node_tests {
         let membership = create_single_node_membership();
 
         // voters() should return empty (excludes self)
-        let voters = membership.voters().await;
+        let voters = membership.voters();
         assert!(
             voters.is_empty(),
             "voters() should be empty for single-node (excludes self)"
@@ -1518,14 +1511,14 @@ mod single_node_tests {
 
         // But initial_cluster_size() should still be 1
         assert_eq!(
-            membership.initial_cluster_size().await,
+            membership.initial_cluster_size(),
             1,
             "initial_cluster_size should be 1 even when voters() is empty"
         );
 
         // is_single_node_cluster() should be true
         assert!(
-            membership.is_single_node_cluster().await,
+            membership.is_single_node_cluster(),
             "is_single_node_cluster should be true"
         );
     }
@@ -1539,7 +1532,7 @@ mod single_node_tests {
         membership.force_remove_node(3).await.expect("Should succeed");
 
         // voters() should be empty now (simulating partition)
-        let voters = membership.voters().await;
+        let voters = membership.voters();
         assert!(
             voters.is_empty(),
             "voters() should be empty after partition"
@@ -1547,14 +1540,14 @@ mod single_node_tests {
 
         // But initial_cluster_size should still be 3
         assert_eq!(
-            membership.initial_cluster_size().await,
+            membership.initial_cluster_size(),
             3,
             "initial_cluster_size should remain 3 even in network partition"
         );
 
         // is_single_node_cluster() should still return false
         assert!(
-            !membership.is_single_node_cluster().await,
+            !membership.is_single_node_cluster(),
             "is_single_node_cluster should return false (was 3-node cluster)"
         );
     }

--- a/d-engine-server/src/network/grpc/grpc_raft_service.rs
+++ b/d-engine-server/src/network/grpc/grpc_raft_service.rs
@@ -11,13 +11,13 @@ use d_engine_core::RaftOneshot;
 use d_engine_core::TypeConfig;
 #[cfg(feature = "watch")]
 use d_engine_core::WatchError;
+use d_engine_core::client::ClientApiError;
+use d_engine_core::config::ReadConsistencyPolicy;
 use d_engine_proto::client::ClientReadRequest;
 use d_engine_proto::client::ClientResponse;
 use d_engine_proto::client::ClientWriteRequest;
-use d_engine_proto::client::KvEntry;
 use d_engine_proto::client::MembershipSnapshot as ProtoMembershipSnapshot;
 use d_engine_proto::client::ScanRequest;
-use d_engine_proto::client::ScanResponse;
 use d_engine_proto::client::WatchMembershipRequest;
 use d_engine_proto::client::WatchRequest;
 use d_engine_proto::client::raft_client_service_server::RaftClientService;
@@ -519,8 +519,6 @@ where
 
         // Fast path: Eventual/LeaseRead → ReadHandle (ReadActor + cmd_tx fallback).
         {
-            use d_engine_core::client::ClientApiError;
-            use d_engine_core::config::ReadConsistencyPolicy;
             if let Some(ref policy) = core_req.consistency_policy
                 && matches!(
                     policy,
@@ -573,7 +571,7 @@ where
     async fn handle_client_scan(
         &self,
         request: tonic::Request<ScanRequest>,
-    ) -> std::result::Result<tonic::Response<ScanResponse>, tonic::Status> {
+    ) -> std::result::Result<tonic::Response<ClientResponse>, tonic::Status> {
         if !self.is_rpc_ready() {
             warn!("handle_client_scan: Node-{} is not ready!", self.node_id);
             return Err(Status::unavailable("Service is not ready"));
@@ -592,18 +590,9 @@ where
         let timeout_duration =
             Duration::from_millis(self.node_config.raft.general_raft_timeout_duration_in_ms);
 
-        let scan_result = handle_rpc_timeout(resp_rx, timeout_duration, "handle_client_scan")
-            .await?
-            .into_inner();
-
-        Ok(tonic::Response::new(ScanResponse {
-            entries: scan_result
-                .entries
-                .into_iter()
-                .map(|(k, v)| KvEntry { key: k, value: v })
-                .collect(),
-            revision: scan_result.revision,
-        }))
+        handle_rpc_timeout(resp_rx, timeout_duration, "handle_client_scan")
+            .await
+            .map(|resp| resp.map(proto_convert::to_proto_response))
     }
 
     /// Watch for changes to a specific key

--- a/d-engine-server/src/network/grpc/grpc_raft_service_test.rs
+++ b/d-engine-server/src/network/grpc/grpc_raft_service_test.rs
@@ -576,6 +576,7 @@ async fn test_handle_client_scan_not_leader_carries_leader_hint_in_metadata() {
     use d_engine_core::client::ClientResponse;
     use d_engine_core::client::LeaderHint;
     use d_engine_proto::client::ScanRequest;
+    use d_engine_proto::error::ErrorCode as ProtoErrorCode;
     use std::sync::atomic::Ordering;
     use tokio::sync::mpsc;
 
@@ -603,6 +604,7 @@ async fn test_handle_client_scan_not_leader_carries_leader_hint_in_metadata() {
         .expect("NotLeader is a business-level response, not an RPC error")
         .into_inner();
 
+    assert_eq!(response.error, ProtoErrorCode::NotLeader as i32);
     let metadata = response.metadata.expect("NotLeader must carry ErrorMetadata");
     assert_eq!(metadata.leader_id.as_deref(), Some("2"));
     assert_eq!(

--- a/d-engine-server/src/network/grpc/grpc_raft_service_test.rs
+++ b/d-engine-server/src/network/grpc/grpc_raft_service_test.rs
@@ -513,3 +513,100 @@ async fn test_handle_client_scan_timeout() {
 
     assert!(result.is_err(), "scan must error when Raft actor is absent");
 }
+
+/// handle_client_scan must forward a successful scan's entries + revision
+/// through to the wire unchanged. Proves the RPC handler's rewritten body
+/// (`proto_convert::to_proto_response`) is actually wired up, not just that
+/// the conversion function works in isolation (already covered separately
+/// in proto_convert_test.rs).
+#[tokio::test]
+#[traced_test]
+async fn test_handle_client_scan_success_returns_entries_and_revision() {
+    use bytes::Bytes;
+    use d_engine_core::ClientCmd;
+    use d_engine_core::client::ClientResponse;
+    use d_engine_proto::client::ScanRequest;
+    use d_engine_proto::client::client_response::SuccessResult;
+    use std::sync::atomic::Ordering;
+    use tokio::sync::mpsc;
+
+    let (_graceful_tx, graceful_rx) = watch::channel(());
+    let mut node = mock_node("/tmp/test_handle_client_scan_success", graceful_rx, None);
+    node.ready.store(true, Ordering::SeqCst);
+
+    let (cmd_tx, mut cmd_rx) = mpsc::channel(1);
+    node.cmd_tx = cmd_tx;
+    tokio::spawn(async move {
+        if let Some(ClientCmd::Scan(_, resp_tx)) = cmd_rx.recv().await {
+            let _ = resp_tx.send(Ok(ClientResponse::scan_results(
+                vec![(Bytes::from("/services/node1"), Bytes::from("10.0.0.1"))],
+                7,
+            )));
+        }
+    });
+
+    let response = node
+        .handle_client_scan(Request::new(ScanRequest {
+            client_id: 1,
+            prefix: Bytes::from("/services/"),
+        }))
+        .await
+        .expect("scan must succeed")
+        .into_inner();
+
+    match response.success_result {
+        Some(SuccessResult::ScanData(sd)) => {
+            assert_eq!(sd.revision, 7);
+            assert_eq!(sd.entries.len(), 1);
+            assert_eq!(sd.entries[0].key, Bytes::from("/services/node1"));
+            assert_eq!(sd.entries[0].value, Bytes::from("10.0.0.1"));
+        }
+        other => panic!("expected ScanData, got: {other:?}"),
+    }
+}
+
+/// #425: a scan rejected because this node isn't leader must carry the real
+/// leader's id/address through to the wire (`ErrorMetadata`), the same
+/// guarantee already proven for write/read — now proven for the RPC-level
+/// scan handler specifically, not just the role-state layer that builds it.
+#[tokio::test]
+#[traced_test]
+async fn test_handle_client_scan_not_leader_carries_leader_hint_in_metadata() {
+    use d_engine_core::ClientCmd;
+    use d_engine_core::client::ClientResponse;
+    use d_engine_core::client::LeaderHint;
+    use d_engine_proto::client::ScanRequest;
+    use std::sync::atomic::Ordering;
+    use tokio::sync::mpsc;
+
+    let (_graceful_tx, graceful_rx) = watch::channel(());
+    let mut node = mock_node("/tmp/test_handle_client_scan_not_leader", graceful_rx, None);
+    node.ready.store(true, Ordering::SeqCst);
+
+    let (cmd_tx, mut cmd_rx) = mpsc::channel(1);
+    node.cmd_tx = cmd_tx;
+    tokio::spawn(async move {
+        if let Some(ClientCmd::Scan(_, resp_tx)) = cmd_rx.recv().await {
+            let _ = resp_tx.send(Ok(ClientResponse::not_leader(Some(LeaderHint {
+                leader_id: 2,
+                address: "http://127.0.0.1:9082".into(),
+            }))));
+        }
+    });
+
+    let response = node
+        .handle_client_scan(Request::new(ScanRequest {
+            client_id: 1,
+            prefix: bytes::Bytes::from("/services/"),
+        }))
+        .await
+        .expect("NotLeader is a business-level response, not an RPC error")
+        .into_inner();
+
+    let metadata = response.metadata.expect("NotLeader must carry ErrorMetadata");
+    assert_eq!(metadata.leader_id.as_deref(), Some("2"));
+    assert_eq!(
+        metadata.leader_address.as_deref(),
+        Some("http://127.0.0.1:9082")
+    );
+}

--- a/d-engine-server/src/network/grpc/grpc_transport.rs
+++ b/d-engine-server/src/network/grpc/grpc_transport.rs
@@ -101,7 +101,7 @@ where
         debug!("Sending cluster configuration update requests");
 
         // Get voting members (control plane operation)
-        let peers = membership.voters().await;
+        let peers = membership.voters();
         if peers.is_empty() {
             warn!("No voting members available for cluster update");
             return Err(NetworkError::EmptyPeerList {
@@ -319,7 +319,7 @@ where
         debug!("Sending vote requests");
 
         // Get voting members (control plane operation)
-        let peers = membership.voters().await;
+        let peers = membership.voters();
         if peers.is_empty() {
             warn!("No voting members available for vote requests");
             return Err(NetworkError::EmptyPeerList {
@@ -445,7 +445,7 @@ where
     ) -> Result<Vec<LeaderDiscoveryResponse>> {
         debug!("Starting leader discovery for node {}", request.node_id);
 
-        let member_ids: Vec<_> = membership.voters().await.iter().map(|m| m.id).collect();
+        let member_ids: Vec<_> = membership.voters().iter().map(|m| m.id).collect();
 
         let tasks = member_ids.into_iter().map(|member_id| {
             Self::process_member(

--- a/d-engine-server/src/proto_convert.rs
+++ b/d-engine-server/src/proto_convert.rs
@@ -21,9 +21,10 @@ use d_engine_core::client::{
     KvEntry, LeaderHint, ReadResults, WriteResult,
 };
 use d_engine_core::config::ReadConsistencyPolicy;
+use d_engine_core::types::ScanResults;
 use d_engine_proto::client::{
-    self as proto_client, ClientResult, ReadResults as ProtoReadResults, WriteCommand,
-    WriteResult as ProtoWriteResult,
+    self as proto_client, ClientResult, ReadResults as ProtoReadResults,
+    ScanResults as ProtoScanResults, WriteCommand, WriteResult as ProtoWriteResult,
 };
 use d_engine_proto::error::{ErrorCode as ProtoErrorCode, ErrorMetadata};
 use prost::Message;
@@ -116,6 +117,12 @@ pub(crate) fn to_core_response(r: proto_client::ClientResponse) -> ClientRespons
                     .collect(),
             })
         }
+        proto_client::client_response::SuccessResult::ScanData(sd) => {
+            ClientResponsePayload::Scan(ScanResults {
+                entries: sd.entries.into_iter().map(|e| (e.key, e.value)).collect(),
+                revision: sd.revision,
+            })
+        }
     });
 
     ClientResponse {
@@ -177,6 +184,16 @@ pub(crate) fn to_proto_response(r: ClientResponse) -> proto_client::ClientRespon
                         value: e.value,
                     })
                     .collect(),
+            })
+        }
+        ClientResponsePayload::Scan(sd) => {
+            proto_client::client_response::SuccessResult::ScanData(ProtoScanResults {
+                entries: sd
+                    .entries
+                    .into_iter()
+                    .map(|(key, value)| proto_client::KvEntry { key, value })
+                    .collect(),
+                revision: sd.revision,
             })
         }
     });

--- a/d-engine-server/src/proto_convert_test.rs
+++ b/d-engine-server/src/proto_convert_test.rs
@@ -4,6 +4,7 @@ use d_engine_core::client::{
     KvEntry, LeaderHint, ReadResults, WriteResult,
 };
 use d_engine_core::config::ReadConsistencyPolicy;
+use d_engine_core::types::ScanResults;
 use d_engine_proto::client as proto_client;
 use d_engine_proto::client::WriteCommand;
 use d_engine_proto::client::write_command::{Insert, Operation};
@@ -196,6 +197,55 @@ fn test_to_proto_response_success_read() {
 }
 
 #[test]
+fn test_to_proto_response_success_scan() {
+    let core_resp = ClientResponse {
+        error: ErrorCode::Success,
+        leader_hint: None,
+        retry_after_ms: None,
+        result: Some(ClientResponsePayload::Scan(ScanResults {
+            entries: vec![(Bytes::from("k1"), Bytes::from("v1"))],
+            revision: 42,
+        })),
+    };
+    let proto_resp = to_proto_response(core_resp);
+
+    assert_eq!(proto_resp.error, ProtoErrorCode::Success as i32);
+    match proto_resp.success_result {
+        Some(proto_client::client_response::SuccessResult::ScanData(sd)) => {
+            assert_eq!(sd.entries.len(), 1);
+            assert_eq!(sd.entries[0].key, Bytes::from("k1"));
+            assert_eq!(sd.entries[0].value, Bytes::from("v1"));
+            assert_eq!(sd.revision, 42);
+        }
+        _ => panic!("expected ScanData"),
+    }
+}
+
+/// revision must survive even when there are no matching entries — it is not
+/// derived from entries.len(), it's the Raft applied index at scan time.
+#[test]
+fn test_to_proto_response_empty_scan_keeps_revision() {
+    let core_resp = ClientResponse {
+        error: ErrorCode::Success,
+        leader_hint: None,
+        retry_after_ms: None,
+        result: Some(ClientResponsePayload::Scan(ScanResults {
+            entries: vec![],
+            revision: 9,
+        })),
+    };
+    let proto_resp = to_proto_response(core_resp);
+
+    match proto_resp.success_result {
+        Some(proto_client::client_response::SuccessResult::ScanData(sd)) => {
+            assert!(sd.entries.is_empty());
+            assert_eq!(sd.revision, 9);
+        }
+        _ => panic!("expected ScanData"),
+    }
+}
+
+#[test]
 fn test_to_proto_response_not_leader_with_hint() {
     let core_resp = ClientResponse {
         error: ErrorCode::NotLeader,
@@ -284,6 +334,56 @@ fn test_to_core_response_not_leader_with_metadata() {
     let hint = core_resp.leader_hint.unwrap();
     assert_eq!(hint.leader_id, 3);
     assert_eq!(hint.address, "10.0.0.3:5003");
+}
+
+#[test]
+fn test_to_core_response_success_scan() {
+    let proto_resp = proto_client::ClientResponse {
+        error: ProtoErrorCode::Success as i32,
+        metadata: None,
+        success_result: Some(proto_client::client_response::SuccessResult::ScanData(
+            proto_client::ScanResults {
+                entries: vec![proto_client::KvEntry {
+                    key: Bytes::from("k1"),
+                    value: Bytes::from("v1"),
+                }],
+                revision: 42,
+            },
+        )),
+    };
+    let core_resp = to_core_response(proto_resp);
+    assert_eq!(core_resp.error, ErrorCode::Success);
+    match core_resp.result {
+        Some(ClientResponsePayload::Scan(sr)) => {
+            assert_eq!(sr.entries, vec![(Bytes::from("k1"), Bytes::from("v1"))]);
+            assert_eq!(sr.revision, 42);
+        }
+        _ => panic!("expected Scan payload"),
+    }
+}
+
+/// revision must survive even when there are no matching entries — it is not
+/// derived from entries.len(), it's the Raft applied index at scan time.
+#[test]
+fn test_to_core_response_empty_scan_keeps_revision() {
+    let proto_resp = proto_client::ClientResponse {
+        error: ProtoErrorCode::Success as i32,
+        metadata: None,
+        success_result: Some(proto_client::client_response::SuccessResult::ScanData(
+            proto_client::ScanResults {
+                entries: vec![],
+                revision: 9,
+            },
+        )),
+    };
+    let core_resp = to_core_response(proto_resp);
+    match core_resp.result {
+        Some(ClientResponsePayload::Scan(sr)) => {
+            assert!(sr.entries.is_empty());
+            assert_eq!(sr.revision, 9);
+        }
+        _ => panic!("expected Scan payload"),
+    }
 }
 
 /// Unparseable leader_id string → LeaderHint is None (not a panic).

--- a/d-engine-server/src/test_utils/mock/mock_rpc.rs
+++ b/d-engine-server/src/test_utils/mock/mock_rpc.rs
@@ -5,7 +5,6 @@ use d_engine_proto::client::ClientResponse;
 use d_engine_proto::client::ClientWriteRequest;
 use d_engine_proto::client::MembershipSnapshot as ProtoMembershipSnapshot;
 use d_engine_proto::client::ScanRequest;
-use d_engine_proto::client::ScanResponse;
 use d_engine_proto::client::WatchMembershipRequest;
 use d_engine_proto::client::WatchRequest;
 use d_engine_proto::client::WatchResponse;
@@ -221,7 +220,7 @@ impl RaftClientService for MockRpcService {
     async fn handle_client_scan(
         &self,
         _request: tonic::Request<ScanRequest>,
-    ) -> std::result::Result<tonic::Response<ScanResponse>, tonic::Status> {
+    ) -> std::result::Result<tonic::Response<ClientResponse>, tonic::Status> {
         Err(tonic::Status::unimplemented("not used in mock"))
     }
 }

--- a/d-engine-server/tests/cluster_lifecycle/scale_single_to_three_node_embedded.rs
+++ b/d-engine-server/tests/cluster_lifecycle/scale_single_to_three_node_embedded.rs
@@ -9,6 +9,7 @@ use tracing_test::traced_test;
 use crate::common::create_rejoin_node_config;
 use crate::common::get_available_ports;
 use crate::common::node_config;
+use crate::common::retry_until;
 
 /// Test scaling from single-node to 3-node cluster
 ///
@@ -620,52 +621,41 @@ election_timeout_max = 6000
     // Node 1 rejoins as follower — wait_ready only guarantees leader recognition,
     // not that log replication has caught up. Retry until data is visible locally.
     info!("Phase 6a: Waiting for Node 1 to sync data after rejoin");
+    let client1 = engine1.client();
 
-    let phase1_val = {
-        let mut val = None;
-        for _ in 0..20 {
-            val = engine1.client().get_eventual(b"phase1-key".to_vec()).await?;
-            if val.is_some() {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(500)).await;
-        }
-        val
-    };
+    let phase1_val = retry_until(
+        20,
+        Duration::from_millis(500),
+        || client1.get_eventual(b"phase1-key".to_vec()),
+        |r| matches!(r, Ok(Some(_))),
+    )
+    .await?;
     assert_eq!(
         phase1_val.as_deref(),
         Some(b"phase1-value".as_ref()),
         "Node 1 should have phase1 data after sync"
     );
 
-    let phase2_val = {
-        let mut val = None;
-        for _ in 0..20 {
-            val = engine1.client().get_eventual(b"phase2-key".to_vec()).await?;
-            if val.is_some() {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(500)).await;
-        }
-        val
-    };
+    let phase2_val = retry_until(
+        20,
+        Duration::from_millis(500),
+        || client1.get_eventual(b"phase2-key".to_vec()),
+        |r| matches!(r, Ok(Some(_))),
+    )
+    .await?;
     assert_eq!(
         phase2_val.as_deref(),
         Some(b"phase2-value".as_ref()),
         "Node 1 should have phase2 data after sync"
     );
 
-    let phase3_val = {
-        let mut val = None;
-        for _ in 0..20 {
-            val = engine1.client().get_eventual(b"phase3-key".to_vec()).await?;
-            if val.is_some() {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(500)).await;
-        }
-        val
-    };
+    let phase3_val = retry_until(
+        20,
+        Duration::from_millis(500),
+        || client1.get_eventual(b"phase3-key".to_vec()),
+        |r| matches!(r, Ok(Some(_))),
+    )
+    .await?;
     assert_eq!(
         phase3_val.as_deref(),
         Some(b"phase3-value".as_ref()),

--- a/d-engine-server/tests/common/mod.rs
+++ b/d-engine-server/tests/common/mod.rs
@@ -625,6 +625,7 @@ where
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = T>,
 {
+    assert!(max_attempts > 0, "max_attempts must be at least 1");
     let mut last = f().await;
     for _ in 1..max_attempts {
         if predicate(&last) {

--- a/d-engine-server/tests/common/mod.rs
+++ b/d-engine-server/tests/common/mod.rs
@@ -613,6 +613,29 @@ pub async fn wait_for_stable_leader(client: &Client) -> Result<(), ClientApiErro
     }
 }
 
+/// Polls `f` until the result satisfies `predicate`, or `max_attempts` is reached.
+/// Sleeps `delay` between attempts. Always returns the last value produced.
+pub async fn retry_until<T, F, Fut>(
+    max_attempts: usize,
+    delay: Duration,
+    mut f: F,
+    predicate: impl Fn(&T) -> bool,
+) -> T
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = T>,
+{
+    let mut last = f().await;
+    for _ in 1..max_attempts {
+        if predicate(&last) {
+            return last;
+        }
+        tokio::time::sleep(delay).await;
+        last = f().await;
+    }
+    last
+}
+
 /// Checks whether the given snapshot path exists, is a directory, and contains any files or
 /// subdirectories.
 ///

--- a/d-engine-server/tests/failover_and_recovery/leader_failover_embedded.rs
+++ b/d-engine-server/tests/failover_and_recovery/leader_failover_embedded.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use d_engine_core::client::ClientApiError;
+use d_engine_core::client::ErrorCode;
+use d_engine_core::client::LeaderHint;
 use d_engine_server::RocksDBUnifiedEngine;
 use d_engine_server::api::DefaultEmbeddedEngine;
 use tracing::info;
@@ -95,6 +98,38 @@ async fn test_embedded_leader_failover() -> Result<(), Box<dyn std::error::Error
         assert_eq!(val.as_deref(), Some(b"initial-value".as_slice()));
     }
     info!("Initial data written successfully");
+
+    // Writing to a follower must be rejected with the real leader's address, so the
+    // caller (e.g. d-lmdb/d-stream, running fully in-process against EmbeddedClient)
+    // can redirect without ever touching gRPC/tonic. See ticket for #425 follow-up.
+    let follower_idx = (0..3).find(|&i| i != leader_idx).expect("cluster has followers");
+    let follower_result = engines[follower_idx]
+        .client()
+        .put(b"should-reject".to_vec(), b"wrong-node".to_vec())
+        .await;
+    match follower_result {
+        Err(ClientApiError::Network {
+            code: ErrorCode::NotLeader,
+            leader_hint,
+            ..
+        }) => {
+            assert_eq!(
+                leader_hint,
+                Some(LeaderHint {
+                    leader_id: initial_leader.leader_id,
+                    // Membership::get_address normalizes to a scheme-prefixed URI
+                    // (see d-engine-server/src/utils/net.rs::address_str) so the
+                    // hint is directly usable to build a GrpcClient.
+                    address: format!("http://127.0.0.1:{}", ports[leader_idx]),
+                }),
+                "follower rejection must carry the real leader's id and address"
+            );
+        }
+        other => panic!(
+            "write to follower must return Network{{NotLeader, leader_hint}}, got: {other:?}"
+        ),
+    }
+    info!("Confirmed: write to follower carries real leader_hint");
 
     // Kill the actual leader node
     let leader_idx = (initial_leader.leader_id - 1) as usize;

--- a/d-engine-server/tests/failover_and_recovery/leader_failover_standalone.rs
+++ b/d-engine-server/tests/failover_and_recovery/leader_failover_standalone.rs
@@ -15,6 +15,7 @@ use crate::common::create_bootstrap_urls;
 use crate::common::create_node_config;
 use crate::common::get_available_ports;
 use crate::common::node_config;
+use crate::common::retry_until;
 use crate::common::start_node;
 use crate::common::wait_for_stable_leader;
 
@@ -65,17 +66,15 @@ async fn test_3_node_failover() -> Result<(), ClientApiError> {
     // Write test data before failover
     client.put("before-failover", "initial-value").await?;
     // Retry read until replicated (fixed sleep is unreliable under parallel test load)
-    let result = {
-        let mut val = None;
-        for _ in 0..10 {
-            tokio::time::sleep(Duration::from_millis(LATENCY_IN_MS)).await;
-            if let Ok(Some(v)) = client.get_eventual("before-failover").await {
-                val = Some(v);
-                break;
-            }
-        }
-        val
-    };
+    let result = retry_until(
+        10,
+        Duration::from_millis(LATENCY_IN_MS),
+        || client.get_eventual("before-failover"),
+        |r| matches!(r, Ok(Some(_))),
+    )
+    .await
+    .ok()
+    .flatten();
     assert_eq!(
         result.expect("Key should exist after write").as_ref(),
         b"initial-value"
@@ -113,30 +112,26 @@ async fn test_3_node_failover() -> Result<(), ClientApiError> {
         }
     }
     // Retry reads until replicated after failover and re-election
-    let old_val = {
-        let mut val = None;
-        for _ in 0..10 {
-            tokio::time::sleep(Duration::from_millis(LATENCY_IN_MS)).await;
-            if let Ok(Some(v)) = client.get_eventual("before-failover").await {
-                val = Some(v);
-                break;
-            }
-        }
-        val
-    };
+    let old_val = retry_until(
+        10,
+        Duration::from_millis(LATENCY_IN_MS),
+        || client.get_eventual("before-failover"),
+        |r| matches!(r, Ok(Some(_))),
+    )
+    .await
+    .ok()
+    .flatten();
     assert_eq!(old_val.unwrap().as_ref(), b"initial-value");
 
-    let new_val = {
-        let mut val = None;
-        for _ in 0..10 {
-            tokio::time::sleep(Duration::from_millis(LATENCY_IN_MS)).await;
-            if let Ok(Some(v)) = client.get_eventual("after-failover").await {
-                val = Some(v);
-                break;
-            }
-        }
-        val
-    };
+    let new_val = retry_until(
+        10,
+        Duration::from_millis(LATENCY_IN_MS),
+        || client.get_eventual("after-failover"),
+        |r| matches!(r, Ok(Some(_))),
+    )
+    .await
+    .ok()
+    .flatten();
     assert_eq!(new_val.unwrap().as_ref(), b"still-works");
 
     info!("Failover test passed. Cluster operational with 2/3 nodes");
@@ -161,17 +156,15 @@ async fn test_3_node_failover() -> Result<(), ClientApiError> {
 
     // Retry read until node 1 synced data from cluster
     client.refresh(None).await?;
-    let synced_val = {
-        let mut val = None;
-        for _ in 0..10 {
-            tokio::time::sleep(Duration::from_millis(LATENCY_IN_MS)).await;
-            if let Ok(Some(v)) = client.get_eventual("after-failover").await {
-                val = Some(v);
-                break;
-            }
-        }
-        val
-    };
+    let synced_val = retry_until(
+        10,
+        Duration::from_millis(LATENCY_IN_MS),
+        || client.get_eventual("after-failover"),
+        |r| matches!(r, Ok(Some(_))),
+    )
+    .await
+    .ok()
+    .flatten();
     assert_eq!(synced_val.unwrap().as_ref(), b"still-works");
 
     info!("Node 1 synced successfully. Test complete");

--- a/d-engine-server/tests/failover_and_recovery/leader_failover_standalone.rs
+++ b/d-engine-server/tests/failover_and_recovery/leader_failover_standalone.rs
@@ -72,9 +72,7 @@ async fn test_3_node_failover() -> Result<(), ClientApiError> {
         || client.get_eventual("before-failover"),
         |r| matches!(r, Ok(Some(_))),
     )
-    .await
-    .ok()
-    .flatten();
+    .await?;
     assert_eq!(
         result.expect("Key should exist after write").as_ref(),
         b"initial-value"
@@ -118,9 +116,7 @@ async fn test_3_node_failover() -> Result<(), ClientApiError> {
         || client.get_eventual("before-failover"),
         |r| matches!(r, Ok(Some(_))),
     )
-    .await
-    .ok()
-    .flatten();
+    .await?;
     assert_eq!(old_val.unwrap().as_ref(), b"initial-value");
 
     let new_val = retry_until(
@@ -129,9 +125,7 @@ async fn test_3_node_failover() -> Result<(), ClientApiError> {
         || client.get_eventual("after-failover"),
         |r| matches!(r, Ok(Some(_))),
     )
-    .await
-    .ok()
-    .flatten();
+    .await?;
     assert_eq!(new_val.unwrap().as_ref(), b"still-works");
 
     info!("Failover test passed. Cluster operational with 2/3 nodes");
@@ -162,9 +156,7 @@ async fn test_3_node_failover() -> Result<(), ClientApiError> {
         || client.get_eventual("after-failover"),
         |r| matches!(r, Ok(Some(_))),
     )
-    .await
-    .ok()
-    .flatten();
+    .await?;
     assert_eq!(synced_val.unwrap().as_ref(), b"still-works");
 
     info!("Node 1 synced successfully. Test complete");

--- a/d-engine-server/tests/readonly_and_learner_mode/learner_readonly_sync_standalone.rs
+++ b/d-engine-server/tests/readonly_and_learner_mode/learner_readonly_sync_standalone.rs
@@ -26,6 +26,7 @@ use crate::common::create_node_config;
 use crate::common::get_available_ports;
 use crate::common::node_config;
 use crate::common::reset;
+use crate::common::retry_until;
 use crate::common::start_node;
 use crate::common::test_put_get;
 
@@ -195,11 +196,18 @@ general_raft_timeout_duration_in_ms = 5000
     test_put_get(&mut client_manager, 3, 102).await?;
     println!("         ✓ New write succeeded through primary cluster");
 
-    // Verify ReadOnly Learner receives the new data
-    let value3 = ClientManager::read_from_node(
-        &node4_endpoint,
-        3,
-        ReadConsistencyPolicy::EventualConsistency,
+    // Verify ReadOnly Learner receives the new data (poll — replication may lag).
+    let value3 = retry_until(
+        10,
+        Duration::from_millis(50),
+        || {
+            ClientManager::read_from_node(
+                &node4_endpoint,
+                3,
+                ReadConsistencyPolicy::EventualConsistency,
+            )
+        },
+        |r| matches!(r, Ok(v) if *v == 102),
     )
     .await?;
     assert_eq!(

--- a/d-engine-server/tests/storage_buffered_raft_log/performance_test.rs
+++ b/d-engine-server/tests/storage_buffered_raft_log/performance_test.rs
@@ -17,19 +17,6 @@ use std::time::Duration;
 use tempfile::tempdir;
 use tokio::time::Instant;
 
-// TODO: Extract 6 real I/O performance tests from legacy_all_tests.rs:
-// - test_filter_out_conflicts_performance_consistent_across_flush_intervals_fresh_cluster (✅ migrated)
-// - test_filter_out_conflicts_performance_consistent_across_flush_intervals (✅ migrated)
-// - test_last_entry_id_performance
-// - test_remove_range_performance
-// - test_performance_benchmarks
-// - test_read_performance_remains_lockfree
-//
-// Note: The following 3 tests were moved to d-engine-core unit tests (require Mock):
-// - test_reset_performance_during_active_flush (moved to core)
-// - test_filter_conflicts_performance_during_flush (moved to core)
-// - test_fresh_cluster_performance_consistency (moved to core)
-
 mod filter_out_conflicts_and_append_performance_tests {
     use super::*;
 

--- a/examples/service-discovery-standalone/watcher.rs
+++ b/examples/service-discovery-standalone/watcher.rs
@@ -36,7 +36,7 @@ use std::time::Duration;
 use anyhow::Result;
 use clap::Parser;
 use d_engine::protocol::{WatchEventType, WatchResponse};
-use d_engine::{Client, ClientApi, ScanResult};
+use d_engine::{Client, ClientApi, ScanResults};
 use futures::StreamExt;
 
 #[derive(Parser)]
@@ -116,10 +116,7 @@ async fn run_exact_watch(
 
     println!("\n=== Watching for Changes (Ctrl+C to exit) ===\n");
 
-    let mut stream = client
-        .watch(key)
-        .await
-        .map_err(|e| anyhow::anyhow!("Watch failed: {e:?}"))?;
+    let mut stream = client.watch(key).await.map_err(|e| anyhow::anyhow!("Watch failed: {e:?}"))?;
 
     while let Some(event_result) = stream.next().await {
         match event_result {
@@ -173,7 +170,7 @@ async fn run_prefix_watch(
         };
 
         // Step 2: linearizable scan — any write before/during scan is in the snapshot
-        let snapshot: ScanResult = match client.scan_prefix(prefix).await {
+        let snapshot: ScanResults = match client.scan_prefix(prefix).await {
             Ok(s) => s,
             Err(e) => {
                 eprintln!("[scan error] {e:?} — reconnecting in 1s");
@@ -185,7 +182,12 @@ async fn run_prefix_watch(
         let mut registry: HashMap<Vec<u8>, String> = snapshot
             .entries
             .into_iter()
-            .map(|entry| (entry.0.to_vec(), String::from_utf8_lossy(&entry.1).to_string()))
+            .map(|entry| {
+                (
+                    entry.0.to_vec(),
+                    String::from_utf8_lossy(&entry.1).to_string(),
+                )
+            })
             .collect();
 
         println!("[connected] watching {prefix} (scan_revision={scan_revision})");


### PR DESCRIPTION
## What Does This PR Do?

Fixes `EmbeddedClient`/`GrpcClient` losing `leader_hint` when a write, read, or scan is rejected by a non-leader node, so callers can actually redirect to the real leader instead of just seeing a generic error.

**Type:**

- [x] Bug Fix (with test)
- [ ] Feature (issue #\_\_\_ approved)
- [ ] Documentation
- [ ] Test/Coverage
- [ ] Performance (with benchmark)

---

## Why Is This Needed?

**For bugs:** Non-leader rejections for `Propose`/`Read`/`Scan` returned `ErrorCode::NotLeader` but dropped `leader_hint`, and `From<ErrorCode>` mapped `NotLeader` to `ClientApiError::Business` (which has no `leader_hint` field at all) instead of `Network`. Callers had no way to find the real leader and redirect — they'd just retry blind or give up. Fixing this required unifying `Scan` into the same `ClientResponsePayload` envelope as `Write`/`Read` (it was previously a separate ad-hoc proto message), which is most of the diff size.

---

## Checklist

**Required:**

- [x] `make test` passes
- [x] Added tests for new code
- [x] Commits squashed to 1-2 logical units

**If changing APIs:**

- [x] Updated relevant docs
- [x] Explained why complexity is justified

---

## Testing

**How tested:**

- Unit tests: `create_not_leader_response`/`push_client_cmd` (Follower/Candidate/Learner) carry real `leader_hint`; `ClientApiError::From<ErrorCode>`/`From<Status>` NotLeader mapping; `EmbeddedClient::scan_prefix` and `handle_client_scan` error/success paths; `client_ext::into_scan_results`; `extract_read_payload` Scan rejection
- Integration tests: `leader_failover_embedded::test_embedded_leader_failover` extended — write to a follower in a real 3-node cluster now asserts the returned `leader_hint` matches the real leader's address
- Manual testing: n/a

**For bug fixes:**

- [x] Added test that fails without this fix

---

## Does This Follow d-engine's Principles?

- [x] Solves a real problem for most users (not just my edge case)
- [x] Keeps implementation simple
- [x] Doesn't bloat the API surface

---

## Reviewer Notes

Deliberately did **not** add `leader_hint` to `LeaderState::drain_read_buffer()` (buffer clear on stepdown) — role is still Leader at that point, `current_leader()` isn't updated yet, so any hint built there would be stale/wrong. See `decisions/013`.

Also fixed a latent gap found while testing: `ScanResults` (the new client-facing scan type) was never re-exported from `d-engine-client`/`d-engine-server`/`d-engine`, which broke `examples/service-discovery-standalone`.

**Estimated review complexity:**

- [ ] Quick (< 100 lines)
- [ ] Medium (< 300 lines)
- [x] Deep (> 300 lines) — 53 files, +1273/-508, but half is test coverage and mechanical proto renames


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prefix scans now consistently return structured scan results (entries plus revision) across client, embedded, and gRPC APIs.
  * Not-leader responses now include network error details with an optional leader hint and retry guidance when available.
* **Bug Fixes**
  * Invalid scan/read response payloads are now rejected with clearer protocol errors.
  * Not-leader error mapping is aligned across server/client paths for consistent error structure.
* **Tests / CI**
  * Enhanced scan conversion and error-handling tests, plus more reliable integration checks using shared retry helpers.
  * CI and test configuration updated to improve execution control and multi-node grouping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->