### PR TITLE
fix #430: data_dir out of config, snapshots_dir fixed derivation, startup lock, NodeBuilder no longer public

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -10,9 +10,10 @@ max-threads = 2
 
 [profile.default]
 
-# Force serial execution for tests that use /tmp/db
+# Force serial execution for tests that use /tmp/db, or that mutate the
+# process-global RAFT__CLUSTER__* env vars (data_dir_lock/single_node_bootstrap)
 [[profile.default.overrides]]
-filter = "test(tmp_db) | test(config_path_env)"
+filter = "test(tmp_db) | test(config_path_env) | test(data_dir_lock) | test(single_node_bootstrap)"
 threads-required = 'num-cpus'
 
 # Serialize wall-clock perf assertions — CPU contention causes false failures, not the
@@ -42,7 +43,7 @@ test-group = "multi-node-cluster-local"
 [profile.ci]
 
 [[profile.ci.overrides]]
-filter = "test(tmp_db) | test(config_path_env)"
+filter = "test(tmp_db) | test(config_path_env) | test(data_dir_lock) | test(single_node_bootstrap)"
 threads-required = 'num-cpus'
 
 [[profile.ci.overrides]]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **MSRV raised to Rust 1.89**: The `data_dir` startup lock (prevents two node processes from
+  sharing the same directory) uses `std::fs::File::try_lock()`, stable since 1.89.0. CI and
+  `rust-toolchain.toml` were already pinned to 1.89.0 — only the `rust-version` field in
+  `Cargo.toml` needed to catch up. If you're building on 1.88, upgrade your toolchain.
+
 - `[raft.read_actor]` replaces the previous flat `read_actor_channel_capacity` / `read_actor_max_drain` fields in `[raft]`. Update existing config files accordingly.
 
 - **⚠️ `StateMachine::entry_term()` removed from trait** (#418): Term lookup belongs to the log layer, not the state machine. Custom `StateMachine` implementations must delete this method — it is no longer part of the trait. See [Migration Guide](./MIGRATION_GUIDE.md) for details.
@@ -47,6 +52,14 @@ All notable changes to this project will be documented in this file.
 
 - **New `shutdown_timeout_ms` in `[raft.persistence]`** (default `5000`): bounds `close()` wait
   against a stuck fsync task. The task itself continues running in the background.
+
+- **`data_dir` removed from `ClusterConfig`** — it is now a required explicit argument to all engine constructors (`EmbeddedEngine::start(data_dir)`, `StandaloneEngine::run(data_dir, shutdown_rx)`, etc.). Remove `[cluster] data_dir` / `[cluster] db_root_dir` from all config files; the constructor argument always wins and the config field is silently ignored.
+
+- **`cluster.log_dir` removed** — was validated but never consumed.
+
+- **`snapshots_dir` is no longer configurable** — always `data_dir/snapshots`. Fixes cross-node snapshot corruption when running multiple nodes on one machine (was a shared `/tmp/snapshots`).
+
+- **`NodeBuilder` is no longer public** — use `EmbeddedEngine::start_custom`/`StandaloneEngine::run_custom` to plug in a custom storage engine or state machine. See [Migration Guide](./MIGRATION_GUIDE.md) for details.
 
 ---
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ authors = ["Joshua Chi <joshokn@gmail.com>"]
 homepage = "https://github.com/deventlab/d-engine"
 repository = "https://github.com/deventlab/d-engine"
 license = "MIT OR Apache-2.0"
-rust-version = "1.88"
+rust-version = "1.89"
 
 [workspace.dependencies]
 d-engine-proto = { path = "./d-engine-proto", version = "0.2.4" }

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -600,4 +600,48 @@ No migration action required unless you want to tune read concurrency.
 
 ---
 
-**Last Updated:** May 2026
+## For v0.2.4 Users: `data_dir` moved out of config in v0.2.5
+
+`data_dir` (formerly `db_root_dir`) is no longer a config file field. Pass it as an explicit argument to the engine constructor instead:
+
+```rust,ignore
+// Before (v0.2.4)
+let engine = EmbeddedEngine::start_with("config.toml").await?;
+// config.toml had [cluster] data_dir = "./db"
+
+// After (v0.2.5)
+let engine = EmbeddedEngine::start_with("./db", "config.toml").await?;
+```
+
+All engine constructors (`start`, `start_with`, `start_custom`, `start_node`, `run`, `run_with`, `run_custom`) now require `data_dir` as the first argument. Remove `[cluster] data_dir` / `[cluster] db_root_dir` from all config files — the entry is silently ignored if left in place, but it's misleading.
+
+**`[cluster] log_dir`** is removed (it was validated but never consumed).
+
+**`snapshots_dir`** is no longer configurable — always `data_dir/snapshots`.
+
+---
+
+## For v0.2.4 Users: `NodeBuilder` is no longer public in v0.2.5
+
+Only affects code that plugged in a custom storage engine or state machine directly via `NodeBuilder`. If you used `EmbeddedEngine` or `StandaloneEngine`, no change needed.
+
+```rust,ignore
+// Before (v0.2.4)
+let node = NodeBuilder::new(data_dir, None, shutdown_rx)
+    .storage_engine(storage_engine)
+    .state_machine(state_machine)
+    .start()
+    .await?;
+node.run().await?;
+
+// After (v0.2.5)
+EmbeddedEngine::start_custom(data_dir, storage_engine, state_machine, None).await?;
+// or, for a standalone gRPC server:
+StandaloneEngine::run_custom(data_dir, storage_engine, state_machine, shutdown_rx, None).await?;
+```
+
+`start_custom`/`run_custom` cover the same ground — explicit `data_dir`, custom `StorageEngine`/`StateMachine`, optional config file.
+
+---
+
+**Last Updated:** August 2026

--- a/benches/embedded-bench/Makefile
+++ b/benches/embedded-bench/Makefile
@@ -10,6 +10,8 @@ CONFIG_DIR := ./config
 NODE ?= n1
 CONFIG_PATH := $(CONFIG_DIR)/$(NODE).toml
 SINGLE_NODE_CONFIG_PATH := $(CONFIG_DIR)/single_node.toml
+DATA_DIR := ./data/$(NODE)
+SINGLE_NODE_DATA_DIR := ./data/single-node
 
 # Metrics port per node — same scheme as examples/three-nodes-standalone
 # (8081/8082/8083), reused because the two setups never run concurrently.
@@ -119,6 +121,7 @@ test-single-write: build
 	@echo "Node: $(NODE)"
 	@echo "========================================"
 	CONFIG_PATH=$(SINGLE_NODE_CONFIG_PATH) \
+	DATA_DIR=$(SINGLE_NODE_DATA_DIR) \
 	METRICS_PORT=$(METRICS_PORT) \
 	RUST_LOG=embedded-bench=$(LOG_LEVEL),d_engine=$(LOG_LEVEL),timing=$(LOG_LEVEL) \
 	$(BENCH_BIN) \
@@ -139,6 +142,7 @@ test-high-conc-write: build
 	@echo "Node: $(NODE)"
 	@echo "========================================"
 	CONFIG_PATH=$(CONFIG_PATH) \
+	DATA_DIR=$(DATA_DIR) \
 	METRICS_PORT=$(METRICS_PORT) \
 	RUST_LOG=embedded-bench=$(LOG_LEVEL),d_engine=$(LOG_LEVEL),timing=$(LOG_LEVEL) \
 	$(BENCH_BIN) \
@@ -163,6 +167,7 @@ test-linearizable-read: build
 	@echo "Node: $(NODE)"
 	@echo "========================================"
 	CONFIG_PATH=$(CONFIG_PATH) \
+	DATA_DIR=$(DATA_DIR) \
 	METRICS_PORT=$(METRICS_PORT) \
 	RUST_LOG=embedded-bench=$(LOG_LEVEL),d_engine=$(LOG_LEVEL),timing=$(LOG_LEVEL) \
 	$(BENCH_BIN) \
@@ -182,6 +187,7 @@ test-lease-read: build
 	@echo "Node: $(NODE)"
 	@echo "========================================"
 	CONFIG_PATH=$(CONFIG_PATH) \
+	DATA_DIR=$(DATA_DIR) \
 	METRICS_PORT=$(METRICS_PORT) \
 	RUST_LOG=embedded-bench=$(LOG_LEVEL),d_engine=$(LOG_LEVEL),timing=$(LOG_LEVEL) \
 	$(BENCH_BIN) \
@@ -201,6 +207,7 @@ test-eventual-read: build
 	@echo "Node: $(NODE)"
 	@echo "========================================"
 	CONFIG_PATH=$(CONFIG_PATH) \
+	DATA_DIR=$(DATA_DIR) \
 	METRICS_PORT=$(METRICS_PORT) \
 	RUST_LOG=embedded-bench=$(LOG_LEVEL),d_engine=$(LOG_LEVEL),timing=$(LOG_LEVEL) \
 	$(BENCH_BIN) \
@@ -220,6 +227,7 @@ test-hot-key: build
 	@echo "Node: $(NODE)"
 	@echo "========================================"
 	CONFIG_PATH=$(CONFIG_PATH) \
+	DATA_DIR=$(DATA_DIR) \
 	METRICS_PORT=$(METRICS_PORT) \
 	RUST_LOG=embedded-bench=$(LOG_LEVEL),d_engine=$(LOG_LEVEL),timing=$(LOG_LEVEL) \
 	$(BENCH_BIN) \
@@ -241,6 +249,7 @@ all-tests: build
 	@echo "Node: $(NODE)"
 	@echo "========================================"
 	CONFIG_PATH=$(CONFIG_PATH) \
+	DATA_DIR=$(DATA_DIR) \
 	METRICS_PORT=$(METRICS_PORT) \
 	RUST_LOG=embedded-bench=$(LOG_LEVEL),d_engine=$(LOG_LEVEL),timing=$(LOG_LEVEL) \
 	$(BENCH_BIN) \

--- a/benches/embedded-bench/config/n1.toml
+++ b/benches/embedded-bench/config/n1.toml
@@ -6,8 +6,6 @@ initial_cluster = [
     { id = 2, address = "0.0.0.0:9082", role = 1, status = 3 },
     { id = 3, address = "0.0.0.0:9083", role = 1, status = 3 },
 ]
-db_root_dir = "./data/n1"
-log_dir = "./logs"
 
 [raft.read_actor]
 channel_capacity = 2048

--- a/benches/embedded-bench/config/n2.toml
+++ b/benches/embedded-bench/config/n2.toml
@@ -6,8 +6,6 @@ initial_cluster = [
     { id = 2, address = "0.0.0.0:9082", role = 1, status = 3 },
     { id = 3, address = "0.0.0.0:9083", role = 1, status = 3 },
 ]
-db_root_dir = "./data/n2"
-log_dir = "./logs"
 
 [raft.read_actor]
 channel_capacity = 2048

--- a/benches/embedded-bench/config/n3.toml
+++ b/benches/embedded-bench/config/n3.toml
@@ -6,8 +6,6 @@ initial_cluster = [
     { id = 2, address = "0.0.0.0:9082", role = 1, status = 3 },
     { id = 3, address = "0.0.0.0:9083", role = 1, status = 3 },
 ]
-db_root_dir = "./data/n3"
-log_dir = "./logs"
 
 [raft.read_actor]
 channel_capacity = 2048

--- a/benches/embedded-bench/config/single_node.toml
+++ b/benches/embedded-bench/config/single_node.toml
@@ -12,8 +12,6 @@ listen_address = "127.0.0.1:9081"
 initial_cluster = [
     { id = 1, address = "127.0.0.1:9081", role = 1, status = 3 }
 ]
-db_root_dir = "./data/single-node"
-log_dir = "./logs"
 
 [raft.snapshot]
 enable = false

--- a/benches/embedded-bench/src/main.rs
+++ b/benches/embedded-bench/src/main.rs
@@ -33,6 +33,10 @@ struct Cli {
     #[arg(long, default_value = "./config/n1.toml")]
     config_path: String,
 
+    /// Data directory (RocksDB storage)
+    #[arg(long, default_value = "./data/n1")]
+    data_dir: String,
+
     /// HTTP server port (server mode only)
     #[arg(long, default_value = "9001")]
     port: u16,
@@ -178,10 +182,14 @@ async fn main() {
         .init();
 
     let config_path = std::env::var("CONFIG_PATH").ok();
+    let data_dir = std::env::var("DATA_DIR").ok();
     let mut cli = Cli::parse();
 
     if let Some(path) = config_path {
         cli.config_path = path;
+    }
+    if let Some(dir) = data_dir {
+        cli.data_dir = dir;
     }
 
     // Same port scheme as examples/three-nodes-standalone (8081/8082/8083 per node) —
@@ -476,7 +484,7 @@ async fn run_local_benchmark(cli: Cli) {
     println!("Starting local benchmark mode...");
 
     let engine = Arc::new(
-        DefaultEmbeddedEngine::start_with(&cli.config_path)
+        DefaultEmbeddedEngine::start_with(&cli.data_dir, &cli.config_path)
             .await
             .expect("Failed to start engine"),
     );
@@ -702,7 +710,7 @@ async fn run_http_server(cli: Cli) {
     println!("Health check port: {}", cli.health_port);
 
     let engine = Arc::new(
-        DefaultEmbeddedEngine::start_with(&cli.config_path)
+        DefaultEmbeddedEngine::start_with(&cli.data_dir, &cli.config_path)
             .await
             .expect("Failed to start engine"),
     );

--- a/config/base/README.md
+++ b/config/base/README.md
@@ -2,25 +2,25 @@
 
 > **Note**: The `config/base/` and `config/overlays/` directories in this repo exist
 > for d-engine's own internal demo purpose only. They have no practical
-> use for application developers. In your own project, you only need a single
-> `d-engine.toml` with the settings you want to override.
+> use for application developers. Config is optional for a single node, and
+> one file per node for a cluster — see examples below. The filename doesn't
+> matter; you pass the path explicitly to `start_with`/`run_with`.
 
 This directory contains annotated reference files — one per configuration section.
 They document every available option so you know what can be tuned.
 
 ## In your application
 
-Write a minimal `d-engine.toml` with only the fields you need — all omitted fields
-use built-in defaults.
+Pass `data_dir` to the engine constructor. A config file is optional — omit it
+entirely for defaults, as in the single-node example below.
 
 **Single node:**
 
-```toml
-[cluster]
-db_root_dir = "./data"
+```rust,ignore
+EmbeddedEngine::start("./data").await?;
 ```
 
-**3-node cluster (one file per node):**
+**3-node cluster (one config file per node):**
 
 ```toml
 [cluster]
@@ -31,7 +31,10 @@ initial_cluster = [
     { id = 2, address = "0.0.0.0:9082", role = 1, status = 3 },
     { id = 3, address = "0.0.0.0:9083", role = 1, status = 3 },
 ]
-db_root_dir = "./db/1"
+```
+
+```rust,ignore
+EmbeddedEngine::start_with("./db/1", "config/n1.toml").await?;
 ```
 
 See [examples/](https://github.com/deventlab/d-engine/tree/main/examples) for complete
@@ -45,7 +48,7 @@ API documentation.
 
 | File              | What it covers                                     |
 | ----------------- | -------------------------------------------------- |
-| `cluster.toml`    | Node identity, peer addresses, data directory      |
+| `cluster.toml`    | Node identity, peer addresses                      |
 | `raft.toml`       | Batching, read consistency, snapshots, replication |
 | `network.toml`    | gRPC timeouts, connection windows, TCP tuning      |
 | `retry.toml`      | Retry policies for RPC operations                  |

--- a/config/base/cluster.toml
+++ b/config/base/cluster.toml
@@ -7,5 +7,3 @@ initial_cluster = [
     { id = 2, name = "n2", address = "127.0.0.1:9082", role = 1, status = 3 },
     { id = 3, name = "n3", address = "127.0.0.1:9083", role = 1, status = 3 },
 ]
-db_root_dir = "/tmp/db"
-log_dir = "/tmp/logs"

--- a/config/base/raft.toml
+++ b/config/base/raft.toml
@@ -174,7 +174,6 @@ snapshot_cool_down_since_last_check = { secs = 60 }
 cleanup_retain_count = 2
 
 # Snapshot storage directory.
-snapshots_dir = "./snapshots/"
 
 # Prefix for snapshot directory names.
 snapshots_dir_prefix = "snapshot"

--- a/config/overlays/n1.toml
+++ b/config/overlays/n1.toml
@@ -6,8 +6,6 @@ initial_cluster = [
     { id = 2, address = "127.0.0.1:9082", role = 1, status = 3 },
     { id = 3, address = "127.0.0.1:9083", role = 1, status = 3 },
 ]
-db_root_dir = "./db/1"
-log_dir = "./logs"
 
 [monitoring]
 prometheus_port = 8081

--- a/config/overlays/n2.toml
+++ b/config/overlays/n2.toml
@@ -6,8 +6,6 @@ initial_cluster = [
     { id = 2, address = "127.0.0.1:9082", role = 1, status = 3 },
     { id = 3, address = "127.0.0.1:9083", role = 1, status = 3 },
 ]
-db_root_dir = "./db/2"
-log_dir = "./logs"
 
 [monitoring]
 prometheus_port = 8082

--- a/config/overlays/n3.toml
+++ b/config/overlays/n3.toml
@@ -6,8 +6,6 @@ initial_cluster = [
     { id = 2, address = "127.0.0.1:9082", role = 1, status = 3 },
     { id = 3, address = "127.0.0.1:9083", role = 1, status = 3 },
 ]
-db_root_dir = "./db/3"
-log_dir = "./logs"
 
 [monitoring]
 prometheus_port = 8083

--- a/config/overlays/prod.toml
+++ b/config/overlays/prod.toml
@@ -1,6 +1,4 @@
 # Production environment coverage configuration
-[cluster]
-data_dir = "/mnt/ssd/raft-data"
 
 [network]
 tcp_keepalive_secs = 7200 # Extend the production environment Keepalive

--- a/d-engine-core/benches/leader_state_bench.rs
+++ b/d-engine-core/benches/leader_state_bench.rs
@@ -120,7 +120,6 @@ use d_engine_core::{
 };
 use d_engine_proto::common::{LogId, NodeStatus};
 use d_engine_proto::server::cluster::{ClusterMembership, NodeMeta};
-use tempfile::TempDir;
 use tokio::sync::mpsc;
 use tokio::time::Instant;
 
@@ -132,9 +131,7 @@ use tokio::time::Instant;
 /// Target: < 500 ns
 /// Failure: > 1000 ns
 fn bench_leader_state_creation(c: &mut Criterion) {
-    let temp_dir = TempDir::new().expect("Failed to create temp dir");
-    let mut node_config = RaftNodeConfig::default();
-    node_config.cluster.db_root_dir = temp_dir.path().to_path_buf();
+    let node_config = RaftNodeConfig::default();
     let config = Arc::new(node_config);
 
     c.bench_function("LeaderState::new", |b| {
@@ -153,10 +150,8 @@ struct BenchFixture {
 }
 
 impl BenchFixture {
-    async fn new(test_name: &str) -> Self {
-        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    async fn new(_test_name: &str) -> Self {
         let mut node_config = RaftNodeConfig::default();
-        node_config.cluster.db_root_dir = temp_dir.path().join(test_name);
         node_config.raft.membership.verify_leadership_persistent_timeout =
             Duration::from_millis(100);
 

--- a/d-engine-core/src/config/cluster.rs
+++ b/d-engine-core/src/config/cluster.rs
@@ -1,5 +1,4 @@
 use std::net::SocketAddr;
-use std::path::PathBuf;
 
 use config::ConfigError;
 use d_engine_proto::common::NodeRole::Follower;
@@ -7,9 +6,7 @@ use d_engine_proto::common::NodeStatus;
 use d_engine_proto::server::cluster::NodeMeta;
 use serde::Deserialize;
 use serde::Serialize;
-use tracing::warn;
 
-use super::validate_directory;
 use crate::Error;
 use crate::Result;
 
@@ -40,22 +37,17 @@ pub struct ClusterConfig {
     ///
     /// Default: `default_initial_cluster()`
     ///
+    /// Accepts either the full form (`{id, address, role, status}`) or the
+    /// common shorthand (`{id, address}` — role/status default to
+    /// Follower/Active). Both forms can be mixed in the same list.
+    ///
     /// # Note
     /// Should contain at least 3 nodes for production deployment
-    #[serde(default = "default_initial_cluster")]
+    #[serde(
+        default = "default_initial_cluster",
+        deserialize_with = "deserialize_initial_cluster"
+    )]
     pub initial_cluster: Vec<NodeMeta>,
-
-    /// Database storage root directory
-    ///
-    /// Default: `default_db_dir()` (/tmp/db)
-    #[serde(default = "default_db_dir")]
-    pub db_root_dir: PathBuf,
-
-    /// Log files output directory
-    ///
-    /// Default: `default_log_dir()` (./logs)
-    #[serde(default = "default_log_dir")]
-    pub log_dir: PathBuf,
 }
 impl Default for ClusterConfig {
     fn default() -> Self {
@@ -63,8 +55,6 @@ impl Default for ClusterConfig {
             node_id: default_node_id(),
             listen_address: default_listen_addr(),
             initial_cluster: default_initial_cluster(),
-            db_root_dir: default_db_dir(),
-            log_dir: default_log_dir(),
         }
     }
 }
@@ -108,24 +98,25 @@ impl ClusterConfig {
             }
         }
 
+        // Check unique listen addresses. Left unchecked, a copy-paste mistake across a
+        // multi-host deployment fails silently: each node binds its own address successfully,
+        // and the cluster just never elects a leader instead of erroring at startup.
+        let mut addresses = std::collections::HashSet::new();
+        for node in &self.initial_cluster {
+            if !addresses.insert(&node.address) {
+                return Err(Error::Config(ConfigError::Message(format!(
+                    "Duplicate listen_address {:?} in initial_cluster",
+                    node.address
+                ))));
+            }
+        }
+
         // Validate network configuration
         if self.listen_address.port() == 0 {
             return Err(Error::Config(ConfigError::Message(
                 "listen_address must specify a non-zero port".into(),
             )));
         }
-
-        // Warn if data path is under /tmp — caller's responsibility to choose a persistent path
-        if self.db_root_dir.starts_with("/tmp") {
-            warn!(
-                "db_root_dir {:?} is a temporary path — data will be lost on reboot. \
-                 Use a persistent path for production.",
-                self.db_root_dir
-            );
-        }
-
-        validate_directory(&self.db_root_dir, "db_root_dir")?;
-        validate_directory(&self.log_dir, "log_dir")?;
 
         Ok(())
     }
@@ -145,9 +136,44 @@ fn default_initial_cluster() -> Vec<NodeMeta> {
 fn default_listen_addr() -> SocketAddr {
     "127.0.0.1:9081".parse().unwrap()
 }
-fn default_db_dir() -> PathBuf {
-    PathBuf::from("/tmp/db")
+
+/// Accepts either the full `NodeMeta` shape (`{id, address, role, status}`)
+/// or the common shorthand (`{id, address}`) — `role`/`status` default to
+/// Follower/Active when omitted. Only this one field's deserialization is
+/// affected; `NodeMeta` itself is untouched (it's a proto wire type reused
+/// elsewhere — e.g. membership changes — where role/status are genuinely
+/// required, not defaultable).
+fn deserialize_initial_cluster<'de, D>(
+    deserializer: D
+) -> std::result::Result<Vec<NodeMeta>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    struct NodeMetaInput {
+        id: u32,
+        address: String,
+        #[serde(default = "default_role_i32")]
+        role: i32,
+        #[serde(default = "default_status_i32")]
+        status: i32,
+    }
+
+    let inputs = Vec::<NodeMetaInput>::deserialize(deserializer)?;
+    Ok(inputs
+        .into_iter()
+        .map(|n| NodeMeta {
+            id: n.id,
+            address: n.address,
+            role: n.role,
+            status: n.status,
+        })
+        .collect())
 }
-fn default_log_dir() -> PathBuf {
-    PathBuf::from("/tmp/logs")
+
+fn default_role_i32() -> i32 {
+    Follower as i32
+}
+fn default_status_i32() -> i32 {
+    NodeStatus::Active.into()
 }

--- a/d-engine-core/src/config/config_test.rs
+++ b/d-engine-core/src/config/config_test.rs
@@ -29,11 +29,17 @@ fn default_config_should_initialize_with_hardcoded_values() {
 #[serial]
 fn new_should_merge_environment_overrides() {
     cleanup_all_raft_env_vars();
-    with_vars(vec![("RAFT__NETWORK__BUFFER_SIZE", Some("1025"))], || {
-        let config = RaftNodeConfig::new().unwrap().validate().unwrap();
+    with_vars(
+        vec![
+            ("RAFT__NETWORK__BUFFER_SIZE", Some("1025")),
+            ("RAFT__CLUSTER__DATA_DIR", Some("test-data")),
+        ],
+        || {
+            let config = RaftNodeConfig::new().unwrap().validate().unwrap();
 
-        assert_eq!(config.network.buffer_size, 1025);
-    });
+            assert_eq!(config.network.buffer_size, 1025);
+        },
+    );
 }
 
 #[test]
@@ -48,9 +54,6 @@ fn with_override_config_should_merge_file_settings() {
     std::fs::write(
         &config_path,
         r#"
-        [cluster]
-        db_root_dir = "/tmp/xx/db" # Override default value
-
         [raft.election]
         election_timeout_min = 1000 # Override default value
         election_timeout_max = 3000 # Add new field
@@ -70,10 +73,6 @@ fn with_override_config_should_merge_file_settings() {
         assert!(result.is_ok());
         let config = result.unwrap();
 
-        assert_eq!(
-            config.cluster.db_root_dir.as_os_str().to_str(),
-            Some("/tmp/xx/db")
-        );
         assert_eq!(config.raft.election.election_timeout_min, 1000);
         assert_eq!(config.raft.election.election_timeout_max, 3000);
     });
@@ -107,6 +106,7 @@ fn environment_variables_should_have_highest_priority() {
         r#"
         [cluster]
         node_id = 100
+        data_dir = "test-data"
         initial_cluster = [
             { id = 100, name = "n1", address = "127.0.0.1:8081", role = 1, status = 1 },
             { id = 200, name = "n2", address = "127.0.0.1:9082", role = 1, status = 1 },
@@ -168,6 +168,8 @@ fn config_should_handle_nested_structures_correctly() {
     std::fs::write(
         &config_path,
         r#"
+        [cluster]
+        data_dir = "test-data"
         [retry.election]
         max_retries = 10
         [retry]
@@ -394,15 +396,13 @@ fn test_override_then_validate_succeeds() {
         r#"
 [cluster]
 node_id = 1
-db_root_dir = "{}/db"
 
 [[cluster.initial_cluster]]
 id = 1
 address = "127.0.0.1:9091"
 role = 3
 status = 3
-"#,
-        temp_dir.path().display()
+"#
     )
     .unwrap();
     drop(file);
@@ -434,15 +434,13 @@ fn test_config_path_env_loads_and_validates() {
         r#"
 [cluster]
 node_id = 99
-db_root_dir = "{}/db"
 
 [[cluster.initial_cluster]]
 id = 99
 address = "127.0.0.1:9091"
 role = 3
 status = 3
-"#,
-        temp_dir.path().display()
+"#
     )
     .unwrap();
     drop(file);
@@ -476,7 +474,6 @@ fn test_config_path_env_with_env_override() {
         r#"
 [cluster]
 node_id = 1
-db_root_dir = "{}/db"
 
 [[cluster.initial_cluster]]
 id = 1
@@ -489,8 +486,7 @@ id = 200
 address = "127.0.0.1:9092"
 role = 3
 status = 3
-"#,
-        temp_dir.path().display()
+"#
     )
     .unwrap();
     drop(file);
@@ -526,15 +522,13 @@ fn test_explicit_override_config_file() {
         r#"
 [cluster]
 node_id = 42
-db_root_dir = "{}/db"
 
 [[cluster.initial_cluster]]
 id = 42
 address = "127.0.0.1:9091"
 role = 3
 status = 3
-"#,
-        temp_dir.path().display()
+"#
     )
     .unwrap();
     drop(file);
@@ -555,13 +549,262 @@ status = 3
 
 #[test]
 fn test_validate_consumes_self_returns_self() {
-    let temp_dir = tempfile::tempdir().unwrap();
-    let mut cfg = RaftNodeConfig::new().unwrap();
-    cfg.cluster.db_root_dir = temp_dir.path().to_path_buf();
+    let cfg = RaftNodeConfig::new().unwrap();
 
     // validate() consumes cfg and returns Result<Self>
     let validated = cfg.validate().expect("Should validate");
 
     // Can use validated
     assert!(validated.cluster.node_id > 0);
+}
+
+// ============================================================================
+// initial_cluster: duplicate node_id / listen_address must be rejected
+// ============================================================================
+
+mod initial_cluster_duplicate_tests {
+    use d_engine_proto::common::NodeRole;
+    use d_engine_proto::common::NodeStatus;
+    use d_engine_proto::server::cluster::NodeMeta;
+
+    use super::*;
+
+    fn voter(
+        id: u32,
+        address: &str,
+    ) -> NodeMeta {
+        NodeMeta {
+            id,
+            address: address.to_string(),
+            role: NodeRole::Follower as i32,
+            status: NodeStatus::Active as i32,
+        }
+    }
+
+    fn base_config() -> RaftNodeConfig {
+        RaftNodeConfig::default()
+    }
+
+    /// Two nodes with the same id must be rejected — this check already existed but had no
+    /// dedicated test before this change.
+    #[test]
+    fn test_validate_rejects_duplicate_node_id() {
+        let mut cfg = base_config();
+        cfg.cluster.node_id = 1;
+        cfg.cluster.initial_cluster = vec![voter(1, "127.0.0.1:9081"), voter(1, "127.0.0.1:9082")];
+
+        let result = cfg.validate();
+
+        assert!(result.is_err(), "duplicate node_id must be rejected");
+    }
+
+    /// Two nodes sharing the same listen_address must be rejected. Left unchecked, this fails
+    /// silently in a real multi-host deployment: each node binds its own local address
+    /// successfully, and the cluster just never elects a leader — a much harder failure to
+    /// diagnose than a loud startup error.
+    #[test]
+    fn test_validate_rejects_duplicate_listen_address() {
+        let mut cfg = base_config();
+        cfg.cluster.node_id = 1;
+        cfg.cluster.initial_cluster = vec![
+            voter(1, "127.0.0.1:9081"),
+            voter(2, "127.0.0.1:9081"), // same address as node 1
+        ];
+
+        let result = cfg.validate();
+
+        assert!(result.is_err(), "duplicate listen_address must be rejected");
+    }
+
+    /// Distinct ids and addresses must still validate successfully — the happy path this
+    /// check must not break.
+    #[test]
+    fn test_validate_accepts_unique_node_id_and_listen_address() {
+        let mut cfg = base_config();
+        cfg.cluster.node_id = 1;
+        cfg.cluster.initial_cluster = vec![
+            voter(1, "127.0.0.1:9081"),
+            voter(2, "127.0.0.1:9082"),
+            voter(3, "127.0.0.1:9083"),
+        ];
+
+        let result = cfg.validate();
+
+        assert!(
+            result.is_ok(),
+            "unique id/address must pass validation: {:?}",
+            result.err()
+        );
+    }
+}
+
+// ============================================================================
+// initial_cluster: shorthand ({id, address}) deserialization
+// ============================================================================
+
+mod initial_cluster_shorthand_tests {
+    use d_engine_proto::common::NodeRole::Follower;
+    use d_engine_proto::common::NodeStatus;
+
+    use super::*;
+
+    /// Deserializes `initial_cluster_toml` (a bare TOML array literal, e.g.
+    /// `"[{ id = 1, address = \"a\" }]"`) through the real `config` crate
+    /// pipeline (file source, not a struct literal) — struct literals bypass
+    /// `deserialize_with` entirely, so this is the only way to actually
+    /// exercise the shorthand-parsing code path.
+    fn deserialize_cluster(
+        initial_cluster_toml: &str
+    ) -> std::result::Result<ClusterConfig, ConfigError> {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let config_path = temp_dir.path().join("cluster.toml");
+        std::fs::write(
+            &config_path,
+            format!("initial_cluster = {initial_cluster_toml}\n"),
+        )
+        .unwrap();
+
+        Config::builder()
+            .add_source(File::with_name(config_path.to_str().unwrap()))
+            .build()?
+            .try_deserialize::<ClusterConfig>()
+    }
+
+    #[test]
+    fn test_field_missing_uses_default_single_node_cluster() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let config_path = temp_dir.path().join("cluster.toml");
+        std::fs::write(&config_path, "node_id = 1\n").unwrap();
+
+        let cfg = Config::builder()
+            .add_source(File::with_name(config_path.to_str().unwrap()))
+            .build()
+            .unwrap()
+            .try_deserialize::<ClusterConfig>()
+            .expect("missing field falls back to default, not an error");
+
+        assert_eq!(cfg.initial_cluster.len(), 1);
+        assert_eq!(cfg.initial_cluster[0].id, 1);
+    }
+
+    #[test]
+    fn test_empty_array_deserializes_to_empty_vec() {
+        let cfg = deserialize_cluster("[]").expect("empty array is not a deserialize error");
+        assert!(cfg.initial_cluster.is_empty());
+    }
+
+    #[test]
+    fn test_single_shorthand_defaults_role_and_status() {
+        let cfg = deserialize_cluster(r#"[{ id = 1, address = "127.0.0.1:9081" }]"#).unwrap();
+
+        assert_eq!(cfg.initial_cluster.len(), 1);
+        assert_eq!(cfg.initial_cluster[0].id, 1);
+        assert_eq!(cfg.initial_cluster[0].address, "127.0.0.1:9081");
+        assert_eq!(cfg.initial_cluster[0].role, Follower as i32);
+        assert_eq!(cfg.initial_cluster[0].status, NodeStatus::Active as i32);
+    }
+
+    #[test]
+    fn test_single_full_form_keeps_explicit_role_and_status() {
+        let cfg = deserialize_cluster(
+            r#"[{ id = 1, address = "127.0.0.1:9081", role = 2, status = 1 }]"#,
+        )
+        .unwrap();
+
+        assert_eq!(cfg.initial_cluster[0].role, 2);
+        assert_eq!(cfg.initial_cluster[0].status, 1);
+    }
+
+    #[test]
+    fn test_mixed_shorthand_and_full_form_in_same_array() {
+        let cfg = deserialize_cluster(
+            r#"[
+                { id = 1, address = "127.0.0.1:9081" },
+                { id = 2, address = "127.0.0.1:9082", role = 2, status = 1 }
+            ]"#,
+        )
+        .unwrap();
+
+        assert_eq!(cfg.initial_cluster.len(), 2);
+        assert_eq!(
+            cfg.initial_cluster[0].role, Follower as i32,
+            "element 1: shorthand defaults"
+        );
+        assert_eq!(cfg.initial_cluster[0].status, NodeStatus::Active as i32);
+        assert_eq!(
+            cfg.initial_cluster[1].role, 2,
+            "element 2: full form keeps explicit value"
+        );
+        assert_eq!(cfg.initial_cluster[1].status, 1);
+    }
+
+    #[test]
+    fn test_missing_id_is_a_deserialize_error() {
+        let result = deserialize_cluster(r#"[{ address = "127.0.0.1:9081" }]"#);
+        assert!(result.is_err(), "id has no default — must be required");
+    }
+
+    #[test]
+    fn test_missing_address_is_a_deserialize_error() {
+        let result = deserialize_cluster(r#"[{ id = 1 }]"#);
+        assert!(result.is_err(), "address has no default — must be required");
+    }
+
+    #[test]
+    fn test_invalid_role_type_is_a_deserialize_error() {
+        let result = deserialize_cluster(
+            r#"[{ id = 1, address = "127.0.0.1:9081", role = "not-a-number" }]"#,
+        );
+        assert!(result.is_err(), "role must be an integer, not a string");
+    }
+
+    #[test]
+    fn test_invalid_status_type_is_a_deserialize_error() {
+        let result = deserialize_cluster(
+            r#"[{ id = 1, address = "127.0.0.1:9081", status = "not-a-number" }]"#,
+        );
+        assert!(result.is_err(), "status must be an integer, not a string");
+    }
+
+    /// `#[serde(default = ...)]` only applies when the key is absent. An
+    /// explicit `null` for a non-`Option` field is still a type error — this
+    /// is a real serde subtlety (flagged during review), worth pinning down
+    /// with a test rather than assuming.
+    #[test]
+    fn test_explicit_null_role_is_a_deserialize_error_not_default() {
+        let result =
+            deserialize_cluster(r#"[{ id = 1, address = "127.0.0.1:9081", role = null }]"#);
+        assert!(
+            result.is_err(),
+            "explicit null must not silently become the default"
+        );
+    }
+
+    #[test]
+    fn test_explicit_null_status_is_a_deserialize_error_not_default() {
+        let result =
+            deserialize_cluster(r#"[{ id = 1, address = "127.0.0.1:9081", status = null }]"#);
+        assert!(
+            result.is_err(),
+            "explicit null must not silently become the default"
+        );
+    }
+
+    #[test]
+    fn test_full_form_missing_only_role_defaults_role_keeps_status() {
+        let cfg =
+            deserialize_cluster(r#"[{ id = 1, address = "127.0.0.1:9081", status = 1 }]"#).unwrap();
+
+        assert_eq!(cfg.initial_cluster[0].role, Follower as i32);
+        assert_eq!(cfg.initial_cluster[0].status, 1);
+    }
+
+    #[test]
+    fn test_full_form_missing_only_status_defaults_status_keeps_role() {
+        let cfg =
+            deserialize_cluster(r#"[{ id = 1, address = "127.0.0.1:9081", role = 2 }]"#).unwrap();
+
+        assert_eq!(cfg.initial_cluster[0].role, 2);
+        assert_eq!(cfg.initial_cluster[0].status, NodeStatus::Active as i32);
+    }
 }

--- a/d-engine-core/src/config/config_test.rs
+++ b/d-engine-core/src/config/config_test.rs
@@ -1,4 +1,5 @@
 use super::*;
+use config::ConfigError;
 use serial_test::serial;
 use std::io::Write;
 use temp_env::with_vars;

--- a/d-engine-core/src/config/mod.rs
+++ b/d-engine-core/src/config/mod.rs
@@ -212,7 +212,7 @@ impl RaftNodeConfig {
 }
 
 /// Ensures directory path is valid and writable
-pub(super) fn validate_directory(
+pub fn validate_directory(
     path: &Path,
     name: &str,
 ) -> Result<()> {

--- a/d-engine-core/src/config/mod.rs
+++ b/d-engine-core/src/config/mod.rs
@@ -6,8 +6,6 @@
 //! - Configuration file support
 //! - Component-wise validation
 mod cluster;
-use std::fmt::Debug;
-use std::path::Path;
 mod lease;
 mod network;
 mod raft;
@@ -15,7 +13,6 @@ mod retry;
 mod storage;
 mod tls;
 pub use cluster::*;
-use config::ConfigError;
 pub use lease::*;
 pub use network::*;
 pub use raft::*;
@@ -32,16 +29,15 @@ mod network_test;
 mod raft_test;
 #[cfg(test)]
 mod tls_test;
-use std::env;
 
+use crate::Result;
 use config::Config;
 use config::Environment;
 use config::File;
 use serde::Deserialize;
 use serde::Serialize;
-
-use crate::Error;
-use crate::Result;
+use std::env;
+use std::fmt::Debug;
 
 /// Main configuration container for Raft consensus engine components
 ///
@@ -209,46 +205,4 @@ impl RaftNodeConfig {
             .map(|n| n.role == NodeRole::Learner as i32)
             .unwrap_or(false)
     }
-}
-
-/// Ensures directory path is valid and writable
-pub fn validate_directory(
-    path: &Path,
-    name: &str,
-) -> Result<()> {
-    if path.as_os_str().is_empty() {
-        return Err(Error::Config(ConfigError::Message(format!(
-            "{name} path cannot be empty"
-        ))));
-    }
-
-    #[cfg(not(test))]
-    {
-        use std::fs;
-        // Check directory existence or create ability
-        if !path.exists() {
-            fs::create_dir_all(path).map_err(|e| {
-                Error::Config(ConfigError::Message(format!(
-                    "Failed to create {} directory at {}: {}",
-                    name,
-                    path.display(),
-                    e
-                )))
-            })?;
-        }
-
-        // Check write permissions
-        let test_file = path.join(".permission_test");
-        fs::write(&test_file, b"test").map_err(|e| {
-            Error::Config(ConfigError::Message(format!(
-                "No write permission in {} directory {}: {}",
-                name,
-                path.display(),
-                e
-            )))
-        })?;
-        fs::remove_file(&test_file).ok();
-    }
-
-    Ok(())
 }

--- a/d-engine-core/src/config/raft.rs
+++ b/d-engine-core/src/config/raft.rs
@@ -1,5 +1,4 @@
 use std::fmt::Debug;
-use std::path::PathBuf;
 use std::time::Duration;
 
 use config::ConfigError;
@@ -8,7 +7,6 @@ use serde::Serialize;
 use tracing::warn;
 
 use super::lease::LeaseConfig;
-use super::validate_directory;
 use crate::Error;
 use crate::Result;
 
@@ -153,8 +151,8 @@ impl Default for RaftConfig {
     }
 }
 impl RaftConfig {
-    /// Validates all Raft subsystem configurations
-    pub fn validate(&self) -> Result<()> {
+    /// Validates all Raft subsystem configurations.
+    pub(crate) fn validate(&self) -> Result<()> {
         if self.learner_catchup_threshold == 0 {
             return Err(Error::Config(ConfigError::Message(
                 "learner_catchup_threshold must be greater than 0".into(),
@@ -539,12 +537,6 @@ pub struct SnapshotConfig {
     #[serde(default = "default_cleanup_retain_count")]
     pub cleanup_retain_count: u64,
 
-    /// Snapshot storage directory
-    ///
-    /// Default: `default_snapshots_dir()` (/tmp/snapshots)
-    #[serde(default = "default_snapshots_dir")]
-    pub snapshots_dir: PathBuf,
-
     #[serde(default = "default_snapshots_dir_prefix")]
     pub snapshots_dir_prefix: String,
 
@@ -606,7 +598,6 @@ impl Default for SnapshotConfig {
             max_log_entries_before_snapshot: default_max_log_entries_before_snapshot(),
             snapshot_cool_down_since_last_check: default_snapshot_cool_down_since_last_check(),
             cleanup_retain_count: default_cleanup_retain_count(),
-            snapshots_dir: default_snapshots_dir(),
             snapshots_dir_prefix: default_snapshots_dir_prefix(),
             chunk_size: default_chunk_size(),
             retained_log_entries: default_retained_log_entries(),
@@ -639,9 +630,6 @@ impl SnapshotConfig {
                 "cleanup_retain_count must be greater than 0".into(),
             )));
         }
-        // Validate storage paths
-        validate_directory(&self.snapshots_dir, "snapshots_dir")?;
-
         // chunk_size should be > 0
         if self.chunk_size == 0 {
             return Err(Error::Config(ConfigError::Message(format!(
@@ -715,10 +703,6 @@ fn default_snapshot_cool_down_since_last_check() -> Duration {
 /// Default number of historical snapshots to retain
 fn default_cleanup_retain_count() -> u64 {
     2
-}
-/// Default snapshots storage path
-fn default_snapshots_dir() -> PathBuf {
-    PathBuf::from("/tmp/snapshots")
 }
 /// Default snapshots directory prefix
 fn default_snapshots_dir_prefix() -> String {

--- a/d-engine-core/src/election/election_handler_test.rs
+++ b/d-engine-core/src/election/election_handler_test.rs
@@ -773,9 +773,8 @@ mod single_node_election_tests {
         membership.expect_is_single_node_cluster().returning(|| false);
 
         // Create minimal node_config with TempDir (no file system pollution)
-        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let mut node_config = RaftNodeConfig::new().expect("Should create default config");
-        node_config.cluster.db_root_dir = temp_dir.path().to_path_buf();
+        let _temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let node_config = RaftNodeConfig::new().expect("Should create default config");
         let node_config = node_config.validate().expect("Should validate config");
 
         // Act
@@ -859,9 +858,8 @@ mod single_node_election_tests {
             }]
         });
 
-        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let mut node_config = RaftNodeConfig::new().expect("Should create default config");
-        node_config.cluster.db_root_dir = temp_dir.path().to_path_buf();
+        let _temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let node_config = RaftNodeConfig::new().expect("Should create default config");
         let node_config = node_config.validate().expect("Should validate config");
 
         let e = election_handler
@@ -952,9 +950,8 @@ mod single_node_election_tests {
         });
 
         // Create minimal node_config with TempDir
-        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let mut node_config = RaftNodeConfig::new().expect("Should create default config");
-        node_config.cluster.db_root_dir = temp_dir.path().to_path_buf();
+        let _temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let node_config = RaftNodeConfig::new().expect("Should create default config");
         let node_config = node_config.validate().expect("Should validate config");
 
         // Execute
@@ -1026,9 +1023,8 @@ mod single_node_election_tests {
             }]
         });
 
-        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let mut node_config = RaftNodeConfig::new().expect("Should create default config");
-        node_config.cluster.db_root_dir = temp_dir.path().to_path_buf();
+        let _temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let node_config = RaftNodeConfig::new().expect("Should create default config");
         let node_config = node_config.validate().expect("Should validate config");
 
         let e = election_handler
@@ -1105,9 +1101,8 @@ mod single_node_election_tests {
             }]
         });
 
-        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let mut node_config = RaftNodeConfig::new().expect("Should create default config");
-        node_config.cluster.db_root_dir = temp_dir.path().to_path_buf();
+        let _temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let node_config = RaftNodeConfig::new().expect("Should create default config");
         let node_config = node_config.validate().expect("Should validate config");
 
         let e = election_handler
@@ -1190,9 +1185,8 @@ mod single_node_election_tests {
             }]
         });
 
-        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let mut node_config = RaftNodeConfig::new().expect("Should create default config");
-        node_config.cluster.db_root_dir = temp_dir.path().to_path_buf();
+        let _temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let node_config = RaftNodeConfig::new().expect("Should create default config");
         let node_config = node_config.validate().expect("Should validate config");
 
         let e = election_handler
@@ -1385,9 +1379,8 @@ mod single_node_election_tests {
     #[tokio::test]
     async fn test_check_vote_request_is_legal_rejects_when_current_term_not_lower() {
         // TODO: Simplify to just `let election_handler = ElectionHandler::<MockTypeConfig>::new(1);`
-        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let mut node_config = RaftNodeConfig::new().expect("Should create default config");
-        node_config.cluster.db_root_dir = temp_dir.path().to_path_buf();
+        let _temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let node_config = RaftNodeConfig::new().expect("Should create default config");
         let _node_config = node_config.validate().expect("Should validate config");
         let election_handler = ElectionHandler::<MockTypeConfig>::new(1);
 
@@ -1455,9 +1448,8 @@ mod single_node_election_tests {
     /// `d-engine-server/tests/components/election/election_handler_test.rs::test_check_vote_request_is_legal_case_1_2`
     #[tokio::test]
     async fn test_check_vote_request_is_legal_rejects_when_request_log_not_more_recent() {
-        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let mut node_config = RaftNodeConfig::new().expect("Should create default config");
-        node_config.cluster.db_root_dir = temp_dir.path().to_path_buf();
+        let _temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let node_config = RaftNodeConfig::new().expect("Should create default config");
         let _node_config = node_config.validate().expect("Should validate config");
         let election_handler = ElectionHandler::<MockTypeConfig>::new(1);
 
@@ -1525,9 +1517,8 @@ mod single_node_election_tests {
     /// `d-engine-server/tests/components/election/election_handler_test.rs::test_check_vote_request_is_legal_case_1_3`
     #[tokio::test]
     async fn test_check_vote_request_is_legal_accepts_when_request_log_more_recent() {
-        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let mut node_config = RaftNodeConfig::new().expect("Should create default config");
-        node_config.cluster.db_root_dir = temp_dir.path().to_path_buf();
+        let _temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let node_config = RaftNodeConfig::new().expect("Should create default config");
         let _node_config = node_config.validate().expect("Should validate config");
         let election_handler = ElectionHandler::<MockTypeConfig>::new(1);
 
@@ -1572,9 +1563,8 @@ mod single_node_election_tests {
     /// `d-engine-server/tests/components/election/election_handler_test.rs::test_check_vote_request_is_legal_case_1_4`
     #[tokio::test]
     async fn test_check_vote_request_is_legal_rejects_when_local_log_more_recent() {
-        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let mut node_config = RaftNodeConfig::new().expect("Should create default config");
-        node_config.cluster.db_root_dir = temp_dir.path().to_path_buf();
+        let _temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let node_config = RaftNodeConfig::new().expect("Should create default config");
         let _node_config = node_config.validate().expect("Should validate config");
         let election_handler = ElectionHandler::<MockTypeConfig>::new(1);
 
@@ -1626,9 +1616,8 @@ mod single_node_election_tests {
     /// `d-engine-server/tests/components/election/election_handler_test.rs::test_check_vote_request_is_legal_case_2_1`
     #[tokio::test]
     async fn test_check_vote_request_is_legal_rejects_when_already_voted_for_different_candidate() {
-        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let mut node_config = RaftNodeConfig::new().expect("Should create default config");
-        node_config.cluster.db_root_dir = temp_dir.path().to_path_buf();
+        let _temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let node_config = RaftNodeConfig::new().expect("Should create default config");
         let _node_config = node_config.validate().expect("Should validate config");
         let election_handler = ElectionHandler::<MockTypeConfig>::new(1);
 
@@ -1679,9 +1668,8 @@ mod single_node_election_tests {
     /// `d-engine-server/tests/components/election/election_handler_test.rs::test_check_vote_request_is_legal_case_2_2`
     #[tokio::test]
     async fn test_check_vote_request_is_legal_rejects_when_voted_in_higher_term() {
-        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let mut node_config = RaftNodeConfig::new().expect("Should create default config");
-        node_config.cluster.db_root_dir = temp_dir.path().to_path_buf();
+        let _temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let node_config = RaftNodeConfig::new().expect("Should create default config");
         let _node_config = node_config.validate().expect("Should validate config");
         let election_handler = ElectionHandler::<MockTypeConfig>::new(1);
 
@@ -1735,9 +1723,8 @@ mod single_node_election_tests {
     /// `d-engine-server/tests/components/election/election_handler_test.rs::test_check_vote_request_is_legal_case_2_3`
     #[tokio::test]
     async fn test_check_vote_request_is_legal_accepts_revote_for_same_candidate_new_term() {
-        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let mut node_config = RaftNodeConfig::new().expect("Should create default config");
-        node_config.cluster.db_root_dir = temp_dir.path().to_path_buf();
+        let _temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let node_config = RaftNodeConfig::new().expect("Should create default config");
         let _node_config = node_config.validate().expect("Should validate config");
         let election_handler = ElectionHandler::<MockTypeConfig>::new(1);
 

--- a/d-engine-core/src/errors.rs
+++ b/d-engine-core/src/errors.rs
@@ -359,6 +359,14 @@ pub enum SystemError {
     #[error("Node failed to start: {0}")]
     NodeStartFailed(String),
 
+    /// A directory under `data_dir` can't be created or written to (wrong
+    /// permissions, or a regular file where a directory is expected) —
+    /// distinct from [`SystemError::NodeStartFailed`]'s "another process
+    /// already holds this data_dir" so callers can tell a permanent
+    /// misconfiguration apart from a transient lock conflict.
+    #[error("Invalid data directory: {0}")]
+    DataDirInvalid(String),
+
     #[error("General server error: {0}")]
     GeneralServer(String),
 

--- a/d-engine-core/src/raft_role/candidate_state_test.rs
+++ b/d-engine-core/src/raft_role/candidate_state_test.rs
@@ -63,9 +63,8 @@ use tokio::sync::{mpsc, watch};
 #[tokio::test]
 async fn test_can_vote_myself_returns_true_for_new_candidate() {
     // Create minimal node_config with TempDir
-    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-    let mut node_config = crate::RaftNodeConfig::new().expect("Should create default config");
-    node_config.cluster.db_root_dir = temp_dir.path().to_path_buf();
+    let _temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let node_config = crate::RaftNodeConfig::new().expect("Should create default config");
     let node_config = node_config.validate().expect("Should validate config");
 
     // Create new CandidateState (has not voted yet)
@@ -98,9 +97,8 @@ async fn test_can_vote_myself_returns_true_for_new_candidate() {
 #[tokio::test]
 async fn test_can_vote_myself_returns_false_after_voting() {
     // Create minimal node_config with TempDir
-    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-    let mut node_config = crate::RaftNodeConfig::new().expect("Should create default config");
-    node_config.cluster.db_root_dir = temp_dir.path().to_path_buf();
+    let _temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let node_config = crate::RaftNodeConfig::new().expect("Should create default config");
     let node_config = node_config.validate().expect("Should validate config");
 
     // Create new CandidateState

--- a/d-engine-core/src/raft_role/raft_role_test.rs
+++ b/d-engine-core/src/raft_role/raft_role_test.rs
@@ -702,12 +702,8 @@ fn test_update_voted_for_learner_discovers_leader() {
 // ============================================================================
 
 fn make_test_config() -> Arc<RaftNodeConfig> {
-    Arc::new(
-        RaftNodeConfig::new()
-            .expect("RaftNodeConfig::new")
-            .validate()
-            .expect("RaftNodeConfig::validate"),
-    )
+    let cfg = RaftNodeConfig::new().expect("RaftNodeConfig::new");
+    Arc::new(cfg.validate().expect("RaftNodeConfig::validate"))
 }
 
 fn make_test_context() -> (RaftContext<MockTypeConfig>, watch::Sender<()>) {

--- a/d-engine-core/src/state_machine_handler/default_state_machine_handler.rs
+++ b/d-engine-core/src/state_machine_handler/default_state_machine_handler.rs
@@ -92,6 +92,10 @@ where
 
     // current_snapshot_version: AtomicU64,
     snapshot_config: SnapshotConfig,
+    /// Explicit runtime path — always `data_dir/snapshots` (see #10). Not
+    /// part of `snapshot_config`; `snapshots_dir` is a runtime identity, not
+    /// a configurable setting.
+    snapshots_dir: PathBuf,
     snapshot_policy: SNP<T>,
     snapshot_in_progress: AtomicBool,
 
@@ -410,21 +414,42 @@ where
 
         let temp_path = self.path_mgr.temp_work_path(&last_included);
 
+        // A crashed/killed previous attempt at this exact index can leave temp_path behind;
+        // without removing it first, generate_snapshot_data fails with "File exists" forever.
+        if let Err(e) = remove_dir_all(&temp_path).await
+            && e.kind() != std::io::ErrorKind::NotFound
+        {
+            return Err(SnapshotError::OperationFailed(format!(
+                "Failed to remove stale temp directory: {e}"
+            ))
+            .into());
+        }
+
         // 3: Create snapshot based on the temp path
         debug!(
             ?temp_path,
             ?last_included,
             "create_snapshot 3: Create snapshot based on the temp path"
         );
-        let checksum_bytes = self
+        let checksum_bytes = match self
             .state_machine
             .generate_snapshot_data(temp_path.clone(), last_included)
-            .await?;
+            .await
+        {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                let _ = remove_dir_all(&temp_path).await;
+                return Err(e);
+            }
+        };
 
         // 4: Compress the snapshot directory into a tar.gz archive
         debug!("create_snapshot 4: Compressing snapshot directory");
         let final_path = self.path_mgr.final_snapshot_path(&last_included);
-        self.compress_directory(&temp_path, &final_path).await?;
+        if let Err(e) = self.compress_directory(&temp_path, &final_path).await {
+            let _ = remove_dir_all(&temp_path).await;
+            return Err(e);
+        }
 
         // 6. Remove the original uncompressed directory
         remove_dir_all(&temp_path).await.map_err(|e| {
@@ -436,7 +461,7 @@ where
         if let Err(e) = self
             .cleanup_snapshot(
                 self.snapshot_config.cleanup_retain_count,
-                &self.snapshot_config.snapshots_dir,
+                &self.snapshots_dir,
                 &self.snapshot_config.snapshots_dir_prefix,
             )
             .await
@@ -792,6 +817,7 @@ where
         node_id: u32,
         last_applied_index: u64,
         state_machine: Arc<SMOF<T>>,
+        snapshots_dir: PathBuf,
         snapshot_config: SnapshotConfig,
         snapshot_policy: SNP<T>,
         #[cfg_attr(not(feature = "watch"), allow(unused_variables))] watch_event_tx: Option<
@@ -811,9 +837,10 @@ where
             state_machine,
             snapshot_policy,
             path_mgr: Arc::new(SnapshotPathManager::new(
-                snapshot_config.snapshots_dir.clone(),
+                snapshots_dir.clone(),
                 snapshot_config.snapshots_dir_prefix.clone(),
             )),
+            snapshots_dir,
             snapshot_config,
 
             snapshot_lock: RwLock::new(()),
@@ -833,6 +860,7 @@ where
         node_id: u32,
         last_applied_index: u64,
         state_machine: Arc<SMOF<T>>,
+        snapshots_dir: PathBuf,
         snapshot_config: SnapshotConfig,
         snapshot_policy: SNP<T>,
     ) -> Self {
@@ -840,6 +868,7 @@ where
             node_id,
             last_applied_index,
             state_machine,
+            snapshots_dir,
             snapshot_config,
             snapshot_policy,
             None,

--- a/d-engine-core/src/state_machine_handler/default_state_machine_handler_test.rs
+++ b/d-engine-core/src/state_machine_handler/default_state_machine_handler_test.rs
@@ -79,6 +79,7 @@ fn test_update_pending_case1() {
         1,
         0,
         Arc::new(state_machine_mock),
+        PathBuf::from("/tmp/test_update_pending_case1"),
         snapshot_config(PathBuf::from("/tmp/test_update_pending_case1")),
         MockSnapshotPolicy::new(),
     );
@@ -97,6 +98,7 @@ fn test_update_pending_case2() {
         1,
         0,
         Arc::new(state_machine_mock),
+        PathBuf::from("/tmp/test_update_pending_case2"),
         snapshot_config(PathBuf::from("/tmp/test_update_pending_case2")),
         MockSnapshotPolicy::new(),
     );
@@ -117,6 +119,7 @@ async fn test_update_pending_case3() {
             1,
             0,
             Arc::new(state_machine_mock),
+            PathBuf::from("/tmp/test_update_pending_case3"),
             snapshot_config(PathBuf::from("/tmp/test_update_pending_case3")),
             MockSnapshotPolicy::new(),
         ),
@@ -142,6 +145,7 @@ fn test_pending_range_case1() {
         1,
         10,
         Arc::new(state_machine_mock),
+        PathBuf::from("/tmp/test_pending_range_case1"),
         snapshot_config(PathBuf::from("/tmp/test_pending_range_case1")),
         MockSnapshotPolicy::new(),
     );
@@ -157,6 +161,7 @@ fn test_pending_range_case2() {
         1,
         10,
         Arc::new(state_machine_mock),
+        PathBuf::from("/tmp/test_pending_range_case2"),
         snapshot_config(PathBuf::from("/tmp/test_pending_range_case2")),
         MockSnapshotPolicy::new(),
     );
@@ -174,6 +179,7 @@ fn test_pending_range_case3() {
         1,
         10,
         Arc::new(state_machine_mock),
+        PathBuf::from("/tmp/test_pending_range_case3"),
         snapshot_config(PathBuf::from("/tmp/test_pending_range_case3")),
         MockSnapshotPolicy::new(),
     );
@@ -215,6 +221,7 @@ mod apply_chunk_test {
             1,
             last_applied_index.unwrap_or(0),
             Arc::new(state_machine),
+            PathBuf::from(path),
             snapshot_config(PathBuf::from(path)),
             MockSnapshotPolicy::new(),
         )
@@ -330,6 +337,7 @@ mod apply_chunk_test {
             1,
             0,
             Arc::new(sm),
+            PathBuf::from("/tmp/test_batch_failure_atomic"),
             snapshot_config(PathBuf::from("/tmp/test_batch_failure_atomic")),
             MockSnapshotPolicy::new(),
             Some(watch_tx),
@@ -434,6 +442,7 @@ mod decode_boundary_tests {
             1,
             0,
             Arc::new(sm),
+            std::path::PathBuf::from("/tmp/test_decode_insert_boundary"),
             snapshot_config(std::path::PathBuf::from("/tmp/test_decode_insert_boundary")),
             MockSnapshotPolicy::new(),
         );
@@ -455,6 +464,7 @@ mod decode_boundary_tests {
             1,
             0,
             Arc::new(sm),
+            std::path::PathBuf::from("/tmp/test_decode_noop_boundary"),
             snapshot_config(std::path::PathBuf::from("/tmp/test_decode_noop_boundary")),
             MockSnapshotPolicy::new(),
         );
@@ -477,6 +487,7 @@ mod decode_boundary_tests {
             1,
             0,
             Arc::new(sm),
+            std::path::PathBuf::from("/tmp/test_decode_config_boundary"),
             snapshot_config(std::path::PathBuf::from("/tmp/test_decode_config_boundary")),
             MockSnapshotPolicy::new(),
         );
@@ -504,6 +515,7 @@ mod decode_boundary_tests {
             1,
             0,
             Arc::new(sm),
+            std::path::PathBuf::from("/tmp/test_decode_mixed_boundary"),
             snapshot_config(std::path::PathBuf::from("/tmp/test_decode_mixed_boundary")),
             MockSnapshotPolicy::new(),
         );
@@ -542,6 +554,7 @@ mod decode_boundary_tests {
             1,
             0,
             Arc::new(sm),
+            std::path::PathBuf::from("/tmp/test_handler_decodes_batch_before_sm_receives_it"),
             snapshot_config(std::path::PathBuf::from(
                 "/tmp/test_handler_decodes_batch_before_sm_receives_it",
             )),
@@ -637,6 +650,7 @@ fn create_test_handler(
         1,
         0,
         Arc::new(state_machine),
+        temp_dir.to_path_buf(),
         config,
         MockSnapshotPolicy::new(),
     )
@@ -658,6 +672,7 @@ async fn test_apply_snapshot_stream_from_leader_case2() {
         1,
         10,
         Arc::new(state_machine_mock),
+        temp_path.to_path_buf(),
         snapshot_config(temp_path.to_path_buf()),
         MockSnapshotPolicy::new(),
     );
@@ -883,6 +898,7 @@ async fn test_apply_snapshot_stream_from_leader_case7() {
         1,
         10,
         Arc::new(state_machine_mock),
+        temp_path.to_path_buf(),
         snapshot_config(temp_path.to_path_buf()),
         MockSnapshotPolicy::new(),
     );
@@ -983,6 +999,7 @@ mod create_snapshot_tests {
             1,
             0,
             Arc::new(sm),
+            temp_path.to_path_buf(),
             config.clone(),
             MockSnapshotPolicy::new(),
         );
@@ -1057,6 +1074,7 @@ mod create_snapshot_tests {
                 1,
                 0,
                 Arc::new(sm),
+                temp_path.to_path_buf(),
                 config.clone(),
                 snapshot_policy,
             ),
@@ -1130,6 +1148,7 @@ mod create_snapshot_tests {
             1,
             3, // Current version
             Arc::new(sm),
+            snapshot_dir.clone(),
             config.clone(),
             MockSnapshotPolicy::new(),
         );
@@ -1172,6 +1191,7 @@ mod create_snapshot_tests {
             1,
             0,
             Arc::new(sm),
+            temp_path.to_path_buf(),
             config.clone(),
             MockSnapshotPolicy::new(),
         );
@@ -1197,12 +1217,13 @@ mod create_snapshot_tests {
             Ok(Bytes::from(vec![0; 32]))
         });
 
-        let config = snapshot_config(temp_path);
+        let config = snapshot_config(temp_path.clone());
         let handler = Arc::new(
             DefaultStateMachineHandler::<MockTypeConfig>::new_without_watch(
                 1,
                 0,
                 Arc::new(sm),
+                temp_path.clone(),
                 config,
                 MockSnapshotPolicy::new(),
             ),
@@ -1230,12 +1251,13 @@ mod create_snapshot_tests {
         sm.expect_generate_snapshot_data()
             .returning(|_, _| Err(SnapshotError::OperationFailed("test error".into()).into()));
 
-        let config = snapshot_config(temp_path);
+        let config = snapshot_config(temp_path.clone());
         let handler = Arc::new(
             DefaultStateMachineHandler::<MockTypeConfig>::new_without_watch(
                 1,
                 0,
                 Arc::new(sm),
+                temp_path.clone(),
                 config,
                 MockSnapshotPolicy::new(),
             ),
@@ -1293,7 +1315,7 @@ mod create_snapshot_tests {
                 Ok(Bytes::from(vec![0; 32]))
             });
 
-        let mut config = snapshot_config(temp_path);
+        let mut config = snapshot_config(temp_path.clone());
         config.retained_log_entries = 10;
 
         let handler = Arc::new(
@@ -1301,6 +1323,7 @@ mod create_snapshot_tests {
                 1,
                 0,
                 Arc::new(sm),
+                temp_path.clone(),
                 config,
                 MockSnapshotPolicy::new(),
             ),
@@ -1375,6 +1398,7 @@ mod create_snapshot_tests {
             1,
             0,
             Arc::new(sm),
+            temp_path.to_path_buf(),
             config,
             MockSnapshotPolicy::new(),
         );
@@ -1429,6 +1453,7 @@ mod create_snapshot_tests {
             1,
             0,
             Arc::new(sm),
+            temp_path.to_path_buf(),
             config,
             MockSnapshotPolicy::new(),
         );
@@ -1437,6 +1462,72 @@ mod create_snapshot_tests {
         assert!(result.is_ok());
         let (metadata, _) = result.unwrap();
         assert_eq!(metadata.last_included, Some(LogId { term: 0, index: 0 }));
+    }
+
+    /// A crash mid-checkpoint must not leave the temp dir behind after create_snapshot() returns Err.
+    #[tokio::test]
+    async fn test_create_snapshot_removes_temp_dir_on_generate_failure() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let snapshot_dir = temp_dir.path().join("snapshots");
+        let mut sm = MockStateMachine::new();
+
+        sm.expect_last_applied().returning(|| LogId { term: 1, index: 5 });
+        sm.expect_generate_snapshot_data().returning(|path, _| {
+            // Simulate a partial write before the failure (e.g. checkpoint killed mid-copy).
+            fs::create_dir_all(&path).unwrap();
+            Err(SnapshotError::OperationFailed("simulated crash".into()).into())
+        });
+
+        let config = snapshot_config(snapshot_dir.clone());
+        let handler = DefaultStateMachineHandler::<MockTypeConfig>::new_without_watch(
+            1,
+            0,
+            Arc::new(sm),
+            snapshot_dir.clone(),
+            config,
+            MockSnapshotPolicy::new(),
+        );
+
+        assert!(handler.create_snapshot().await.is_err());
+        assert!(
+            !snapshot_dir.join("temp-5-1").exists(),
+            "orphaned temp dir was not cleaned up"
+        );
+    }
+
+    /// A stale temp dir left by a previous crash must not block the next snapshot at the same index.
+    #[tokio::test]
+    async fn test_create_snapshot_succeeds_despite_stale_temp_dir() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let snapshot_dir = temp_dir.path().join("snapshots");
+        let stale_temp_path = snapshot_dir.join("temp-5-1");
+        fs::create_dir_all(stale_temp_path.join("sm.tmp")).unwrap();
+
+        let mut sm = MockStateMachine::new();
+        sm.expect_last_applied().returning(|| LogId { term: 1, index: 5 });
+        sm.expect_generate_snapshot_data().returning(|path, _| {
+            // Real engines (e.g. RocksDB checkpoint) fail with "File exists" if `path`
+            // is already present — mirror that here instead of using the idempotent
+            // `create_dir_all`, otherwise this test can't distinguish "cleaned up" from
+            // "never checked".
+            if path.exists() {
+                return Err(SnapshotError::OperationFailed("mkdir: File exists".into()).into());
+            }
+            fs::create_dir_all(&path).unwrap();
+            Ok(Bytes::from(vec![0; 32]))
+        });
+
+        let config = snapshot_config(snapshot_dir.clone());
+        let handler = DefaultStateMachineHandler::<MockTypeConfig>::new_without_watch(
+            1,
+            0,
+            Arc::new(sm),
+            snapshot_dir.clone(),
+            config,
+            MockSnapshotPolicy::new(),
+        );
+
+        assert!(handler.create_snapshot().await.is_ok());
     }
 }
 
@@ -1503,6 +1594,7 @@ async fn test_cleanup_snapshot_case1() {
         1,
         0,
         Arc::new(sm),
+        temp_dir.path().to_path_buf(),
         config.clone(),
         MockSnapshotPolicy::new(),
     );
@@ -1542,6 +1634,7 @@ async fn test_cleanup_snapshot_case2() {
         1,
         0,
         Arc::new(sm),
+        temp_dir.path().to_path_buf(),
         config.clone(),
         MockSnapshotPolicy::new(),
     );
@@ -1579,6 +1672,7 @@ async fn test_cleanup_snapshot_case3() {
         1,
         0,
         Arc::new(sm),
+        temp_dir.path().to_path_buf(),
         config.clone(),
         MockSnapshotPolicy::new(),
     );
@@ -1948,6 +2042,7 @@ async fn test_snapshot_compression() {
         1,
         0,
         Arc::new(sm),
+        temp_path.to_path_buf(),
         config,
         MockSnapshotPolicy::new(),
     );
@@ -1992,6 +2087,7 @@ async fn test_apply_snapshot_stream_from_leader_decompresses_before_apply() {
         1,
         10,
         Arc::new(state_machine_mock),
+        temp_path.to_path_buf(),
         snapshot_config(temp_path.to_path_buf()),
         MockSnapshotPolicy::new(),
     );
@@ -2606,6 +2702,7 @@ mod prev_kv_apply_tests {
             1,
             0,
             Arc::new(sm),
+            std::path::PathBuf::from("/tmp/test_skip_get_when_no_prev_kv"),
             snapshot_config(std::path::PathBuf::from(
                 "/tmp/test_skip_get_when_no_prev_kv",
             )),
@@ -2642,6 +2739,7 @@ mod prev_kv_apply_tests {
             1,
             0,
             Arc::new(sm),
+            std::path::PathBuf::from("/tmp/test_reads_prev_value_when_nonzero"),
             snapshot_config(std::path::PathBuf::from(
                 "/tmp/test_reads_prev_value_when_nonzero",
             )),
@@ -2688,6 +2786,7 @@ mod prev_kv_apply_tests {
             1,
             0,
             Arc::new(sm),
+            std::path::PathBuf::from("/tmp/test_stops_reading_after_count_zero"),
             snapshot_config(std::path::PathBuf::from(
                 "/tmp/test_stops_reading_after_count_zero",
             )),
@@ -2734,6 +2833,7 @@ mod wait_applied_tests {
             1,
             10, // last_applied = 10
             Arc::new(MockStateMachine::new()),
+            PathBuf::from("/tmp/test_wait_applied_fast_path"),
             snapshot_config(PathBuf::from("/tmp/test_wait_applied_fast_path")),
             MockSnapshotPolicy::new(),
         );
@@ -2777,6 +2877,7 @@ mod wait_applied_tests {
                 1,
                 0,
                 Arc::new(MockStateMachine::new()),
+                PathBuf::from("/tmp/test_wait_applied_blocking"),
                 snapshot_config(PathBuf::from("/tmp/test_wait_applied_blocking")),
                 MockSnapshotPolicy::new(),
             ),
@@ -2832,6 +2933,7 @@ mod wait_applied_tests {
                 1,
                 0,
                 Arc::new(MockStateMachine::new()),
+                PathBuf::from("/tmp/test_wait_applied_multiple_waiters"),
                 snapshot_config(PathBuf::from("/tmp/test_wait_applied_multiple_waiters")),
                 MockSnapshotPolicy::new(),
             ),

--- a/d-engine-core/src/state_machine_handler/wait_applied_test.rs
+++ b/d-engine-core/src/state_machine_handler/wait_applied_test.rs
@@ -19,6 +19,7 @@ fn create_test_handler_with_applied(
         1,            // node_id
         last_applied, // last_applied
         state_machine,
+        std::path::PathBuf::from("/tmp/test_wait_applied"),
         snap_config,
         MockSnapshotPolicy::new(),
     )

--- a/d-engine-core/src/test_utils/common.rs
+++ b/d-engine-core/src/test_utils/common.rs
@@ -69,12 +69,15 @@ pub fn generate_delete_commands(range: RangeInclusive<u64>) -> Bytes {
     buffer.freeze()
 }
 
-pub fn snapshot_config(snapshots_dir: PathBuf) -> SnapshotConfig {
+/// `snapshots_dir` is unused — kept as a no-op parameter so existing call
+/// sites (many passing a unique `/tmp`-style path, back when this fed
+/// `SnapshotConfig.snapshots_dir`) don't all need touching. snapshots_dir
+/// isn't a `d-engine-core` concept anymore (see #10).
+pub fn snapshot_config(_snapshots_dir: PathBuf) -> SnapshotConfig {
     SnapshotConfig {
         max_log_entries_before_snapshot: 1,
         snapshot_cool_down_since_last_check: Duration::from_secs(0),
         cleanup_retain_count: 2,
-        snapshots_dir,
         chunk_size: 1024,
         retained_log_entries: 1,
         sender_yield_every_n_chunks: 1,

--- a/d-engine-core/src/test_utils/common_test.rs
+++ b/d-engine-core/src/test_utils/common_test.rs
@@ -4,7 +4,6 @@ use crate::test_utils::create_config_entries;
 use crate::test_utils::create_mixed_entries;
 use crate::test_utils::generate_delete_commands;
 use crate::test_utils::generate_insert_commands;
-use crate::test_utils::node_config;
 use crate::test_utils::snapshot_config;
 
 #[test]
@@ -112,21 +111,19 @@ fn test_generate_delete_commands_large_range() {
 #[test]
 fn test_snapshot_config_defaults() {
     let dir = PathBuf::from("/tmp/snapshots");
-    let config = snapshot_config(dir.clone());
+    let config = snapshot_config(dir);
 
     assert_eq!(config.max_log_entries_before_snapshot, 1);
     assert_eq!(config.cleanup_retain_count, 2);
     assert_eq!(config.chunk_size, 1024);
     assert!(config.enable);
-    assert_eq!(config.snapshots_dir, dir);
 }
 
 #[test]
 fn test_snapshot_config_paths() {
     let dir = PathBuf::from("/var/raft/snapshots");
-    let config = snapshot_config(dir.clone());
+    let config = snapshot_config(dir);
 
-    assert_eq!(config.snapshots_dir, dir);
     assert_eq!(config.snapshots_dir_prefix, "snapshot-");
 }
 
@@ -165,45 +162,6 @@ fn test_snapshot_config_yield_settings() {
 
     assert_eq!(config.sender_yield_every_n_chunks, 1);
     assert_eq!(config.receiver_yield_every_n_chunks, 1);
-}
-
-#[test]
-fn test_node_config_initialization() {
-    let config = node_config("/tmp/raft");
-
-    assert_eq!(
-        config.cluster.db_root_dir,
-        std::path::PathBuf::from("/tmp/raft")
-    );
-}
-
-#[test]
-fn test_node_config_different_paths() {
-    let path1 = "/data/raft1";
-    let path2 = "/data/raft2";
-
-    let config1 = node_config(path1);
-    let config2 = node_config(path2);
-
-    assert_eq!(config1.cluster.db_root_dir, std::path::PathBuf::from(path1));
-    assert_eq!(config2.cluster.db_root_dir, std::path::PathBuf::from(path2));
-    assert_ne!(config1.cluster.db_root_dir, config2.cluster.db_root_dir);
-}
-
-#[test]
-fn test_node_config_absolute_path() {
-    let path = "/absolute/path/to/db";
-    let config = node_config(path);
-
-    assert!(config.cluster.db_root_dir.is_absolute());
-}
-
-#[test]
-fn test_node_config_relative_path() {
-    let path = "./relative/db";
-    let config = node_config(path);
-
-    assert_eq!(config.cluster.db_root_dir, std::path::PathBuf::from(path));
 }
 
 #[test]

--- a/d-engine-core/src/test_utils/mock/mock_raft_builder.rs
+++ b/d-engine-core/src/test_utils/mock/mock_raft_builder.rs
@@ -302,14 +302,18 @@ impl MockBuilder {
         self
     }
 
+    /// `data_dir` is unused — kept as a no-op parameter so the ~45 existing
+    /// call sites (each passing a unique `/tmp/test_xxx` path, back when this
+    /// fed `ClusterConfig.data_dir`) don't all need touching. data_dir isn't
+    /// a `d-engine-core` concept anymore (see #9).
     pub fn with_db_path(
         mut self,
-        db_root_dir: impl AsRef<Path>,
+        _data_dir: impl AsRef<Path>,
     ) -> Self {
-        let mut node_config = RaftNodeConfig::new().expect("Should succeed to init RaftNodeConfig");
-        node_config.cluster.db_root_dir = db_root_dir.as_ref().to_path_buf();
-        let node_config =
-            node_config.validate().expect("Should succeed to validate RaftNodeConfig");
+        let node_config = RaftNodeConfig::new()
+            .expect("Should succeed to init RaftNodeConfig")
+            .validate()
+            .expect("Should succeed to validate RaftNodeConfig");
         self.node_config = Some(node_config);
         self
     }

--- a/d-engine-core/src/test_utils/mod.rs
+++ b/d-engine-core/src/test_utils/mod.rs
@@ -26,8 +26,13 @@ pub use mock::*;
 pub use replication_test_helpers::*;
 pub use snapshot::*;
 
-pub fn node_config(db_path: &str) -> crate::RaftNodeConfig {
-    let mut s = crate::RaftNodeConfig::new().expect("RaftNodeConfig should be inited successfully");
-    s.cluster.db_root_dir = std::path::PathBuf::from(db_path);
-    s.validate().expect("RaftNodeConfig should be validated successfully")
+/// `db_path` is unused — kept as a no-op parameter so the many existing call
+/// sites (each passing a unique `/tmp/test_xxx` path, back when this fed
+/// `ClusterConfig.data_dir`) don't all need touching. data_dir isn't a
+/// `d-engine-core` concept anymore (see #9).
+pub fn node_config(_db_path: &str) -> crate::RaftNodeConfig {
+    crate::RaftNodeConfig::new()
+        .expect("RaftNodeConfig should be inited successfully")
+        .validate()
+        .expect("RaftNodeConfig should be validated successfully")
 }

--- a/d-engine-server/Cargo.toml
+++ b/d-engine-server/Cargo.toml
@@ -61,7 +61,6 @@ tonic-health = { workspace = true }
 parking_lot = "0.12.3"
 crossbeam = "0.8"
 crossbeam-skiplist = "0.1"
-
 metrics = { version = "0.24", features = [] }
 
 

--- a/d-engine-server/benches/watch_overhead.rs
+++ b/d-engine-server/benches/watch_overhead.rs
@@ -83,7 +83,7 @@ async fn create_embedded_engine()
         r#"
 [cluster]
 listen_address = "127.0.0.1:{port}"
-db_root_dir = "{}"
+data_dir = "{}"
 single_node = true
 
 [raft.watch]
@@ -103,6 +103,7 @@ watcher_buffer_size = 100
     let state_machine = Arc::new(state_machine);
 
     let engine = DefaultEmbeddedEngine::start_custom(
+        &db_path,
         storage,
         state_machine,
         Some(config_path.to_str().unwrap()),

--- a/d-engine-server/src/api/embedded.rs
+++ b/d-engine-server/src/api/embedded.rs
@@ -308,10 +308,9 @@ where
     /// non-path settings (node_id, cluster topology, timeouts, etc.); any
     /// `data_dir` entry in the config file is ignored.
     ///
-    /// The data_dir lock is acquired inside this call, before the node
-    /// starts — but `storage_engine`/`state_machine` are already
-    /// constructed by the caller by the time they're passed in. Callers
-    /// must not open or use `data_dir` themselves before calling this.
+    /// d-engine's data_dir lock only protects d-engine's own files.
+    /// `storage_engine`/`state_machine` are constructed by the caller;
+    /// their concurrency safety is the caller's responsibility.
     ///
     /// # Arguments
     /// - `data_dir`: root directory for this node's persistent state
@@ -345,6 +344,7 @@ where
     ///
     /// For library wrappers that build their own config layer and
     /// translate to `RaftNodeConfig` in Rust — no config file required.
+    /// Same lock scope as [`start_custom`](Self::start_custom) — see its doc.
     pub async fn start_node(
         data_dir: impl AsRef<std::path::Path>,
         storage_engine: Arc<SE>,
@@ -405,6 +405,11 @@ where
             .state_machine(state_machine);
         if let Some(lock) = data_dir_lock {
             builder = builder.data_dir_lock(lock);
+        } else {
+            tracing::warn!(
+                "storage_engine/state_machine were built before d-engine's data_dir \
+                 lock — their concurrency safety is the caller's responsibility"
+            );
         }
         let node = builder.start().await?;
 

--- a/d-engine-server/src/api/embedded.rs
+++ b/d-engine-server/src/api/embedded.rs
@@ -3,17 +3,6 @@
 //! This module provides [`EmbeddedEngine`], a high-level wrapper around [`Node`]
 //! that simplifies lifecycle management for embedded use cases.
 //!
-//! ## Comparison: Node vs EmbeddedEngine
-//!
-//! ### Using Node (Low-level API)
-//! ```ignore
-//! let node = NodeBuilder::new(config).start().await?;
-//! // Node does not provide client directly - use EmbeddedEngine instead
-//! tokio::spawn(async move { node.run().await });
-//! // Manual lifecycle management required
-//! ```
-//!
-//! ### Using EmbeddedEngine (High-level API)
 //! ```ignore
 //! let engine = EmbeddedEngine::start("./data/my-app").await?;
 //! engine.wait_ready(Duration::from_secs(5)).await?;
@@ -22,10 +11,8 @@
 //! // Lifecycle managed automatically
 //! ```
 //!
-//! ## When to Use
-//!
-//! - **EmbeddedEngine**: Application developers who want simplicity
-//! - **Node**: Framework developers who need fine-grained control
+//! Need a custom storage engine or state machine? Use [`EmbeddedEngine::start_custom`]
+//! instead of `start`/`start_with`.
 //!
 //! # Application Responsibilities in Multi-Node Deployments
 //!
@@ -200,34 +187,24 @@ impl<T: TypeConfig> Clone for EmbeddedEngine<T> {
 impl EmbeddedEngine<RaftTypeConfig<RocksDBStorageEngine, RocksDBStateMachine>> {
     /// Start engine with an explicit data directory.
     ///
-    /// `data_dir` has highest priority and always overrides `cluster.db_root_dir` from
-    /// `CONFIG_PATH` or `RAFT__` environment variables. Other configuration (network,
-    /// Raft timeouts, cluster topology) is still read from those sources if set.
-    ///
     /// The directory is created automatically if it does not exist.
     /// If it already contains data the engine opens it in place (idempotent).
     ///
     /// # Example
     /// ```ignore
-    /// // Minimal — just supply a path
     /// let engine = EmbeddedEngine::start("./data/my-app").await?;
     /// engine.wait_ready(Duration::from_secs(5)).await?;
-    ///
-    /// // Works with any AsRef<Path>
-    /// let engine = EmbeddedEngine::start(std::path::Path::new("/var/lib/my-app")).await?;
     /// ```
     pub async fn start(data_dir: impl AsRef<std::path::Path>) -> Result<Self> {
-        let mut config = d_engine_core::RaftNodeConfig::new()?;
-        config.cluster.db_root_dir = data_dir.as_ref().to_path_buf();
-        let config = config.validate()?;
-
-        let base_dir = config.cluster.db_root_dir.clone();
-        tokio::fs::create_dir_all(&base_dir)
-            .await
-            .map_err(|e| crate::Error::Fatal(format!("Failed to create data directory: {e}")))?;
+        let config = d_engine_core::RaftNodeConfig::new()?.validate()?;
+        let data_dir = crate::node::DataDir::new(data_dir.as_ref())?;
+        // Lock before touching storage — otherwise two racing processes both
+        // get partway into opening the same RocksDB directory before either
+        // one even checks this lock.
+        let data_dir_lock = crate::node::DataDirLock::acquire(data_dir.as_path())?;
 
         let (storage, mut sm) = if config.storage.unified_db {
-            let db_path = base_dir.join("db");
+            let db_path = data_dir.unified_db_path()?;
             info!(
                 "Starting embedded engine with unified RocksDB at {:?}",
                 db_path
@@ -236,10 +213,10 @@ impl EmbeddedEngine<RaftTypeConfig<RocksDBStorageEngine, RocksDBStateMachine>> {
         } else {
             info!(
                 "Starting embedded engine with separate RocksDB instances at {:?}",
-                base_dir
+                data_dir.as_path()
             );
-            let storage = RocksDBStorageEngine::new(base_dir.join("storage"))?;
-            let sm = RocksDBStateMachine::new(base_dir.join("state_machine"))?;
+            let storage = RocksDBStorageEngine::new(data_dir.storage_path()?)?;
+            let sm = RocksDBStateMachine::new(data_dir.state_machine_path()?)?;
             (storage, sm)
         };
 
@@ -248,23 +225,28 @@ impl EmbeddedEngine<RaftTypeConfig<RocksDBStorageEngine, RocksDBStateMachine>> {
         ));
         sm.set_lease(lease);
 
-        Self::start_node(config, Arc::new(storage), Arc::new(sm)).await
+        Self::start_node_with_lock(
+            data_dir.as_path().to_path_buf(),
+            data_dir_lock,
+            Arc::new(storage),
+            Arc::new(sm),
+            config,
+        )
+        .await
     }
 
-    /// Start engine with explicit configuration file.
-    ///
-    /// Reads configuration from specified file path.
-    /// Data directory is determined by config's `cluster.db_root_dir` setting.
-    ///
-    /// # Arguments
-    /// - `config_path`: Path to configuration file (e.g. "d-engine.toml")
+    /// Start engine with an explicit data directory plus a config file for
+    /// everything else (topology, timeouts, network — not data_dir; a
+    /// `[cluster] data_dir` entry in the file, if present, is ignored).
     ///
     /// # Example
     /// ```ignore
-    /// let engine = EmbeddedEngine::start_with("config/node1.toml").await?;
-    /// engine.wait_ready(Duration::from_secs(5)).await?;
+    /// let engine = EmbeddedEngine::start_with("./data/my-app", "config/node1.toml").await?;
     /// ```
-    pub async fn start_with(config_path: impl AsRef<std::path::Path>) -> Result<Self> {
+    pub async fn start_with(
+        data_dir: impl AsRef<std::path::Path>,
+        config_path: impl AsRef<std::path::Path>,
+    ) -> Result<Self> {
         let path_str = config_path
             .as_ref()
             .to_str()
@@ -273,14 +255,11 @@ impl EmbeddedEngine<RaftTypeConfig<RocksDBStorageEngine, RocksDBStateMachine>> {
         let config = d_engine_core::RaftNodeConfig::new()?
             .with_override_config(path_str)?
             .validate()?;
-        let base_dir = std::path::PathBuf::from(&config.cluster.db_root_dir);
-
-        tokio::fs::create_dir_all(&base_dir)
-            .await
-            .map_err(|e| crate::Error::Fatal(format!("Failed to create data directory: {e}")))?;
+        let data_dir = crate::node::DataDir::new(data_dir.as_ref())?;
+        let data_dir_lock = crate::node::DataDirLock::acquire(data_dir.as_path())?;
 
         let (storage, mut sm) = if config.storage.unified_db {
-            let db_path = base_dir.join("db");
+            let db_path = data_dir.unified_db_path()?;
             info!(
                 "Starting embedded engine with unified RocksDB at {:?}",
                 db_path
@@ -289,10 +268,10 @@ impl EmbeddedEngine<RaftTypeConfig<RocksDBStorageEngine, RocksDBStateMachine>> {
         } else {
             info!(
                 "Starting embedded engine with separate RocksDB instances at {:?}",
-                base_dir
+                data_dir.as_path()
             );
-            let storage = RocksDBStorageEngine::new(base_dir.join("storage"))?;
-            let sm = RocksDBStateMachine::new(base_dir.join("state_machine"))?;
+            let storage = RocksDBStorageEngine::new(data_dir.storage_path()?)?;
+            let sm = RocksDBStateMachine::new(data_dir.state_machine_path()?)?;
             (storage, sm)
         };
 
@@ -301,7 +280,18 @@ impl EmbeddedEngine<RaftTypeConfig<RocksDBStorageEngine, RocksDBStateMachine>> {
         ));
         sm.set_lease(lease);
 
-        Self::start_custom(Arc::new(storage), Arc::new(sm), Some(path_str)).await
+        // start_node_with_lock directly, not start_custom — config is
+        // already loaded/validated here, and the lock is already held;
+        // start_custom would re-parse config_path again for no benefit and
+        // can't accept a pre-acquired lock anyway.
+        Self::start_node_with_lock(
+            data_dir.as_path().to_path_buf(),
+            data_dir_lock,
+            Arc::new(storage),
+            Arc::new(sm),
+            config,
+        )
+        .await
     }
 }
 
@@ -312,35 +302,43 @@ where
     SE: StorageEngine + Debug + 'static,
     SM: StateMachine + Debug + 'static,
 {
-    /// Start engine with custom storage and state machine.
+    /// Starts the engine with a custom storage engine and state machine.
     ///
-    /// Advanced API for users providing custom storage implementations.
+    /// `data_dir` is required and explicit — `config_path` is only for
+    /// non-path settings (node_id, cluster topology, timeouts, etc.); any
+    /// `data_dir` entry in the config file is ignored.
+    ///
+    /// The data_dir lock is acquired inside this call, before the node
+    /// starts — but `storage_engine`/`state_machine` are already
+    /// constructed by the caller by the time they're passed in. Callers
+    /// must not open or use `data_dir` themselves before calling this.
     ///
     /// # Arguments
-    /// - `config_path`: Optional path to configuration file
-    /// - `storage_engine`: Custom storage engine implementation
-    /// - `state_machine`: Custom state machine implementation
+    /// - `data_dir`: root directory for this node's persistent state
+    /// - `storage_engine`: custom storage engine implementation
+    /// - `state_machine`: custom state machine implementation
+    /// - `config_path`: optional config file for non-path settings
     ///
     /// # Example
     /// ```ignore
     /// let storage = Arc::new(MyCustomStorage::new()?);
     /// let sm = Arc::new(MyCustomStateMachine::new()?);
-    /// let engine = EmbeddedEngine::start_custom(storage, sm, None).await?;
+    /// let engine = EmbeddedEngine::start_custom("./data/my-node", storage, sm, None).await?;
     /// ```
     pub async fn start_custom(
+        data_dir: impl AsRef<std::path::Path>,
         storage_engine: Arc<SE>,
         state_machine: Arc<SM>,
         config_path: Option<&str>,
     ) -> Result<Self> {
         let node_config = if let Some(path) = config_path {
-            d_engine_core::RaftNodeConfig::default()
-                .with_override_config(path)?
-                .validate()?
+            d_engine_core::RaftNodeConfig::default().with_override_config(path)?
         } else {
-            d_engine_core::RaftNodeConfig::new()?.validate()?
+            d_engine_core::RaftNodeConfig::new()?
         };
+        let node_config = node_config.validate()?;
 
-        Self::start_node(node_config, storage_engine, state_machine).await
+        Self::start_node(data_dir, storage_engine, state_machine, node_config).await
     }
 
     /// Start engine with custom storage, state machine, and programmatic config.
@@ -348,9 +346,48 @@ where
     /// For library wrappers that build their own config layer and
     /// translate to `RaftNodeConfig` in Rust — no config file required.
     pub async fn start_node(
-        node_config: d_engine_core::RaftNodeConfig,
+        data_dir: impl AsRef<std::path::Path>,
         storage_engine: Arc<SE>,
         state_machine: Arc<SM>,
+        node_config: d_engine_core::RaftNodeConfig,
+    ) -> Result<Self> {
+        Self::start_node_inner(
+            data_dir.as_ref().to_path_buf(),
+            None,
+            storage_engine,
+            state_machine,
+            node_config,
+        )
+        .await
+    }
+
+    /// Same as `start_node`, but for callers (`start`/`start_with`) that
+    /// already opened storage and therefore must have acquired the lock
+    /// *before* that — see `NodeBuilder::data_dir_lock`'s doc comment.
+    #[allow(dead_code)]
+    async fn start_node_with_lock(
+        data_dir: std::path::PathBuf,
+        data_dir_lock: crate::node::DataDirLock,
+        storage_engine: Arc<SE>,
+        state_machine: Arc<SM>,
+        node_config: d_engine_core::RaftNodeConfig,
+    ) -> Result<Self> {
+        Self::start_node_inner(
+            data_dir,
+            Some(data_dir_lock),
+            storage_engine,
+            state_machine,
+            node_config,
+        )
+        .await
+    }
+
+    async fn start_node_inner(
+        data_dir: std::path::PathBuf,
+        data_dir_lock: Option<crate::node::DataDirLock>,
+        storage_engine: Arc<SE>,
+        state_machine: Arc<SM>,
+        node_config: d_engine_core::RaftNodeConfig,
     ) -> Result<Self> {
         info!("Starting embedded d-engine");
         d_engine_core::init_clock();
@@ -361,14 +398,15 @@ where
         // for the direct-SM fast path. LOCK release is decoupled from Arc<SM> counting
         // (via close_db()), so holding multiple Arc<SM> clones is safe.
         let sm_for_client = Arc::clone(&state_machine);
-
         let sm_for_engine = Arc::clone(&state_machine);
 
-        let node = NodeBuilder::init(node_config.validate()?, shutdown_rx)
+        let mut builder = NodeBuilder::init(data_dir, node_config.validate()?, shutdown_rx)
             .storage_engine(storage_engine)
-            .state_machine(state_machine)
-            .start()
-            .await?;
+            .state_machine(state_machine);
+        if let Some(lock) = data_dir_lock {
+            builder = builder.data_dir_lock(lock);
+        }
+        let node = builder.start().await?;
 
         let leader_elected_rx = node.leader_change_notifier();
         let membership_rx = node.membership_change_notifier();
@@ -461,7 +499,7 @@ impl<T: TypeConfig> EmbeddedEngine<T> {
     /// let leader = engine.wait_ready(Duration::from_secs(3)).await?;
     ///
     /// // Multi-node production
-    /// let engine = EmbeddedEngine::start_with("cluster.toml").await?;
+    /// let engine = EmbeddedEngine::start_with("./data/node1", "cluster.toml").await?;
     /// let leader = engine.wait_ready(Duration::from_secs(10)).await?;
     /// println!("Leader elected: {} (term {})", leader.leader_id, leader.term);
     /// ```

--- a/d-engine-server/src/api/embedded_client_test/embedded_client_test.rs
+++ b/d-engine-server/src/api/embedded_client_test/embedded_client_test.rs
@@ -122,7 +122,7 @@ mod integration_tests {
             r#"
 [cluster]
 listen_address = "127.0.0.1:{}"
-db_root_dir = "{}"
+data_dir = "{}"
 single_node = true
 
 [raft]
@@ -142,7 +142,7 @@ max_batch_size = 1
         );
         std::fs::write(&config_path, config_content).expect("Failed to write config");
 
-        let engine = DefaultEmbeddedEngine::start_with(config_path.to_str().unwrap())
+        let engine = DefaultEmbeddedEngine::start_with(&db_path, config_path.to_str().unwrap())
             .await
             .expect("Failed to start engine");
 

--- a/d-engine-server/src/api/embedded_test/embedded_env_test.rs
+++ b/d-engine-server/src/api/embedded_test/embedded_env_test.rs
@@ -56,10 +56,10 @@ mod start_data_dir_tests {
         }
     }
 
-    /// data_dir overrides cluster.db_root_dir set in CONFIG_PATH.
+    /// data_dir overrides cluster.data_dir set in CONFIG_PATH.
     #[tokio::test]
     #[serial]
-    async fn test_start_data_dir_overrides_config_path_db_root_dir() {
+    async fn test_start_data_dir_overrides_config_path_data_dir() {
         let temp_dir = tempfile::tempdir().expect("tempdir");
         let config_data_dir = temp_dir.path().join("from-config");
         let explicit_data_dir = temp_dir.path().join("from-arg");
@@ -69,7 +69,7 @@ mod start_data_dir_tests {
         std::fs::write(
             &config_path,
             format!(
-                "[cluster]\ndb_root_dir = \"{}\"\n[cluster.rpc]\nlisten_addr = \"127.0.0.1:0\"\n",
+                "[cluster]\ndata_dir = \"{}\"\n[cluster.rpc]\nlisten_addr = \"127.0.0.1:0\"\n",
                 config_data_dir.display()
             ),
         )
@@ -90,10 +90,10 @@ mod start_data_dir_tests {
         }
     }
 
-    /// /tmp paths emit a warning but are not rejected.
+    /// /tmp paths are accepted — a legitimate explicit choice d-engine does not second-guess.
     #[tokio::test]
     #[serial(tmp_db)]
-    async fn test_start_tmp_path_warns_but_succeeds() {
+    async fn test_start_tmp_path_accepted() {
         let tmp_path = std::path::PathBuf::from("/tmp/d-engine-env-test");
         let _ = std::fs::remove_dir_all(&tmp_path);
 
@@ -101,7 +101,7 @@ mod start_data_dir_tests {
 
         assert!(
             result.is_ok(),
-            "/tmp path should succeed with warn, not error: {:?}",
+            "/tmp path must be accepted: {:?}",
             result.err()
         );
 

--- a/d-engine-server/src/api/embedded_test/embedded_env_test.rs
+++ b/d-engine-server/src/api/embedded_test/embedded_env_test.rs
@@ -94,10 +94,11 @@ mod start_data_dir_tests {
     #[tokio::test]
     #[serial(tmp_db)]
     async fn test_start_tmp_path_accepted() {
-        let tmp_path = std::path::PathBuf::from("/tmp/d-engine-env-test");
-        let _ = std::fs::remove_dir_all(&tmp_path);
+        let tmp_dir = tempfile::Builder::new()
+            .tempdir_in("/tmp")
+            .expect("Failed to create temp dir in /tmp");
 
-        let result = EmbeddedEngine::start(&tmp_path).await;
+        let result = EmbeddedEngine::start(tmp_dir.path()).await;
 
         assert!(
             result.is_ok(),
@@ -108,6 +109,5 @@ mod start_data_dir_tests {
         if let Ok(engine) = result {
             engine.stop().await.ok();
         }
-        let _ = std::fs::remove_dir_all(&tmp_path);
     }
 }

--- a/d-engine-server/src/api/embedded_test/embedded_test.rs
+++ b/d-engine-server/src/api/embedded_test/embedded_test.rs
@@ -38,10 +38,10 @@ mod embedded_engine_tests {
 
     #[tokio::test]
     async fn test_wait_ready_single_node_success() {
-        let (storage, sm, _temp_dir) = create_test_storage_and_sm().await;
+        let (storage, sm, temp_dir) = create_test_storage_and_sm().await;
 
         // Start embedded engine (single node)
-        let engine = TestEngine::start_custom(storage, sm, None)
+        let engine = TestEngine::start_custom(temp_dir.path(), storage, sm, None)
             .await
             .expect("Failed to start engine");
 
@@ -65,9 +65,9 @@ mod embedded_engine_tests {
 
     #[tokio::test]
     async fn test_wait_ready_timeout() {
-        let (storage, sm, _temp_dir) = create_test_storage_and_sm().await;
+        let (storage, sm, temp_dir) = create_test_storage_and_sm().await;
 
-        let engine = TestEngine::start_custom(storage, sm, None)
+        let engine = TestEngine::start_custom(temp_dir.path(), storage, sm, None)
             .await
             .expect("Failed to start engine");
 
@@ -85,9 +85,9 @@ mod embedded_engine_tests {
 
     #[tokio::test]
     async fn test_leader_change_notifier_basic() {
-        let (storage, sm, _temp_dir) = create_test_storage_and_sm().await;
+        let (storage, sm, temp_dir) = create_test_storage_and_sm().await;
 
-        let engine = TestEngine::start_custom(storage, sm, None)
+        let engine = TestEngine::start_custom(temp_dir.path(), storage, sm, None)
             .await
             .expect("Failed to start engine");
 
@@ -119,9 +119,9 @@ mod embedded_engine_tests {
 
     #[tokio::test]
     async fn test_ready_and_wait_ready_sequence() {
-        let (storage, sm, _temp_dir) = create_test_storage_and_sm().await;
+        let (storage, sm, temp_dir) = create_test_storage_and_sm().await;
 
-        let engine = TestEngine::start_custom(storage, sm, None)
+        let engine = TestEngine::start_custom(temp_dir.path(), storage, sm, None)
             .await
             .expect("Failed to start engine");
 
@@ -148,9 +148,9 @@ mod embedded_engine_tests {
 
     #[tokio::test]
     async fn test_client_available_after_wait_ready() {
-        let (storage, sm, _temp_dir) = create_test_storage_and_sm().await;
+        let (storage, sm, temp_dir) = create_test_storage_and_sm().await;
 
-        let engine = TestEngine::start_custom(storage, sm, None)
+        let engine = TestEngine::start_custom(temp_dir.path(), storage, sm, None)
             .await
             .expect("Failed to start engine");
 
@@ -174,9 +174,9 @@ mod embedded_engine_tests {
 
     #[tokio::test]
     async fn test_multiple_leader_change_notifier_subscribers() {
-        let (storage, sm, _temp_dir) = create_test_storage_and_sm().await;
+        let (storage, sm, temp_dir) = create_test_storage_and_sm().await;
 
-        let engine = TestEngine::start_custom(storage, sm, None)
+        let engine = TestEngine::start_custom(temp_dir.path(), storage, sm, None)
             .await
             .expect("Failed to start engine");
 
@@ -211,9 +211,9 @@ mod embedded_engine_tests {
 
     #[tokio::test]
     async fn test_engine_stop_cleans_up() {
-        let (storage, sm, _temp_dir) = create_test_storage_and_sm().await;
+        let (storage, sm, temp_dir) = create_test_storage_and_sm().await;
 
-        let engine = TestEngine::start_custom(storage, sm, None)
+        let engine = TestEngine::start_custom(temp_dir.path(), storage, sm, None)
             .await
             .expect("Failed to start engine");
 
@@ -224,9 +224,9 @@ mod embedded_engine_tests {
 
     #[tokio::test]
     async fn test_wait_ready_race_condition_already_elected() {
-        let (storage, sm, _temp_dir) = create_test_storage_and_sm().await;
+        let (storage, sm, temp_dir) = create_test_storage_and_sm().await;
 
-        let engine = TestEngine::start_custom(storage, sm, None)
+        let engine = TestEngine::start_custom(temp_dir.path(), storage, sm, None)
             .await
             .expect("Failed to start engine");
 
@@ -258,10 +258,10 @@ mod embedded_engine_tests {
 
     #[tokio::test]
     async fn test_wait_ready_multiple_calls_concurrent() {
-        let (storage, sm, _temp_dir) = create_test_storage_and_sm().await;
+        let (storage, sm, temp_dir) = create_test_storage_and_sm().await;
 
         let engine = Arc::new(
-            TestEngine::start_custom(storage, sm, None)
+            TestEngine::start_custom(temp_dir.path(), storage, sm, None)
                 .await
                 .expect("Failed to start engine"),
         );
@@ -305,9 +305,9 @@ mod embedded_engine_tests {
 
     #[tokio::test]
     async fn test_wait_ready_check_current_value_first() {
-        let (storage, sm, _temp_dir) = create_test_storage_and_sm().await;
+        let (storage, sm, temp_dir) = create_test_storage_and_sm().await;
 
-        let engine = TestEngine::start_custom(storage, sm, None)
+        let engine = TestEngine::start_custom(temp_dir.path(), storage, sm, None)
             .await
             .expect("Failed to start engine");
 
@@ -349,8 +349,7 @@ mod embedded_engine_tests {
 
         #[tokio::test]
         #[serial(tmp_db)]
-        async fn test_start_with_tmp_path_warns_but_succeeds() {
-            // /tmp paths warn but are not rejected — caller's choice
+        async fn test_start_with_tmp_path_accepted() {
             let tmp_path = std::path::PathBuf::from("/tmp/d-engine-test-start");
             let _ = std::fs::remove_dir_all(&tmp_path);
 
@@ -358,14 +357,13 @@ mod embedded_engine_tests {
 
             assert!(
                 result.is_ok(),
-                "start() should succeed with /tmp path (warn only). Error: {:?}",
-                result.as_ref().err()
+                "start() must accept a /tmp path: {:?}",
+                result.err()
             );
 
             if let Ok(engine) = result {
                 engine.stop().await.ok();
             }
-
             let _ = std::fs::remove_dir_all(&tmp_path);
         }
 
@@ -402,12 +400,12 @@ mod embedded_engine_tests {
             let config_path = _temp_dir.path().join("test_config.toml");
             let data_dir = _temp_dir.path().join("data");
 
-            // Create valid config with custom db_root_dir
+            // Create valid config with custom data_dir
             let config_content = format!(
                 r#"
 [cluster]
 node_id = 1
-db_root_dir = "{}"
+data_dir = "{}"
 
 [cluster.rpc]
 listen_addr = "127.0.0.1:0"
@@ -422,7 +420,7 @@ election_timeout_max_ms = 3000
             std::fs::write(&config_path, config_content).expect("Failed to write config");
 
             // Should succeed with valid config
-            let result = EmbeddedEngine::start_with(config_path.to_str().unwrap()).await;
+            let result = EmbeddedEngine::start_with(&data_dir, config_path.to_str().unwrap()).await;
             assert!(
                 result.is_ok(),
                 "start_with() should succeed with valid config"
@@ -436,7 +434,9 @@ election_timeout_max_ms = 3000
 
         #[tokio::test]
         async fn test_start_with_nonexistent_config() {
-            let result = EmbeddedEngine::start_with("/nonexistent/config.toml").await;
+            let _temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+            let result =
+                EmbeddedEngine::start_with(_temp_dir.path(), "/nonexistent/config.toml").await;
 
             assert!(
                 result.is_err(),
@@ -444,78 +444,41 @@ election_timeout_max_ms = 3000
             );
         }
 
+        /// /tmp is accepted — a legitimate explicit choice, not something d-engine judges.
         #[tokio::test]
-        #[cfg(debug_assertions)]
         #[serial(tmp_db)]
-        async fn test_start_with_tmp_db_allows_in_debug() {
+        async fn test_start_with_tmp_db_accepted() {
             let _temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
             let config_path = _temp_dir.path().join("test_config.toml");
-
-            // Clean up /tmp/db before test
             let _ = std::fs::remove_dir_all("/tmp/db");
 
-            // Create config with /tmp/db
             let config_content = r#"
 [cluster]
 node_id = 1
-db_root_dir = "/tmp/db"
 
 [cluster.rpc]
 listen_addr = "127.0.0.1:0"
 "#;
             std::fs::write(&config_path, config_content).expect("Failed to write config");
 
-            // In debug mode, should succeed with warning
-            let result = EmbeddedEngine::start_with(config_path.to_str().unwrap()).await;
+            let result = EmbeddedEngine::start_with("/tmp/db", config_path.to_str().unwrap()).await;
             assert!(
                 result.is_ok(),
-                "start_with() should allow /tmp/db in debug mode"
+                "start_with() must accept /tmp/db: {:?}",
+                result.err()
             );
 
             if let Ok(engine) = result {
                 engine.stop().await.ok();
             }
-
-            // Clean up after test
             let _ = std::fs::remove_dir_all("/tmp/db");
         }
 
         #[tokio::test]
-        #[cfg(not(debug_assertions))]
-        #[serial]
-        async fn test_start_with_tmp_db_rejects_in_release() {
-            let _temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-            let config_path = _temp_dir.path().join("test_config.toml");
-
-            // Create config with /tmp/db
-            let config_content = r#"
-[cluster]
-node_id = 1
-db_root_dir = "/tmp/db"
-
-[cluster.rpc]
-listen_addr = "127.0.0.1:0"
-"#;
-            std::fs::write(&config_path, config_content).expect("Failed to write config");
-
-            // In release mode, should reject
-            let result = EmbeddedEngine::start_with(config_path.to_str().unwrap()).await;
-            assert!(
-                result.is_err(),
-                "start_with() should reject /tmp/db in release mode"
-            );
-
-            if let Err(e) = result {
-                let err_msg = format!("{:?}", e);
-                assert!(err_msg.contains("/tmp/db") || err_msg.contains("db_root_dir"));
-            }
-        }
-
-        #[tokio::test]
         async fn test_drop_without_stop_warning() {
-            let (storage, sm, _temp_dir) = create_test_storage_and_sm().await;
+            let (storage, sm, temp_dir) = create_test_storage_and_sm().await;
 
-            let engine = TestEngine::start_custom(storage, sm, None)
+            let engine = TestEngine::start_custom(temp_dir.path(), storage, sm, None)
                 .await
                 .expect("Failed to start engine");
 
@@ -532,8 +495,8 @@ listen_addr = "127.0.0.1:0"
         #[tokio::test]
         #[serial(tmp_db)]
         async fn test_stop_releases_sm_lock_immediately() {
-            let data_dir = std::path::PathBuf::from("/tmp/d-engine-lock-release-test");
-            let _ = std::fs::remove_dir_all(&data_dir);
+            let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+            let data_dir = temp_dir.path().join("d-engine-lock-release-test");
 
             let engine =
                 EmbeddedEngine::start(&data_dir).await.expect("First start should succeed");
@@ -567,10 +530,7 @@ listen_addr = "127.0.0.1:0"
 
         /// Build a minimal valid `RaftNodeConfig` backed by a temp directory.
         /// Uses a fixed high port; tests are serialized to avoid conflicts.
-        fn make_config(
-            temp_dir: &tempfile::TempDir,
-            node_id: u32,
-        ) -> d_engine_core::RaftNodeConfig {
+        fn make_config(node_id: u32) -> d_engine_core::RaftNodeConfig {
             let listen_addr: SocketAddr = "127.0.0.1:19731".parse().unwrap();
             d_engine_core::RaftNodeConfig {
                 cluster: ClusterConfig {
@@ -582,8 +542,6 @@ listen_addr = "127.0.0.1:0"
                         role: NodeRole::Follower as i32,
                         status: NodeStatus::Active.into(),
                     }],
-                    db_root_dir: temp_dir.path().join("engine"),
-                    log_dir: temp_dir.path().join("logs"),
                 },
                 ..Default::default()
             }
@@ -595,11 +553,12 @@ listen_addr = "127.0.0.1:0"
         #[serial(start_node)]
         async fn test_start_node_with_programmatic_config_starts_and_stops() {
             let (storage, sm, temp_dir) = create_test_storage_and_sm().await;
-            let config = make_config(&temp_dir, 1);
+            let config = make_config(1);
 
-            let engine = TestEngine::start_node(config, storage, sm)
-                .await
-                .expect("start_node should succeed with valid programmatic config");
+            let engine =
+                TestEngine::start_node(temp_dir.path().join("engine"), storage, sm, config)
+                    .await
+                    .expect("start_node should succeed with valid programmatic config");
 
             engine
                 .wait_ready(Duration::from_secs(5))
@@ -615,9 +574,10 @@ listen_addr = "127.0.0.1:0"
         #[serial(start_node)]
         async fn test_start_node_unvalidated_config_returns_error() {
             let (storage, sm, temp_dir) = create_test_storage_and_sm().await;
-            let config = make_config(&temp_dir, 0);
+            let config = make_config(0);
 
-            let result = TestEngine::start_node(config, storage, sm).await;
+            let result =
+                TestEngine::start_node(temp_dir.path().join("engine"), storage, sm, config).await;
             assert!(
                 result.is_err(),
                 "start_node with node_id=0 should return validation error"
@@ -631,11 +591,12 @@ listen_addr = "127.0.0.1:0"
         async fn test_start_node_uses_passed_se_and_sm_instances() {
             let (storage, sm, temp_dir) = create_test_storage_and_sm().await;
             let sm_for_direct_read = Arc::clone(&sm);
-            let config = make_config(&temp_dir, 1);
+            let config = make_config(1);
 
-            let engine = TestEngine::start_node(config, storage, sm)
-                .await
-                .expect("start_node should succeed");
+            let engine =
+                TestEngine::start_node(temp_dir.path().join("engine"), storage, sm, config)
+                    .await
+                    .expect("start_node should succeed");
             engine
                 .wait_ready(Duration::from_secs(5))
                 .await
@@ -665,11 +626,12 @@ listen_addr = "127.0.0.1:0"
         #[serial(start_node)]
         async fn test_batch_empty_ops_returns_invalid_argument() {
             let (storage, sm, temp_dir) = create_test_storage_and_sm().await;
-            let config = make_config(&temp_dir, 1);
+            let config = make_config(1);
 
-            let engine = TestEngine::start_node(config, storage, sm)
-                .await
-                .expect("start_node should succeed");
+            let engine =
+                TestEngine::start_node(temp_dir.path().join("engine"), storage, sm, config)
+                    .await
+                    .expect("start_node should succeed");
             engine
                 .wait_ready(Duration::from_secs(5))
                 .await
@@ -696,9 +658,9 @@ listen_addr = "127.0.0.1:0"
         #[tokio::test]
         #[serial]
         async fn test_watch_registers_successfully() {
-            let (storage, sm, _temp_dir) = create_test_storage_and_sm().await;
+            let (storage, sm, temp_dir) = create_test_storage_and_sm().await;
 
-            let engine = TestEngine::start_custom(storage, sm, None)
+            let engine = TestEngine::start_custom(temp_dir.path(), storage, sm, None)
                 .await
                 .expect("Failed to start engine");
 
@@ -756,6 +718,10 @@ listen_addr = "127.0.0.1:0"
         /// - Watch receives no events
         #[tokio::test]
         async fn test_watch_with_tempdir_dropped() {
+            // Separate from the storage/sm tempdir below — this one must stay alive for the
+            // whole test, unlike that one which is dropped on purpose.
+            let data_dir = tempfile::tempdir().expect("Failed to create temp dir");
+
             let (storage, sm) = {
                 let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
                 let storage_path = temp_dir.path().join("storage");
@@ -775,7 +741,7 @@ listen_addr = "127.0.0.1:0"
                 // temp_dir dropped here — underlying paths are now invalid
             };
 
-            let engine = TestEngine::start_custom(storage, sm, None)
+            let engine = TestEngine::start_custom(data_dir.path(), storage, sm, None)
                 .await
                 .expect("Failed to start engine");
 
@@ -816,9 +782,9 @@ listen_addr = "127.0.0.1:0"
         async fn test_watch_with_tempdir_alive() {
             println!("\n=== Testing Watch with TempDir ALIVE ===");
 
-            let _temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-            let storage_path = _temp_dir.path().join("storage");
-            let sm_path = _temp_dir.path().join("sm");
+            let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+            let storage_path = temp_dir.path().join("storage");
+            let sm_path = temp_dir.path().join("sm");
 
             std::fs::create_dir_all(&storage_path).unwrap();
             std::fs::create_dir_all(&sm_path).unwrap();
@@ -833,16 +799,21 @@ listen_addr = "127.0.0.1:0"
 
             // Default general_raft_timeout_duration_in_ms is 50ms — too tight for CI.
             // Override to 5000ms so put() doesn't time out on slow machines.
-            let config_path = _temp_dir.path().join("test.toml");
+            let config_path = temp_dir.path().join("test.toml");
             std::fs::write(
                 &config_path,
                 "[raft]\ngeneral_raft_timeout_duration_in_ms = 5000\n",
             )
             .unwrap();
 
-            let engine = TestEngine::start_custom(storage, sm, Some(config_path.to_str().unwrap()))
-                .await
-                .expect("Failed to start engine");
+            let engine = TestEngine::start_custom(
+                temp_dir.path(),
+                storage,
+                sm,
+                Some(config_path.to_str().unwrap()),
+            )
+            .await
+            .expect("Failed to start engine");
 
             engine
                 .wait_ready(Duration::from_secs(5))
@@ -911,9 +882,9 @@ listen_addr = "127.0.0.1:0"
     /// Business scenario: Most basic embedded deployment (1 node)
     #[tokio::test]
     async fn test_is_leader_single_node() {
-        let (storage, sm, _temp_dir) = create_test_storage_and_sm().await;
+        let (storage, sm, temp_dir) = create_test_storage_and_sm().await;
 
-        let engine = TestEngine::start_custom(storage, sm, None)
+        let engine = TestEngine::start_custom(temp_dir.path(), storage, sm, None)
             .await
             .expect("Failed to start engine");
 
@@ -951,9 +922,9 @@ listen_addr = "127.0.0.1:0"
     /// Business scenario: Application calls APIs during startup before cluster is ready
     #[tokio::test]
     async fn test_leader_info_before_election() {
-        let (storage, sm, _temp_dir) = create_test_storage_and_sm().await;
+        let (storage, sm, temp_dir) = create_test_storage_and_sm().await;
 
-        let engine = TestEngine::start_custom(storage, sm, None)
+        let engine = TestEngine::start_custom(temp_dir.path(), storage, sm, None)
             .await
             .expect("Failed to start engine");
 
@@ -1001,10 +972,10 @@ listen_addr = "127.0.0.1:0"
     /// (e.g., HAProxy checking /primary endpoint from multiple load balancers)
     #[tokio::test]
     async fn test_is_leader_concurrent_access() {
-        let (storage, sm, _temp_dir) = create_test_storage_and_sm().await;
+        let (storage, sm, temp_dir) = create_test_storage_and_sm().await;
 
         let engine = Arc::new(
-            TestEngine::start_custom(storage, sm, None)
+            TestEngine::start_custom(temp_dir.path(), storage, sm, None)
                 .await
                 .expect("Failed to start engine"),
         );
@@ -1085,9 +1056,9 @@ listen_addr = "127.0.0.1:0"
     /// Business scenario: Monitoring dashboard polling cluster state every second
     #[tokio::test]
     async fn test_leader_info_consistency() {
-        let (storage, sm, _temp_dir) = create_test_storage_and_sm().await;
+        let (storage, sm, temp_dir) = create_test_storage_and_sm().await;
 
-        let engine = TestEngine::start_custom(storage, sm, None)
+        let engine = TestEngine::start_custom(temp_dir.path(), storage, sm, None)
             .await
             .expect("Failed to start engine");
 
@@ -1126,10 +1097,10 @@ listen_addr = "127.0.0.1:0"
     /// If this test hangs and times out, the regression is present.
     #[tokio::test]
     async fn test_linearizable_read_single_voter_returns_committed_value() {
-        let (storage, sm, _temp_dir) = create_test_storage_and_sm().await;
+        let (storage, sm, temp_dir) = create_test_storage_and_sm().await;
 
         // Start embedded engine (single node)
-        let engine = TestEngine::start_custom(storage, sm, None)
+        let engine = TestEngine::start_custom(temp_dir.path(), storage, sm, None)
             .await
             .expect("Failed to start engine");
 
@@ -1171,7 +1142,7 @@ mod unified_db_tests {
             r#"
 [cluster]
 node_id = 1
-db_root_dir = "{}"
+data_dir = "{}"
 
 [cluster.rpc]
 listen_addr = "127.0.0.1:0"
@@ -1199,7 +1170,7 @@ unified_db = {unified}
         let config_path = temp_dir.path().join("config.toml");
         std::fs::write(&config_path, make_config(temp_dir.path(), true)).expect("write config");
 
-        let engine = EmbeddedEngine::start_with(config_path.to_str().unwrap())
+        let engine = EmbeddedEngine::start_with(temp_dir.path(), config_path.to_str().unwrap())
             .await
             .expect("start_with(unified_db=true) must succeed");
 
@@ -1228,7 +1199,7 @@ unified_db = {unified}
 
         // --- Phase 1: write a key ---
         {
-            let engine = EmbeddedEngine::start_with(config_path.to_str().unwrap())
+            let engine = EmbeddedEngine::start_with(temp_dir.path(), config_path.to_str().unwrap())
                 .await
                 .expect("first start must succeed");
             engine.wait_ready(Duration::from_secs(5)).await.expect("leader election");
@@ -1244,7 +1215,7 @@ unified_db = {unified}
 
         // --- Phase 2: reopen and verify ---
         {
-            let engine = EmbeddedEngine::start_with(config_path.to_str().unwrap())
+            let engine = EmbeddedEngine::start_with(temp_dir.path(), config_path.to_str().unwrap())
                 .await
                 .expect("second start must succeed — DB lock must have been released");
             engine
@@ -1277,7 +1248,7 @@ unified_db = {unified}
 
         // --- Phase 1: write ---
         {
-            let engine = EmbeddedEngine::start_with(config_path.to_str().unwrap())
+            let engine = EmbeddedEngine::start_with(temp_dir.path(), config_path.to_str().unwrap())
                 .await
                 .expect("first start must succeed");
             engine.wait_ready(Duration::from_secs(5)).await.expect("leader election");
@@ -1289,7 +1260,7 @@ unified_db = {unified}
 
         // --- Phase 2: verify ---
         {
-            let engine = EmbeddedEngine::start_with(config_path.to_str().unwrap())
+            let engine = EmbeddedEngine::start_with(temp_dir.path(), config_path.to_str().unwrap())
                 .await
                 .expect("second start must succeed");
             engine

--- a/d-engine-server/src/api/embedded_test/embedded_test.rs
+++ b/d-engine-server/src/api/embedded_test/embedded_test.rs
@@ -350,10 +350,11 @@ mod embedded_engine_tests {
         #[tokio::test]
         #[serial(tmp_db)]
         async fn test_start_with_tmp_path_accepted() {
-            let tmp_path = std::path::PathBuf::from("/tmp/d-engine-test-start");
-            let _ = std::fs::remove_dir_all(&tmp_path);
+            let tmp_dir = tempfile::Builder::new()
+                .tempdir_in("/tmp")
+                .expect("Failed to create temp dir in /tmp");
 
-            let result = EmbeddedEngine::start(&tmp_path).await;
+            let result = EmbeddedEngine::start(tmp_dir.path()).await;
 
             assert!(
                 result.is_ok(),
@@ -364,7 +365,6 @@ mod embedded_engine_tests {
             if let Ok(engine) = result {
                 engine.stop().await.ok();
             }
-            let _ = std::fs::remove_dir_all(&tmp_path);
         }
 
         #[tokio::test]
@@ -450,7 +450,9 @@ election_timeout_max_ms = 3000
         async fn test_start_with_tmp_db_accepted() {
             let _temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
             let config_path = _temp_dir.path().join("test_config.toml");
-            let _ = std::fs::remove_dir_all("/tmp/db");
+            let tmp_db_dir = tempfile::Builder::new()
+                .tempdir_in("/tmp")
+                .expect("Failed to create temp dir in /tmp");
 
             let config_content = r#"
 [cluster]
@@ -461,17 +463,17 @@ listen_addr = "127.0.0.1:0"
 "#;
             std::fs::write(&config_path, config_content).expect("Failed to write config");
 
-            let result = EmbeddedEngine::start_with("/tmp/db", config_path.to_str().unwrap()).await;
+            let result =
+                EmbeddedEngine::start_with(tmp_db_dir.path(), config_path.to_str().unwrap()).await;
             assert!(
                 result.is_ok(),
-                "start_with() must accept /tmp/db: {:?}",
+                "start_with() must accept a /tmp path: {:?}",
                 result.err()
             );
 
             if let Ok(engine) = result {
                 engine.stop().await.ok();
             }
-            let _ = std::fs::remove_dir_all("/tmp/db");
         }
 
         #[tokio::test]

--- a/d-engine-server/src/api/standalone.rs
+++ b/d-engine-server/src/api/standalone.rs
@@ -136,10 +136,9 @@ impl StandaloneEngine {
     /// `config_path` is only for non-path settings (node_id, cluster topology, timeouts, etc.);
     /// any `data_dir` entry in the config file is ignored.
     ///
-    /// The data_dir lock is acquired before the node starts, but
-    /// `storage_engine`/`state_machine` are already constructed by the
-    /// caller by the time they're passed in. Callers must not open or use
-    /// `data_dir` themselves before calling this.
+    /// d-engine's data_dir lock only protects d-engine's own files.
+    /// `storage_engine`/`state_machine` are constructed by the caller;
+    /// their concurrency safety is the caller's responsibility.
     ///
     /// # Example
     /// ```ignore
@@ -173,6 +172,7 @@ impl StandaloneEngine {
     ///
     /// For library wrappers that build their own config layer and
     /// translate to `RaftNodeConfig` in Rust — no config file required.
+    /// Same lock scope as [`run_custom`](Self::run_custom) — see its doc.
     ///
     /// Blocks until `shutdown_rx` receives a signal.
     pub async fn start_node<SE, SM>(
@@ -241,6 +241,11 @@ impl StandaloneEngine {
             .state_machine(state_machine);
         if let Some(lock) = data_dir_lock {
             builder = builder.data_dir_lock(lock);
+        } else {
+            tracing::warn!(
+                "storage_engine/state_machine were built before d-engine's data_dir \
+                 lock — their concurrency safety is the caller's responsibility"
+            );
         }
         let node = builder.start().await?;
         node.run().await

--- a/d-engine-server/src/api/standalone.rs
+++ b/d-engine-server/src/api/standalone.rs
@@ -21,16 +21,8 @@ pub struct StandaloneEngine;
 impl StandaloneEngine {
     /// Run server with an explicit data directory.
     ///
-    /// `data_dir` has highest priority and always overrides `cluster.db_root_dir` from
-    /// `CONFIG_PATH` or `RAFT__` environment variables. Other configuration (network,
-    /// Raft timeouts, cluster topology) is still read from those sources if set.
-    ///
     /// The directory is created automatically if it does not exist.
     /// Blocks until shutdown signal is received.
-    ///
-    /// # Arguments
-    /// * `data_dir` - Path to the data directory
-    /// * `shutdown_rx` - Shutdown signal receiver
     ///
     /// # Example
     /// ```ignore
@@ -42,17 +34,15 @@ impl StandaloneEngine {
         data_dir: impl AsRef<std::path::Path>,
         shutdown_rx: watch::Receiver<()>,
     ) -> Result<()> {
-        let mut config = d_engine_core::RaftNodeConfig::new()?;
-        config.cluster.db_root_dir = data_dir.as_ref().to_path_buf();
-        let config = config.validate()?;
-        let base_dir = config.cluster.db_root_dir.clone();
-
-        tokio::fs::create_dir_all(&base_dir)
-            .await
-            .map_err(|e| crate::Error::Fatal(format!("Failed to create data directory: {e}")))?;
+        let config = d_engine_core::RaftNodeConfig::new()?.validate()?;
+        let data_dir = crate::node::DataDir::new(data_dir.as_ref())?;
+        // Lock before touching storage — otherwise two racing processes both
+        // get partway into opening the same RocksDB directory before either
+        // one even checks this lock.
+        let data_dir_lock = crate::node::DataDirLock::acquire(data_dir.as_path())?;
 
         let (storage, mut sm) = if config.storage.unified_db {
-            let db_path = base_dir.join("db");
+            let db_path = data_dir.unified_db_path()?;
             tracing::info!(
                 "Starting standalone server with unified RocksDB at {:?}",
                 db_path
@@ -61,10 +51,10 @@ impl StandaloneEngine {
         } else {
             tracing::info!(
                 "Starting standalone server with separate RocksDB instances at {:?}",
-                base_dir
+                data_dir.as_path()
             );
-            let storage = RocksDBStorageEngine::new(base_dir.join("storage"))?;
-            let sm = RocksDBStateMachine::new(base_dir.join("state_machine"))?;
+            let storage = RocksDBStorageEngine::new(data_dir.storage_path()?)?;
+            let sm = RocksDBStateMachine::new(data_dir.state_machine_path()?)?;
             (storage, sm)
         };
 
@@ -73,40 +63,40 @@ impl StandaloneEngine {
         ));
         sm.set_lease(lease);
 
-        Self::start_node(config, Arc::new(storage), Arc::new(sm), shutdown_rx).await
+        Self::start_node_with_lock(
+            data_dir.as_path().to_path_buf(),
+            data_dir_lock,
+            Arc::new(storage),
+            Arc::new(sm),
+            shutdown_rx,
+            config,
+        )
+        .await
     }
 
-    /// Run server with explicit configuration file.
-    ///
-    /// Reads configuration from specified file path.
-    /// Data directory is determined by config's `cluster.db_root_dir` setting.
-    /// Blocks until shutdown signal is received.
-    ///
-    /// # Arguments
-    /// * `config_path` - Path to configuration file
-    /// * `shutdown_rx` - Shutdown signal receiver
+    /// Run server with an explicit data directory plus a config file for
+    /// everything else (a `[cluster] data_dir` entry in the file, if
+    /// present, is ignored). Blocks until shutdown signal is received.
     ///
     /// # Example
     /// ```ignore
     /// let (shutdown_tx, shutdown_rx) = watch::channel(());
-    /// StandaloneEngine::run_with("config/node1.toml", shutdown_rx).await?;
+    /// StandaloneEngine::run_with("./data/my-node", "config/node1.toml", shutdown_rx).await?;
     /// ```
     #[cfg(feature = "rocksdb")]
     pub async fn run_with(
+        data_dir: impl AsRef<std::path::Path>,
         config_path: impl AsRef<std::path::Path>,
         shutdown_rx: watch::Receiver<()>,
     ) -> Result<()> {
         let config = d_engine_core::RaftNodeConfig::new()?
             .with_override_config(config_path)?
             .validate()?;
-        let base_dir = std::path::PathBuf::from(&config.cluster.db_root_dir);
-
-        tokio::fs::create_dir_all(&base_dir)
-            .await
-            .map_err(|e| crate::Error::Fatal(format!("Failed to create data directory: {e}")))?;
+        let data_dir = crate::node::DataDir::new(data_dir.as_ref())?;
+        let data_dir_lock = crate::node::DataDirLock::acquire(data_dir.as_path())?;
 
         let (storage, mut sm) = if config.storage.unified_db {
-            let db_path = base_dir.join("db");
+            let db_path = data_dir.unified_db_path()?;
             tracing::info!(
                 "Starting standalone server with unified RocksDB at {:?}",
                 db_path
@@ -115,10 +105,10 @@ impl StandaloneEngine {
         } else {
             tracing::info!(
                 "Starting standalone server with separate RocksDB instances at {:?}",
-                base_dir
+                data_dir.as_path()
             );
-            let storage = RocksDBStorageEngine::new(base_dir.join("storage"))?;
-            let sm = RocksDBStateMachine::new(base_dir.join("state_machine"))?;
+            let storage = RocksDBStorageEngine::new(data_dir.storage_path()?)?;
+            let sm = RocksDBStateMachine::new(data_dir.state_machine_path()?)?;
             (storage, sm)
         };
 
@@ -127,19 +117,29 @@ impl StandaloneEngine {
         ));
         sm.set_lease(lease);
 
-        Self::start_node(config, Arc::new(storage), Arc::new(sm), shutdown_rx).await
+        // start_node_with_lock directly — config already loaded/validated,
+        // lock already held.
+        Self::start_node_with_lock(
+            data_dir.as_path().to_path_buf(),
+            data_dir_lock,
+            Arc::new(storage),
+            Arc::new(sm),
+            shutdown_rx,
+            config,
+        )
+        .await
     }
 
-    /// Run server with custom storage engine and state machine.
+    /// Runs the server with a custom storage engine and state machine.
     ///
-    /// Advanced API for users providing custom storage implementations.
-    /// Blocks until shutdown signal is received.
+    /// Blocks until `shutdown_rx` receives a signal. `data_dir` is required and explicit —
+    /// `config_path` is only for non-path settings (node_id, cluster topology, timeouts, etc.);
+    /// any `data_dir` entry in the config file is ignored.
     ///
-    /// # Arguments
-    /// * `storage_engine` - Custom storage engine implementation
-    /// * `state_machine` - Custom state machine implementation
-    /// * `shutdown_rx` - Shutdown signal receiver
-    /// * `config` - config_path - Optional path to configuration file
+    /// The data_dir lock is acquired before the node starts, but
+    /// `storage_engine`/`state_machine` are already constructed by the
+    /// caller by the time they're passed in. Callers must not open or use
+    /// `data_dir` themselves before calling this.
     ///
     /// # Example
     /// ```ignore
@@ -147,9 +147,10 @@ impl StandaloneEngine {
     /// let sm = Arc::new(MyCustomStateMachine::new()?);
     ///
     /// let (shutdown_tx, shutdown_rx) = watch::channel(());
-    /// StandaloneEngine::run_custom(storage, sm, shutdown_rx, Some("config.toml")).await?;
+    /// StandaloneEngine::run_custom("./data/my-node", storage, sm, shutdown_rx, Some("config.toml")).await?;
     /// ```
     pub async fn run_custom<SE, SM>(
+        data_dir: impl AsRef<std::path::Path>,
         storage_engine: Arc<SE>,
         state_machine: Arc<SM>,
         shutdown_rx: watch::Receiver<()>,
@@ -160,13 +161,12 @@ impl StandaloneEngine {
         SM: StateMachine + std::fmt::Debug + 'static,
     {
         let config = if let Some(path) = config_path {
-            d_engine_core::RaftNodeConfig::default()
-                .with_override_config(path)?
-                .validate()?
+            d_engine_core::RaftNodeConfig::default().with_override_config(path)?
         } else {
-            d_engine_core::RaftNodeConfig::new()?.validate()?
+            d_engine_core::RaftNodeConfig::new()?
         };
-        Self::start_node(config, storage_engine, state_machine, shutdown_rx).await
+        let config = config.validate()?;
+        Self::start_node(data_dir, storage_engine, state_machine, shutdown_rx, config).await
     }
 
     /// Start standalone server with custom storage, state machine, and programmatic config.
@@ -176,20 +176,73 @@ impl StandaloneEngine {
     ///
     /// Blocks until `shutdown_rx` receives a signal.
     pub async fn start_node<SE, SM>(
-        config: d_engine_core::RaftNodeConfig,
+        data_dir: impl AsRef<std::path::Path>,
         storage_engine: Arc<SE>,
         state_machine: Arc<SM>,
         shutdown_rx: watch::Receiver<()>,
+        config: d_engine_core::RaftNodeConfig,
     ) -> Result<()>
     where
         SE: StorageEngine + std::fmt::Debug + 'static,
         SM: StateMachine + std::fmt::Debug + 'static,
     {
-        let node = NodeBuilder::init(config.validate()?, shutdown_rx)
+        Self::start_node_inner(
+            data_dir.as_ref().to_path_buf(),
+            None,
+            storage_engine,
+            state_machine,
+            shutdown_rx,
+            config,
+        )
+        .await
+    }
+
+    /// Same as `start_node`, but for callers (`run`/`run_with`) that already
+    /// opened storage and therefore must have acquired the lock *before*
+    /// that — see `NodeBuilder::data_dir_lock`'s doc comment.
+    #[allow(dead_code)]
+    async fn start_node_with_lock<SE, SM>(
+        data_dir: std::path::PathBuf,
+        data_dir_lock: crate::node::DataDirLock,
+        storage_engine: Arc<SE>,
+        state_machine: Arc<SM>,
+        shutdown_rx: watch::Receiver<()>,
+        config: d_engine_core::RaftNodeConfig,
+    ) -> Result<()>
+    where
+        SE: StorageEngine + std::fmt::Debug + 'static,
+        SM: StateMachine + std::fmt::Debug + 'static,
+    {
+        Self::start_node_inner(
+            data_dir,
+            Some(data_dir_lock),
+            storage_engine,
+            state_machine,
+            shutdown_rx,
+            config,
+        )
+        .await
+    }
+
+    async fn start_node_inner<SE, SM>(
+        data_dir: std::path::PathBuf,
+        data_dir_lock: Option<crate::node::DataDirLock>,
+        storage_engine: Arc<SE>,
+        state_machine: Arc<SM>,
+        shutdown_rx: watch::Receiver<()>,
+        config: d_engine_core::RaftNodeConfig,
+    ) -> Result<()>
+    where
+        SE: StorageEngine + std::fmt::Debug + 'static,
+        SM: StateMachine + std::fmt::Debug + 'static,
+    {
+        let mut builder = NodeBuilder::init(data_dir, config.validate()?, shutdown_rx)
             .storage_engine(storage_engine)
-            .state_machine(state_machine)
-            .start()
-            .await?;
+            .state_machine(state_machine);
+        if let Some(lock) = data_dir_lock {
+            builder = builder.data_dir_lock(lock);
+        }
+        let node = builder.start().await?;
         node.run().await
     }
 }

--- a/d-engine-server/src/api/standalone_test.rs
+++ b/d-engine-server/src/api/standalone_test.rs
@@ -35,10 +35,10 @@ mod standalone_server_tests {
         assert!(result.is_ok(), "run() should succeed: {:?}", result.err());
     }
 
-    /// /tmp data_dir emits a warning but is not rejected.
+    /// A /tmp data_dir is a legitimate explicit choice — d-engine does not judge it.
     #[tokio::test]
     #[serial(tmp_db)]
-    async fn test_run_tmp_path_warns_but_succeeds() {
+    async fn test_run_tmp_path_accepted() {
         let tmp_path = std::path::PathBuf::from("/tmp/d-engine-standalone-test");
         let _ = std::fs::remove_dir_all(&tmp_path);
 
@@ -56,17 +56,17 @@ mod standalone_server_tests {
             .expect("server task must not panic");
         assert!(
             result.is_ok(),
-            "/tmp path should succeed with warning: {:?}",
+            "/tmp path must be accepted: {:?}",
             result.err()
         );
 
         let _ = std::fs::remove_dir_all(&tmp_path);
     }
 
-    /// data_dir overrides cluster.db_root_dir set in CONFIG_PATH.
+    /// data_dir overrides cluster.data_dir set in CONFIG_PATH.
     #[tokio::test]
     #[serial]
-    async fn test_run_data_dir_overrides_config_path_db_root_dir() {
+    async fn test_run_data_dir_overrides_config_path_data_dir() {
         let temp_dir = tempfile::tempdir().expect("tempdir");
         let config_data_dir = temp_dir.path().join("from-config");
         let explicit_data_dir = temp_dir.path().join("from-arg");
@@ -75,7 +75,7 @@ mod standalone_server_tests {
         std::fs::write(
             &config_path,
             format!(
-                "[cluster]\ndb_root_dir = \"{}\"\n[cluster.rpc]\nlisten_addr = \"127.0.0.1:0\"\n",
+                "[cluster]\ndata_dir = \"{}\"\n[cluster.rpc]\nlisten_addr = \"127.0.0.1:0\"\n",
                 config_data_dir.display()
             ),
         )
@@ -130,7 +130,7 @@ mod standalone_server_tests {
             &config_path,
             format!(
                 concat!(
-                    "[cluster]\nnode_id = 1\ndb_root_dir = \"{}\"\n\n",
+                    "[cluster]\nnode_id = 1\ndata_dir = \"{}\"\n\n",
                     "[cluster.rpc]\nlisten_addr = \"127.0.0.1:0\"\n\n",
                     "[raft]\nheartbeat_idle_flush_interval_ms = 500\n",
                     "election_timeout_min_ms = 1500\nelection_timeout_max_ms = 3000\n"
@@ -142,10 +142,9 @@ mod standalone_server_tests {
 
         let (shutdown_tx, shutdown_rx) = watch::channel(());
         let config_path_str = config_path.to_str().unwrap().to_string();
-        let handle =
-            tokio::spawn(
-                async move { StandaloneEngine::run_with(&config_path_str, shutdown_rx).await },
-            );
+        let handle = tokio::spawn(async move {
+            StandaloneEngine::run_with(&data_dir, &config_path_str, shutdown_rx).await
+        });
 
         tokio::time::sleep(Duration::from_millis(100)).await;
         shutdown_tx.send(()).ok();
@@ -162,18 +161,21 @@ mod standalone_server_tests {
 
     #[tokio::test]
     async fn test_run_with_nonexistent_config() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
         let (_shutdown_tx, shutdown_rx) = watch::channel(());
-        let result = StandaloneEngine::run_with("/nonexistent/config.toml", shutdown_rx).await;
+        let result =
+            StandaloneEngine::run_with(temp_dir.path(), "/nonexistent/config.toml", shutdown_rx)
+                .await;
         assert!(
             result.is_err(),
             "run_with() should fail with nonexistent config"
         );
     }
 
-    /// run_with() with a /tmp db_root_dir emits a warning but is not rejected.
+    /// run_with() with a /tmp data_dir is accepted — it's a legitimate explicit choice.
     #[tokio::test]
     #[serial(tmp_db)]
-    async fn test_run_with_tmp_db_warns_but_succeeds() {
+    async fn test_run_with_tmp_db_accepted() {
         let temp_dir = tempfile::tempdir().expect("tempdir");
         let config_path = temp_dir.path().join("config.toml");
         let tmp_db = "/tmp/d-engine-standalone-runwith-test";
@@ -181,18 +183,16 @@ mod standalone_server_tests {
 
         std::fs::write(
             &config_path,
-            format!(
-                "[cluster]\nnode_id = 1\ndb_root_dir = \"{tmp_db}\"\n\n[cluster.rpc]\nlisten_addr = \"127.0.0.1:0\"\n"
-            ),
+            "[cluster]\nnode_id = 1\n\n[cluster.rpc]\nlisten_addr = \"127.0.0.1:0\"\n",
         )
         .expect("write config");
 
         let (shutdown_tx, shutdown_rx) = watch::channel(());
         let config_path_str = config_path.to_str().unwrap().to_string();
-        let handle =
-            tokio::spawn(
-                async move { StandaloneEngine::run_with(&config_path_str, shutdown_rx).await },
-            );
+        let tmp_db_string = tmp_db.to_string();
+        let handle = tokio::spawn(async move {
+            StandaloneEngine::run_with(&tmp_db_string, &config_path_str, shutdown_rx).await
+        });
 
         tokio::time::sleep(Duration::from_millis(100)).await;
         shutdown_tx.send(()).ok();
@@ -203,7 +203,7 @@ mod standalone_server_tests {
             .expect("server task must not panic");
         assert!(
             result.is_ok(),
-            "/tmp path should succeed with warning: {:?}",
+            "/tmp path must be accepted: {:?}",
             result.err()
         );
 
@@ -218,19 +218,16 @@ mod standalone_server_tests {
 
         std::fs::write(
             &config_path,
-            format!(
-                "[cluster]\nnode_id = 1\ndb_root_dir = \"{}\"\n\n[cluster.rpc]\nlisten_addr = \"127.0.0.1:0\"\n",
-                data_dir.display()
-            ),
+            "[cluster]\nnode_id = 1\n\n[cluster.rpc]\nlisten_addr = \"127.0.0.1:0\"\n",
         )
         .expect("write config");
 
         let (shutdown_tx, shutdown_rx) = watch::channel(());
         let config_path_str = config_path.to_str().unwrap().to_string();
-        let handle =
-            tokio::spawn(
-                async move { StandaloneEngine::run_with(&config_path_str, shutdown_rx).await },
-            );
+        let data_dir_str = data_dir.to_str().unwrap().to_string();
+        let handle = tokio::spawn(async move {
+            StandaloneEngine::run_with(&data_dir_str, &config_path_str, shutdown_rx).await
+        });
 
         tokio::time::sleep(Duration::from_millis(100)).await;
         shutdown_tx.send(()).expect("send shutdown");
@@ -263,11 +260,8 @@ mod start_node_tests {
     use crate::api::StandaloneEngine;
     use crate::storage::TtlLease;
 
-    /// Build a minimal valid `RaftNodeConfig` backed by a temp directory.
-    fn make_config(
-        temp_dir: &tempfile::TempDir,
-        node_id: u32,
-    ) -> d_engine_core::RaftNodeConfig {
+    /// Build a minimal valid `RaftNodeConfig`.
+    fn make_config(node_id: u32) -> d_engine_core::RaftNodeConfig {
         let listen_addr: SocketAddr = "127.0.0.1:19732".parse().unwrap();
         d_engine_core::RaftNodeConfig {
             cluster: ClusterConfig {
@@ -279,8 +273,6 @@ mod start_node_tests {
                     role: NodeRole::Follower as i32,
                     status: NodeStatus::Active.into(),
                 }],
-                db_root_dir: temp_dir.path().join("engine"),
-                log_dir: temp_dir.path().join("logs"),
             },
             ..Default::default()
         }
@@ -313,16 +305,17 @@ mod start_node_tests {
     async fn test_start_node_with_programmatic_config_starts_and_stops() {
         let temp_dir = tempfile::tempdir().expect("tempdir");
         let (storage, sm) = create_rocksdb_se_and_sm(&temp_dir);
-        let config = make_config(&temp_dir, 1);
+        let config = make_config(1);
         let storage_path = temp_dir.path().join("storage");
         let sm_path = temp_dir.path().join("sm");
 
         let (shutdown_tx, shutdown_rx) = watch::channel(());
         let handle = tokio::spawn(StandaloneEngine::start_node(
-            config,
+            temp_dir.path().join("engine"),
             storage,
             sm,
             shutdown_rx,
+            config,
         ));
 
         tokio::time::sleep(Duration::from_millis(200)).await;
@@ -359,9 +352,16 @@ mod start_node_tests {
         let temp_dir = tempfile::tempdir().expect("tempdir");
         let (storage, sm) = create_rocksdb_se_and_sm(&temp_dir);
         let (_shutdown_tx, shutdown_rx) = watch::channel(());
-        let config = make_config(&temp_dir, 0); // node_id=0 triggers validation error
+        let config = make_config(0); // node_id=0 triggers validation error
 
-        let result = StandaloneEngine::start_node(config, storage, sm, shutdown_rx).await;
+        let result = StandaloneEngine::start_node(
+            temp_dir.path().join("engine"),
+            storage,
+            sm,
+            shutdown_rx,
+            config,
+        )
+        .await;
         assert!(
             result.is_err(),
             "start_node with node_id=0 must return validation error"
@@ -384,14 +384,15 @@ mod start_node_tests {
         sm.set_lease(Arc::new(TtlLease::new(Default::default())));
         let sm = Arc::new(sm);
 
-        let config = make_config(&temp_dir, 1);
+        let config = make_config(1);
 
         let (shutdown_tx, shutdown_rx) = watch::channel(());
         let handle = tokio::spawn(StandaloneEngine::start_node(
-            config,
+            temp_dir.path().join("engine"),
             storage,
             sm,
             shutdown_rx,
+            config,
         ));
 
         tokio::time::sleep(Duration::from_millis(200)).await;
@@ -454,7 +455,7 @@ mod run_custom_tests {
             &config_path,
             format!(
                 concat!(
-                    "[cluster]\nnode_id = {node_id}\ndb_root_dir = \"{data_dir}\"\n\n",
+                    "[cluster]\nnode_id = {node_id}\ndata_dir = \"{data_dir}\"\n\n",
                     "[cluster.rpc]\nlisten_addr = \"127.0.0.1:19733\"\n\n",
                     "[raft]\nheartbeat_idle_flush_interval_ms = 500\n",
                     "election_timeout_min_ms = 1500\nelection_timeout_max_ms = 3000\n"
@@ -501,6 +502,7 @@ mod run_custom_tests {
         let (shutdown_tx, shutdown_rx) = watch::channel(());
         let config_path_str = config_path.to_str().unwrap().to_string();
         let handle = tokio::spawn(StandaloneEngine::run_custom(
+            temp_dir.path().to_path_buf(),
             storage,
             sm,
             shutdown_rx,
@@ -518,25 +520,21 @@ mod run_custom_tests {
         unsafe { std::env::remove_var("CONFIG_PATH") };
 
         let temp_dir = tempfile::tempdir().expect("tempdir");
-        // Use a persistent path so default /tmp/db gets a real dir
         let (storage, sm) = create_rocksdb_se_and_sm(&temp_dir);
-        // Override db_root_dir via env so default config points to our temp dir
-        unsafe {
-            std::env::set_var(
-                "RAFT__CLUSTER__DB_ROOT_DIR",
-                temp_dir.path().join("db").to_str().unwrap(),
-            );
-        }
 
         let (shutdown_tx, shutdown_rx) = watch::channel(());
         let handle = tokio::spawn(StandaloneEngine::run_custom::<
             RocksDBStorageEngine,
             RocksDBStateMachine,
-        >(storage, sm, shutdown_rx, None::<&str>));
+        >(
+            temp_dir.path().to_path_buf(),
+            storage,
+            sm,
+            shutdown_rx,
+            None::<&str>,
+        ));
 
         shutdown_and_assert(shutdown_tx, handle, 300, "run_custom without config").await;
-
-        unsafe { std::env::remove_var("RAFT__CLUSTER__DB_ROOT_DIR") };
     }
 
     /// `run_custom` with a nonexistent config file path must return an error.
@@ -548,6 +546,7 @@ mod run_custom_tests {
         let (_shutdown_tx, shutdown_rx) = watch::channel(());
 
         let result = StandaloneEngine::run_custom(
+            temp_dir.path(),
             storage,
             sm,
             shutdown_rx,
@@ -570,8 +569,14 @@ mod run_custom_tests {
         let (_shutdown_tx, shutdown_rx) = watch::channel(());
 
         let config_path_str = config_path.to_str().unwrap().to_string();
-        let result =
-            StandaloneEngine::run_custom(storage, sm, shutdown_rx, Some(config_path_str)).await;
+        let result = StandaloneEngine::run_custom(
+            temp_dir.path(),
+            storage,
+            sm,
+            shutdown_rx,
+            Some(config_path_str),
+        )
+        .await;
         assert!(
             result.is_err(),
             "run_custom with node_id=0 must return validation error"
@@ -592,15 +597,11 @@ mod unified_db_tests {
 
     use crate::api::StandaloneEngine;
 
-    fn make_config(
-        data_dir: &std::path::Path,
-        unified: bool,
-    ) -> String {
+    fn make_config(unified: bool) -> String {
         format!(
             r#"
 [cluster]
 node_id = 1
-db_root_dir = "{}"
 
 [cluster.rpc]
 listen_addr = "127.0.0.1:0"
@@ -612,8 +613,7 @@ election_timeout_max_ms = 3000
 
 [storage]
 unified_db = {unified}
-"#,
-            data_dir.display()
+"#
         )
     }
 
@@ -627,15 +627,16 @@ unified_db = {unified}
     async fn test_run_with_unified_db_starts_and_shuts_down_cleanly() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let config_path = temp_dir.path().join("config.toml");
-        std::fs::write(&config_path, make_config(temp_dir.path(), true)).expect("write config");
+        std::fs::write(&config_path, make_config(true)).expect("write config");
+        let data_dir = temp_dir.path().join("engine");
 
         let (shutdown_tx, shutdown_rx) = watch::channel(());
 
         let config_path_str = config_path.to_str().unwrap().to_string();
-        let handle =
-            tokio::spawn(
-                async move { StandaloneEngine::run_with(&config_path_str, shutdown_rx).await },
-            );
+        let data_dir_str = data_dir.to_str().unwrap().to_string();
+        let handle = tokio::spawn(async move {
+            StandaloneEngine::run_with(&data_dir_str, &config_path_str, shutdown_rx).await
+        });
 
         // Give the server enough time to open RocksDB and start the Raft loop.
         tokio::time::sleep(Duration::from_millis(200)).await;
@@ -663,15 +664,16 @@ unified_db = {unified}
     async fn test_run_with_separate_db_starts_and_shuts_down_cleanly() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let config_path = temp_dir.path().join("config.toml");
-        std::fs::write(&config_path, make_config(temp_dir.path(), false)).expect("write config");
+        std::fs::write(&config_path, make_config(false)).expect("write config");
+        let data_dir = temp_dir.path().join("engine");
 
         let (shutdown_tx, shutdown_rx) = watch::channel(());
 
         let config_path_str = config_path.to_str().unwrap().to_string();
-        let handle =
-            tokio::spawn(
-                async move { StandaloneEngine::run_with(&config_path_str, shutdown_rx).await },
-            );
+        let data_dir_str = data_dir.to_str().unwrap().to_string();
+        let handle = tokio::spawn(async move {
+            StandaloneEngine::run_with(&data_dir_str, &config_path_str, shutdown_rx).await
+        });
 
         tokio::time::sleep(Duration::from_millis(200)).await;
 

--- a/d-engine-server/src/lib.rs
+++ b/d-engine-server/src/lib.rs
@@ -106,7 +106,8 @@ mod read_actor_test;
 
 /// Node lifecycle management
 ///
-/// Contains [`Node`] and [`NodeBuilder`] for server setup.
+/// Contains [`Node`], the Raft consensus participant. Built internally by
+/// [`EmbeddedEngine`](crate::EmbeddedEngine)/[`StandaloneEngine`](crate::StandaloneEngine).
 pub mod node;
 
 /// Public API layer for different deployment modes
@@ -177,7 +178,6 @@ pub use d_engine_core::client::{ClientApi, ClientApiError, ClientApiResult};
 /// Implement this trait to create your own storage engine.
 pub use d_engine_core::{StateMachine, StorageEngine};
 pub use node::Node;
-pub use node::NodeBuilder;
 // Re-export storage implementations
 pub use storage::{FileStateMachine, FileStorageEngine};
 // Re-export core types needed by applications

--- a/d-engine-server/src/network/grpc/grpc_raft_service_test.rs
+++ b/d-engine-server/src/network/grpc/grpc_raft_service_test.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 use std::time::Duration;
 
 use crate::ApplyResult;
@@ -187,16 +186,10 @@ async fn test_server_is_not_ready() {
 #[traced_test]
 async fn test_handle_rpc_services_successfully() {
     tokio::time::pause();
-    let mut settings = RaftNodeConfig::new()
-        .expect("Should succeed to init RaftNodeConfig.")
-        .validate()
-        .expect("Validate RaftNodeConfig successfully");
+    let settings = RaftNodeConfig::new().expect("Should succeed to init RaftNodeConfig.");
+    let mut settings = settings.validate().expect("Validate RaftNodeConfig successfully");
     settings.raft.general_raft_timeout_duration_in_ms = 200;
     settings.raft.batching.max_batch_size = 1;
-    settings.cluster.db_root_dir = PathBuf::from(
-        "/tmp/
-    test_handle_rpc_services_successfully",
-    );
     let mut membership = MockMembership::<MockTypeConfig>::new();
 
     membership.expect_voters().returning(Vec::new);

--- a/d-engine-server/src/network/grpc/grpc_transport_test.rs
+++ b/d-engine-server/src/network/grpc/grpc_transport_test.rs
@@ -35,10 +35,12 @@ use crate::test_utils::MockRpcService;
 use crate::test_utils::create_test_chunk;
 use crate::test_utils::create_test_snapshot_stream;
 
-fn node_config(db_path: &str) -> RaftNodeConfig {
-    let mut s = RaftNodeConfig::new().expect("RaftNodeConfig should be inited successfully");
-    s.cluster.db_root_dir = std::path::PathBuf::from(db_path);
-    s.validate().expect("RaftNodeConfig should be validated successfully")
+/// `db_path` is unused — data_dir isn't a `d-engine-core` concept anymore (see #9).
+fn node_config(_db_path: &str) -> RaftNodeConfig {
+    RaftNodeConfig::new()
+        .expect("RaftNodeConfig should be inited successfully")
+        .validate()
+        .expect("RaftNodeConfig should be validated successfully")
 }
 
 fn mock_membership(

--- a/d-engine-server/src/node/builder.rs
+++ b/d-engine-server/src/node/builder.rs
@@ -125,6 +125,7 @@ where
     /// Creates a new NodeBuilder with cluster configuration loaded from file
     ///
     /// # Arguments
+    /// * `data_dir` - Node data directory
     /// * `cluster_path` - Optional path to node-specific cluster configuration
     /// * `shutdown_signal` - Watch channel for graceful shutdown signaling
     ///
@@ -166,13 +167,14 @@ where
     /// file or environment variables are present.
     ///
     /// # Arguments
+    /// * `data_dir` - Node data directory
     /// * `node_config` - Fully assembled and validated node configuration
     /// * `shutdown_signal` - Watch channel for graceful shutdown signaling
     ///
     /// # Usage
     /// ```ignore
     /// let config: RaftNodeConfig = /* build and validate your config */;
-    /// let builder = NodeBuilder::from_node_config(config, shutdown_rx);
+    /// let builder = NodeBuilder::from_node_config("./data/my-node", config, shutdown_rx);
     /// ```
     ///
     /// Test-only: production code always goes through `init()`.
@@ -806,8 +808,7 @@ where
 
     /// Test constructor with custom database path
     ///
-    /// # Safety
-    /// Bypasses normal configuration validation - use for testing only
+    /// Test-only helper using the default validated node configuration.
     #[cfg(test)]
     pub(crate) fn new_from_db_path(
         db_path: &str,

--- a/d-engine-server/src/node/builder.rs
+++ b/d-engine-server/src/node/builder.rs
@@ -29,7 +29,6 @@
 //!   config.
 
 use crate::read_actor::run_read_actor;
-use d_engine_core::ClusterConfig;
 use d_engine_core::CommitHandler;
 use d_engine_core::CommitHandlerDependencies;
 use d_engine_core::DefaultCommitHandler;
@@ -40,7 +39,6 @@ use d_engine_core::InternalEvent;
 use d_engine_core::LogSizePolicy;
 use d_engine_core::NewCommitData;
 use d_engine_core::Raft;
-use d_engine_core::RaftConfig;
 use d_engine_core::RaftCoreHandlers;
 use d_engine_core::RaftLog;
 use d_engine_core::RaftNodeConfig;
@@ -95,7 +93,7 @@ use crate::storage::BufferedRaftLog;
 ///     .state_machine(Arc::new(FileStateMachine::new(...).await?))
 ///     .start().await?;
 /// ```
-pub struct NodeBuilder<SE, SM>
+pub(crate) struct NodeBuilder<SE, SM>
 where
     SE: StorageEngine + Debug,
     SM: StateMachine + Debug,
@@ -110,6 +108,11 @@ where
     pub(super) state_machine_handler: Option<Arc<SMHOF<RaftTypeConfig<SE, SM>>>>,
     pub(super) snapshot_policy: Option<SNP<RaftTypeConfig<SE, SM>>>,
     pub(super) shutdown_signal: watch::Receiver<()>,
+
+    pub(super) data_dir: std::path::PathBuf,
+    /// Pre-acquired lock, for callers that must open storage before
+    /// NodeBuilder ever runs — see `data_dir_lock()`'s doc comment.
+    pub(super) data_dir_lock: Option<super::DataDirLock>,
 
     pub(super) node: Option<Arc<Node<RaftTypeConfig<SE, SM>>>>,
 }
@@ -128,7 +131,11 @@ where
     /// # Panics
     /// Will panic if configuration loading fails (consider returning Result
     /// instead)
+    ///
+    /// Test-only: production code always goes through `init()`.
+    #[cfg(test)]
     pub fn new(
+        data_dir: impl Into<std::path::PathBuf>,
         cluster_path: Option<&str>,
         shutdown_signal: watch::Receiver<()>,
     ) -> Self {
@@ -147,27 +154,7 @@ where
                 .expect("Validate node_config successfully")
         };
 
-        Self::init(node_config, shutdown_signal)
-    }
-
-    /// Constructs NodeBuilder from in-memory cluster configuration
-    ///
-    /// # Arguments
-    /// * `cluster_config` - Pre-built cluster configuration
-    /// * `shutdown_signal` - Graceful shutdown notification channel
-    ///
-    /// # Usage
-    /// ```ignore
-    /// let builder = NodeBuilder::from_cluster_config(my_config, shutdown_rx);
-    /// ```
-    pub fn from_cluster_config(
-        cluster_config: ClusterConfig,
-        shutdown_signal: watch::Receiver<()>,
-    ) -> Self {
-        let mut node_config = RaftNodeConfig::new().expect("Load node_config successfully");
-        node_config.cluster = cluster_config;
-        let node_config = node_config.validate().expect("Validate node_config successfully");
-        Self::init(node_config, shutdown_signal)
+        Self::init(data_dir, node_config, shutdown_signal)
     }
 
     /// Constructs NodeBuilder from a fully-built [`RaftNodeConfig`].
@@ -187,15 +174,20 @@ where
     /// let config: RaftNodeConfig = /* build and validate your config */;
     /// let builder = NodeBuilder::from_node_config(config, shutdown_rx);
     /// ```
+    ///
+    /// Test-only: production code always goes through `init()`.
+    #[cfg(test)]
     pub fn from_node_config(
+        data_dir: impl Into<std::path::PathBuf>,
         node_config: RaftNodeConfig,
         shutdown_signal: watch::Receiver<()>,
     ) -> Self {
-        Self::init(node_config, shutdown_signal)
+        Self::init(data_dir, node_config, shutdown_signal)
     }
 
     /// Core initialization logic shared by all construction paths
     pub(crate) fn init(
+        data_dir: impl Into<std::path::PathBuf>,
         node_config: RaftNodeConfig,
         shutdown_signal: watch::Receiver<()>,
     ) -> Self {
@@ -209,6 +201,8 @@ where
             shutdown_signal,
             state_machine_handler: None,
             snapshot_policy: None,
+            data_dir: data_dir.into(),
+            data_dir_lock: None,
             node: None,
         }
     }
@@ -231,7 +225,10 @@ where
         self
     }
 
-    /// Replaces the entire node configuration
+    /// Replaces the entire node configuration.
+    ///
+    /// Test-only: production code always goes through `init()`.
+    #[cfg(test)]
     pub fn node_config(
         mut self,
         node_config: RaftNodeConfig,
@@ -241,12 +238,25 @@ where
         self
     }
 
-    /// Replaces the raft  configuration
-    pub fn raft_config(
+    /// Supplies a pre-acquired data_dir lock. For callers that must open
+    /// storage (e.g. RocksDB) *before* NodeBuilder ever runs — the lock has
+    /// to be acquired before that happens, not after, or two racing
+    /// processes both get partway into opening the same storage directory
+    /// before either one even checks this lock.
+    ///
+    /// If unset, `build()` acquires its own lock — this stays the default
+    /// so NodeBuilder remains the guaranteed choke point for every path
+    /// that doesn't pre-open storage itself (`start_custom`, `run_custom`,
+    /// direct `NodeBuilder` use).
+    ///
+    /// Crate-private: `DataDirLock` itself isn't exposed outside
+    /// `d-engine-server` — external callers (including `NodeBuilder`'s own
+    /// public API surface, e.g. d-lmdb) never need this.
+    pub(crate) fn data_dir_lock(
         mut self,
-        config: RaftConfig,
+        lock: super::DataDirLock,
     ) -> Self {
-        self.node_config.raft = config;
+        self.data_dir_lock = Some(lock);
         self
     }
 
@@ -263,6 +273,27 @@ where
     pub async fn build(mut self) -> Result<Self> {
         let node_id = self.node_id;
         let node_config = self.node_config.clone();
+
+        let data_dir = super::DataDir::new(self.data_dir.clone())?;
+
+        // Use a pre-acquired lock if the caller already opened storage before
+        // reaching us (see `data_dir_lock()`'s doc comment); otherwise this is
+        // the first and only chance to fail immediately if another process
+        // already holds this data_dir, before any storage/state-machine
+        // initialization runs.
+        let data_dir_lock = match self.data_dir_lock.take() {
+            Some(lock) => {
+                debug_assert!(
+                    lock.matches(data_dir.as_path()),
+                    "pre-acquired data_dir_lock does not match this builder's data_dir"
+                );
+                lock
+            }
+            None => super::DataDirLock::acquire(data_dir.as_path())?,
+        };
+
+        // snapshots_dir is not configurable — always data_dir/snapshots (see #10).
+        let snapshots_dir = data_dir.snapshots_dir()?;
 
         // Init CommitHandler
         let (new_commit_event_tx, new_commit_event_rx) = mpsc::unbounded_channel::<NewCommitData>();
@@ -391,6 +422,7 @@ where
                 node_id,
                 last_applied_index,
                 state_machine.clone(),
+                snapshots_dir,
                 node_config.raft.snapshot.clone(),
                 snapshot_policy,
                 #[cfg(feature = "watch")]
@@ -603,6 +635,8 @@ where
             _lease_cleanup_handle: lease_cleanup_handle,
             shutdown_signal: self.shutdown_signal.clone(),
             read_lease,
+            _data_dir: data_dir,
+            _data_dir_lock: data_dir_lock,
         };
 
         self.node = Some(Arc::new(node));
@@ -714,26 +748,6 @@ where
         })
     }
 
-    /// Sets a custom state machine handler implementation.
-    ///
-    /// Allows providing a custom implementation that processes committed log entries
-    /// and applies them to the state machine. If not set, a default implementation
-    /// is used during `build()`.
-    ///
-    /// # Arguments
-    /// * `handler` - custom handler implementing the `StateMachineHandler` trait
-    ///
-    /// # Notes
-    /// - The handler must be thread-safe (shared across threads via `Arc`)
-    /// - The handler must correctly handle snapshot creation and restoration
-    pub fn with_custom_state_machine_handler(
-        mut self,
-        handler: Arc<SMHOF<RaftTypeConfig<SE, SM>>>,
-    ) -> Self {
-        self.state_machine_handler = Some(handler);
-        self
-    }
-
     /// Starts the gRPC server for cluster communication.
     ///
     /// # Panics
@@ -797,12 +811,13 @@ where
         db_path: &str,
         shutdown_signal: watch::Receiver<()>,
     ) -> Self {
-        use std::path::PathBuf;
-
-        let mut node_config = RaftNodeConfig::new().expect("Load node_config successfully");
-        node_config.cluster.db_root_dir = PathBuf::from(db_path);
+        let node_config = RaftNodeConfig::new().expect("Load node_config successfully");
         let node_config = node_config.validate().expect("Validate node_config successfully");
 
-        Self::init(node_config, shutdown_signal)
+        Self::init(db_path, node_config, shutdown_signal)
     }
 }
+
+#[cfg(test)]
+#[path = "builder_test.rs"]
+mod builder_test;

--- a/d-engine-server/src/node/builder.rs
+++ b/d-engine-server/src/node/builder.rs
@@ -283,10 +283,12 @@ where
         // initialization runs.
         let data_dir_lock = match self.data_dir_lock.take() {
             Some(lock) => {
-                debug_assert!(
-                    lock.matches(data_dir.as_path()),
-                    "pre-acquired data_dir_lock does not match this builder's data_dir"
-                );
+                if !lock.matches(data_dir.as_path()) {
+                    return Err(SystemError::NodeStartFailed(
+                        "pre-acquired data_dir_lock does not match builder data_dir".to_string(),
+                    )
+                    .into());
+                }
                 lock
             }
             None => super::DataDirLock::acquire(data_dir.as_path())?,

--- a/d-engine-server/src/node/builder_test.rs
+++ b/d-engine-server/src/node/builder_test.rs
@@ -19,7 +19,7 @@ use tracing_test::traced_test;
 
 use crate::FileStateMachine;
 use crate::FileStorageEngine;
-use crate::NodeBuilder;
+use crate::node::NodeBuilder;
 use crate::node::RaftTypeConfig;
 use crate::storage::BufferedRaftLog;
 use crate::test_utils::insert_raft_log;
@@ -145,39 +145,9 @@ fn create_temp_config(content: &str) -> (PathBuf, String) {
 }
 
 #[test]
-#[serial]
-fn test_config_override_success() {
-    // Prepare test configuration
-    let (_dir, config_path) = create_temp_config(
-        r#"
-    [cluster]
-    db_root_dir = "./custom_db"
-    "#,
-    );
-
-    // Use temporary environment variables
-    temp_env::with_var("CONFIG_PATH", Some(config_path.clone()), || {
-        let base_config = RaftNodeConfig::new().unwrap().validate().unwrap();
-        let updated_config = base_config.with_override_config(&config_path).unwrap();
-
-        // Verify path coverage
-        assert_eq!(
-            updated_config.cluster.db_root_dir,
-            PathBuf::from("./custom_db"),
-            "DB root dir not overridden"
-        );
-
-        // Verify that other fields remain default
-        assert_eq!(
-            updated_config.cluster.node_id, 1,
-            "Node ID should remain default"
-        );
-    });
-}
-
-#[test]
 fn test_config_override_invalid_path() {
-    let base_config = RaftNodeConfig::new().unwrap().validate().unwrap();
+    let base_config = RaftNodeConfig::new().unwrap();
+    let base_config = base_config.validate().unwrap();
     let result = base_config.with_override_config("non_existent.toml");
 
     assert!(
@@ -193,12 +163,13 @@ fn test_config_override_invalid_format() {
         r#"
     invalid_toml_format
     cluster: {
-    db_root_dir: "./custom_db"
+    data_dir: "./custom_db"
     }
     "#,
     );
 
-    let base_config = RaftNodeConfig::new().unwrap().validate().unwrap();
+    let base_config = RaftNodeConfig::new().unwrap();
+    let base_config = base_config.validate().unwrap();
     let result = base_config.with_override_config(&config_path);
 
     assert!(
@@ -210,23 +181,20 @@ fn test_config_override_invalid_format() {
 #[test]
 #[serial]
 fn test_config_override_priority() {
+    // default listen_address = 127.0.0.1:9081 < file override (:9082) < env override (:9083).
+    // Uses listen_address rather than node_id: overriding node_id alone would fail the
+    // separate self-in-cluster validate() check against the default initial_cluster (id=1).
     let (_dir, config_path) = create_temp_config(
         r#"
     [cluster]
-    db_root_dir = "./file_db"
+    listen_address = "127.0.0.1:9082"
     "#,
     );
-
-    let temp_env_dir = tempdir().unwrap();
-    let env_db_path = temp_env_dir.path().join("env_db");
 
     temp_env::with_vars(
         vec![
             ("CONFIG_PATH", Some(config_path.as_str())),
-            (
-                "RAFT__CLUSTER__DB_ROOT_DIR",
-                Some(env_db_path.to_str().unwrap()),
-            ),
+            ("RAFT__CLUSTER__LISTEN_ADDRESS", Some("127.0.0.1:9083")),
         ],
         || {
             let config = RaftNodeConfig::new().unwrap().validate().unwrap();
@@ -234,7 +202,8 @@ fn test_config_override_priority() {
             // Verify that environment variables have higher priority than configuration
             // files
             assert_eq!(
-                config.cluster.db_root_dir, env_db_path,
+                config.cluster.listen_address,
+                "127.0.0.1:9083".parse::<std::net::SocketAddr>().unwrap(),
                 "Environment variable should override file config"
             );
         },
@@ -251,7 +220,8 @@ fn test_partial_override() {
     "#,
     );
 
-    let base_config = RaftNodeConfig::new().unwrap().validate().unwrap();
+    let base_config = RaftNodeConfig::new().unwrap();
+    let base_config = base_config.validate().unwrap();
     let updated_config = base_config.with_override_config(&config_path).unwrap();
 
     // Validate covered fields
@@ -262,7 +232,7 @@ fn test_partial_override() {
 
     // Verify unmodified fields
     assert_eq!(
-        updated_config.cluster.db_root_dir, base_config.cluster.db_root_dir,
+        updated_config.cluster.node_id, base_config.cluster.node_id,
         "Cluster config should remain unchanged"
     );
 }
@@ -270,11 +240,15 @@ fn test_partial_override() {
 #[test]
 fn test_from_node_config_preserves_caller_config() {
     let (_, shutdown_rx) = watch::channel(());
-    let mut config = RaftNodeConfig::new().unwrap().validate().unwrap();
+    let config = RaftNodeConfig::new().unwrap();
+    let mut config = config.validate().unwrap();
     config.cluster.node_id = 99;
 
-    let builder =
-        NodeBuilder::<MockStorageEngine, MockStateMachine>::from_node_config(config, shutdown_rx);
+    let builder = NodeBuilder::<MockStorageEngine, MockStateMachine>::from_node_config(
+        "test-data",
+        config,
+        shutdown_rx,
+    );
 
     // Verify caller's config is used directly — no detour through RaftNodeConfig::new() defaults
     assert_eq!(
@@ -284,13 +258,16 @@ fn test_from_node_config_preserves_caller_config() {
 }
 
 #[test]
+#[serial]
 fn test_node_config_setter_syncs_node_id() {
     let (_, shutdown_rx) = watch::channel(());
-    let mut config = RaftNodeConfig::new().unwrap().validate().unwrap();
+    let config = RaftNodeConfig::new().unwrap();
+    let mut config = config.validate().unwrap();
     config.cluster.node_id = 7;
 
-    let builder = NodeBuilder::<MockStorageEngine, MockStateMachine>::new(None, shutdown_rx)
-        .node_config(config);
+    let builder =
+        NodeBuilder::<MockStorageEngine, MockStateMachine>::new("test-data", None, shutdown_rx)
+            .node_config(config);
 
     // node_config on the builder must reflect the new config after setter
     assert_eq!(

--- a/d-engine-server/src/node/data_dir.rs
+++ b/d-engine-server/src/node/data_dir.rs
@@ -1,0 +1,87 @@
+use std::path::Path;
+use std::path::PathBuf;
+
+use d_engine_core::Result;
+
+/// Explicit runtime identity of a node: the physical directory this process
+/// owns. `new()` rejects an empty path and creates the
+/// directory if missing
+#[derive(Debug)]
+pub(crate) struct DataDir {
+    path: PathBuf,
+    /// Test-only: keeps `for_test()`'s backing `TempDir` alive for as long as
+    /// this `DataDir` lives, so the directory is cleaned up automatically on
+    /// drop instead of leaking into `/tmp` for the rest of the process.
+    #[cfg(test)]
+    _tempdir: Option<tempfile::TempDir>,
+}
+
+impl DataDir {
+    pub(crate) fn new(path: impl Into<PathBuf>) -> Result<Self> {
+        let path = path.into();
+        d_engine_core::validate_directory(&path, "data_dir")?;
+        Ok(Self {
+            path,
+            #[cfg(test)]
+            _tempdir: None,
+        })
+    }
+
+    pub(crate) fn as_path(&self) -> &Path {
+        &self.path
+    }
+
+    /// This node's snapshot directory — always `data_dir/snapshots`, not
+    /// independently configurable.
+    /// Validated/created the same way `data_dir` itself is — same rule,
+    /// same place, because the two are one concept, not two.
+    pub(crate) fn snapshots_dir(&self) -> Result<PathBuf> {
+        let dir = self.path.join("snapshots");
+        d_engine_core::validate_directory(&dir, "snapshots_dir")?;
+        Ok(dir)
+    }
+
+    /// Path for unified single-DB mode (`storage.unified_db = true`).
+    /// Validated eagerly so a permission problem fails loudly here, at
+    /// startup, instead of surfacing later as an opaque storage-engine IO
+    /// error. Backend-agnostic path convention — not RocksDB-specific;
+    /// any storage engine's `start_custom`/`run_custom` caller can use it.
+    #[allow(dead_code)]
+    pub(crate) fn unified_db_path(&self) -> Result<PathBuf> {
+        let dir = self.path.join("db");
+        d_engine_core::validate_directory(&dir, "db")?;
+        Ok(dir)
+    }
+
+    /// Storage engine path (separate-DB mode). Same eager validation and
+    /// backend-agnostic intent as `unified_db_path` — see its doc comment.
+    #[allow(dead_code)]
+    pub(crate) fn storage_path(&self) -> Result<PathBuf> {
+        let dir = self.path.join("storage");
+        d_engine_core::validate_directory(&dir, "storage")?;
+        Ok(dir)
+    }
+
+    /// State machine path (separate-DB mode). Same eager validation and
+    /// backend-agnostic intent as `unified_db_path` — see its doc comment.
+    #[allow(dead_code)]
+    pub(crate) fn state_machine_path(&self) -> Result<PathBuf> {
+        let dir = self.path.join("state_machine");
+        d_engine_core::validate_directory(&dir, "state_machine")?;
+        Ok(dir)
+    }
+
+    /// Test-only: a fresh, uniquely-generated temp directory — for mocks that
+    /// don't care about a real node identity, just need a valid `DataDir`.
+    /// The backing `TempDir` is owned by this `DataDir` and cleaned up
+    /// automatically when it drops.
+    #[cfg(test)]
+    pub(crate) fn for_test() -> Self {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let path = tempdir.path().to_path_buf();
+        Self {
+            path,
+            _tempdir: Some(tempdir),
+        }
+    }
+}

--- a/d-engine-server/src/node/data_dir.rs
+++ b/d-engine-server/src/node/data_dir.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use d_engine_core::Result;
+use d_engine_core::SystemError;
 
 /// Explicit runtime identity of a node: the physical directory this process
 /// owns. `new()` rejects an empty path and creates the
@@ -19,7 +20,7 @@ pub(crate) struct DataDir {
 impl DataDir {
     pub(crate) fn new(path: impl Into<PathBuf>) -> Result<Self> {
         let path = path.into();
-        d_engine_core::validate_directory(&path, "data_dir")?;
+        validate_directory(&path, "data_dir")?;
         Ok(Self {
             path,
             #[cfg(test)]
@@ -37,7 +38,7 @@ impl DataDir {
     /// same place, because the two are one concept, not two.
     pub(crate) fn snapshots_dir(&self) -> Result<PathBuf> {
         let dir = self.path.join("snapshots");
-        d_engine_core::validate_directory(&dir, "snapshots_dir")?;
+        validate_directory(&dir, "snapshots_dir")?;
         Ok(dir)
     }
 
@@ -49,7 +50,7 @@ impl DataDir {
     #[allow(dead_code)]
     pub(crate) fn unified_db_path(&self) -> Result<PathBuf> {
         let dir = self.path.join("db");
-        d_engine_core::validate_directory(&dir, "db")?;
+        validate_directory(&dir, "db")?;
         Ok(dir)
     }
 
@@ -58,7 +59,7 @@ impl DataDir {
     #[allow(dead_code)]
     pub(crate) fn storage_path(&self) -> Result<PathBuf> {
         let dir = self.path.join("storage");
-        d_engine_core::validate_directory(&dir, "storage")?;
+        validate_directory(&dir, "storage")?;
         Ok(dir)
     }
 
@@ -67,7 +68,7 @@ impl DataDir {
     #[allow(dead_code)]
     pub(crate) fn state_machine_path(&self) -> Result<PathBuf> {
         let dir = self.path.join("state_machine");
-        d_engine_core::validate_directory(&dir, "state_machine")?;
+        validate_directory(&dir, "state_machine")?;
         Ok(dir)
     }
 
@@ -84,4 +85,41 @@ impl DataDir {
             _tempdir: Some(tempdir),
         }
     }
+}
+
+/// Ensures directory path is valid and writable.
+fn validate_directory(
+    path: &Path,
+    name: &str,
+) -> Result<()> {
+    if path.as_os_str().is_empty() {
+        return Err(SystemError::DataDirInvalid(format!("{name} path cannot be empty")).into());
+    }
+
+    if !path.exists() {
+        std::fs::create_dir_all(path).map_err(|e| {
+            SystemError::DataDirInvalid(format!(
+                "Failed to create {} directory at {}: {}",
+                name,
+                path.display(),
+                e
+            ))
+        })?;
+    }
+
+    // Unique, collision-free write-permission probe: never overwrites an
+    // existing file, and is removed automatically on drop.
+    tempfile::Builder::new()
+        .prefix(".d-engine-write-test-")
+        .tempfile_in(path)
+        .map_err(|e| {
+            SystemError::DataDirInvalid(format!(
+                "No write permission in {} directory {}: {}",
+                name,
+                path.display(),
+                e
+            ))
+        })?;
+
+    Ok(())
 }

--- a/d-engine-server/src/node/dir_lock.rs
+++ b/d-engine-server/src/node/dir_lock.rs
@@ -1,0 +1,78 @@
+// d-engine-server/src/node/dir_lock.rs
+
+//! Exclusive OS-level lock on a node's `data_dir`, held for the life of the process.
+//! Prevents two node processes from pointing at the same physical directory —
+//! without this, the failure mode is a confusing mid-run error (e.g. snapshot
+//! `mkdir: File exists`) instead of a clear rejection at startup.
+
+pub(crate) struct DataDirLock {
+    // Kept only to hold the OS-level lock; released automatically when this
+    // `File` is dropped (flock on Unix, LockFileEx on Windows).
+    _file: std::fs::File,
+    // Remembered so callers that pass a pre-acquired lock into NodeBuilder
+    // can be checked against the data_dir they also pass in — see `matches`.
+    path: std::path::PathBuf,
+    // Test-only: keeps `for_test()`'s backing `TempDir` alive for as long as
+    // this lock lives, so the directory is cleaned up automatically on drop
+    // instead of leaking into `/tmp` for the rest of the process.
+    #[cfg(test)]
+    _tempdir: Option<tempfile::TempDir>,
+}
+
+impl DataDirLock {
+    /// Acquires an exclusive lock on `dir`. Fails immediately if another
+    /// process already holds it.
+    pub(crate) fn acquire(dir: &std::path::Path) -> d_engine_core::Result<Self> {
+        let lock_path = dir.join(".d-engine.lock");
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(&lock_path)
+            .map_err(|e| {
+                d_engine_core::SystemError::NodeStartFailed(format!(
+                    "failed to open lock file {}: {e}",
+                    lock_path.display()
+                ))
+            })?;
+        file.try_lock().map_err(|_| {
+            d_engine_core::SystemError::NodeStartFailed(format!(
+                "data_dir {} is already in use by another process",
+                dir.display()
+            ))
+        })?;
+        Ok(Self {
+            _file: file,
+            path: dir.to_path_buf(),
+            #[cfg(test)]
+            _tempdir: None,
+        })
+    }
+
+    /// True if this lock was acquired for `dir`. Used to catch a
+    /// pre-acquired lock being paired with the wrong data_dir (e.g. via
+    /// `NodeBuilder::data_dir_lock`) before it can cause silent confusion.
+    pub(crate) fn matches(
+        &self,
+        dir: &std::path::Path,
+    ) -> bool {
+        self.path == dir
+    }
+
+    /// Test-only: locks a fresh, uniquely-generated temp directory instead of
+    /// whatever `data_dir` the mock config carries — avoids cross-test lock
+    /// collisions when many MockNodeBuilders share a default data_dir path.
+    /// The backing `TempDir` is owned by the returned lock and cleaned up
+    /// automatically when it drops.
+    #[cfg(test)]
+    pub(crate) fn for_test() -> Self {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut lock = Self::acquire(dir.path()).expect("acquire test lock");
+        lock._tempdir = Some(dir);
+        lock
+    }
+}
+
+#[cfg(test)]
+#[path = "dir_lock_test.rs"]
+mod dir_lock_test;

--- a/d-engine-server/src/node/dir_lock.rs
+++ b/d-engine-server/src/node/dir_lock.rs
@@ -58,19 +58,6 @@ impl DataDirLock {
     ) -> bool {
         self.path == dir
     }
-
-    /// Test-only: locks a fresh, uniquely-generated temp directory instead of
-    /// whatever `data_dir` the mock config carries — avoids cross-test lock
-    /// collisions when many MockNodeBuilders share a default data_dir path.
-    /// The backing `TempDir` is owned by the returned lock and cleaned up
-    /// automatically when it drops.
-    #[cfg(test)]
-    pub(crate) fn for_test() -> Self {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let mut lock = Self::acquire(dir.path()).expect("acquire test lock");
-        lock._tempdir = Some(dir);
-        lock
-    }
 }
 
 #[cfg(test)]

--- a/d-engine-server/src/node/dir_lock_test.rs
+++ b/d-engine-server/src/node/dir_lock_test.rs
@@ -1,0 +1,41 @@
+use super::DataDirLock;
+
+#[test]
+fn test_acquire_succeeds_on_fresh_dir() {
+    let dir = tempfile::tempdir().unwrap();
+    let lock = DataDirLock::acquire(dir.path());
+    assert!(lock.is_ok());
+}
+
+#[test]
+fn test_second_acquire_on_same_dir_fails_while_first_held() {
+    let dir = tempfile::tempdir().unwrap();
+    let _first = DataDirLock::acquire(dir.path()).unwrap();
+    let second = DataDirLock::acquire(dir.path());
+    assert!(second.is_err());
+}
+
+#[test]
+fn test_acquire_succeeds_again_after_first_lock_dropped() {
+    let dir = tempfile::tempdir().unwrap();
+    let first = DataDirLock::acquire(dir.path()).unwrap();
+    drop(first);
+    let second = DataDirLock::acquire(dir.path());
+    assert!(second.is_ok());
+}
+
+#[test]
+fn test_matches_true_for_locked_dir_false_for_other_dir() {
+    let dir = tempfile::tempdir().unwrap();
+    let other_dir = tempfile::tempdir().unwrap();
+    let lock = DataDirLock::acquire(dir.path()).unwrap();
+
+    assert!(
+        lock.matches(dir.path()),
+        "lock must match the dir it was acquired for"
+    );
+    assert!(
+        !lock.matches(other_dir.path()),
+        "lock must not match an unrelated dir"
+    );
+}

--- a/d-engine-server/src/node/mod.rs
+++ b/d-engine-server/src/node/mod.rs
@@ -9,16 +9,12 @@
 //! - Maintains node readiness state for cluster coordination
 //! - Executes the main event processing loop inside Raft
 //!
-//! ## Example Usage
-//! ```ignore
-//! let node = NodeBuilder::new(node_config).start().await?;
-//! tokio::spawn(async move {
-//!     node.run().await.expect("Raft node execution failed");
-//! });
-//! ```
+//! Built internally by the crate — application code never constructs a
+//! [`Node`] directly. Use [`crate::EmbeddedEngine`] or
+//! [`crate::StandaloneEngine`] instead.
 
 mod builder;
-pub use builder::*;
+pub(crate) use builder::*;
 
 mod leader_notifier;
 pub(crate) use leader_notifier::*;
@@ -29,11 +25,12 @@ use tracing::info;
 #[doc(hidden)]
 pub use type_config::*;
 
-/// Test Modules
-#[cfg(test)]
-mod builder_test;
-#[cfg(test)]
-mod node_test;
+mod data_dir;
+pub(crate) use data_dir::DataDir;
+
+mod dir_lock;
+pub(crate) use dir_lock::DataDirLock;
+
 #[cfg(test)]
 mod test_helpers;
 
@@ -61,14 +58,9 @@ use tokio::sync::watch;
 /// Represents a single node participating in a Raft cluster.
 /// Coordinates protocol execution, storage, and networking.
 ///
-/// Created via [`NodeBuilder`].
-///
-/// # Running the Node
-///
-/// ```rust,ignore
-/// let node = builder.start()?;
-/// node.run().await?;  // Blocks until shutdown
-/// ```
+/// Built internally — never constructed directly. Use
+/// [`EmbeddedEngine`](crate::EmbeddedEngine) or
+/// [`StandaloneEngine`](crate::StandaloneEngine) to start a node.
 pub struct Node<T>
 where
     T: TypeConfig,
@@ -129,6 +121,15 @@ where
 
     /// Read lease — same Arc as the one inside SharedState, exposed for EmbeddedClient.
     pub(crate) read_lease: Arc<ReadLease>,
+
+    /// Explicit runtime identity — the data_dir this process owns. Same value
+    /// used to acquire `_data_dir_lock`. No consumers yet; kept for future
+    /// runtime introspection (e.g. exposing the active data_dir to callers).
+    pub(crate) _data_dir: DataDir,
+
+    /// Exclusive lock on this node's data_dir, held for the process lifetime.
+    /// Released automatically when the last `Arc<Node<T>>` is dropped.
+    pub(crate) _data_dir_lock: DataDirLock,
 
     /// Fast-path read routing. Always set; `read_tx = None` means no ReadActor.
     pub(crate) read_handle: crate::api::StandaloneReadHandle,
@@ -375,3 +376,7 @@ where
         self.raft_core.lock().await.current_term()
     }
 }
+
+#[cfg(test)]
+#[path = "node_test.rs"]
+mod node_test;

--- a/d-engine-server/src/node/node_test.rs
+++ b/d-engine-server/src/node/node_test.rs
@@ -75,10 +75,8 @@ async fn run_success_without_joining() {
             .with_raft_log(raft_log)
             .with_replication_handler(replication_handler)
             .with_node_config({
-                let mut config = RaftNodeConfig::new()
-                    .expect("Default config")
-                    .validate()
-                    .expect("Validate RaftNodeConfig successfully");
+                let config = RaftNodeConfig::new().expect("Default config");
+                let mut config = config.validate().expect("Validate RaftNodeConfig successfully");
                 // Mark as non-joining node
                 config.cluster.initial_cluster = vec![
                     NodeMeta {
@@ -171,10 +169,8 @@ async fn run_success_with_joining() {
     // Build node using MockBuilder
     let node_id = 100;
     let config = {
-        let mut config = RaftNodeConfig::new()
-            .expect("Default config")
-            .validate()
-            .expect("Validate RaftNodeConfig successfully");
+        let config = RaftNodeConfig::new().expect("Default config");
+        let mut config = config.validate().expect("Validate RaftNodeConfig successfully");
         // Mark as non-joining node
         config.cluster.node_id = node_id;
         config.cluster.initial_cluster = vec![
@@ -262,10 +258,8 @@ async fn run_fails_on_health_check() {
         let builder = MockBuilder::new(shutdown_rx.clone())
             .with_membership(membership) // Inject our mock membership
             .with_node_config({
-                let mut config = RaftNodeConfig::new()
-                    .expect("Default config")
-                    .validate()
-                    .expect("Validate RaftNodeConfig successfully");
+                let config = RaftNodeConfig::new().expect("Default config");
+                let mut config = config.validate().expect("Validate RaftNodeConfig successfully");
                 // Mark as non-joining node
                 config.cluster.initial_cluster = vec![
                     NodeMeta {
@@ -589,10 +583,8 @@ mod bootstrap_strategy_tests {
             .returning(|_, _, _, _| Err(d_engine_core::Error::Fatal("no snapshot".to_string())));
 
         let config = {
-            let mut cfg = RaftNodeConfig::new()
-                .expect("Default config")
-                .validate()
-                .expect("Validate RaftNodeConfig successfully");
+            let cfg = RaftNodeConfig::new().expect("Default config");
+            let mut cfg = cfg.validate().expect("Validate RaftNodeConfig successfully");
             cfg.cluster.node_id = node_id;
             cfg.cluster.initial_cluster = vec![
                 NodeMeta {
@@ -684,10 +676,8 @@ mod bootstrap_strategy_tests {
                 .with_raft_log(prepare_mock_raft_log())
                 .with_replication_handler(prepare_mock_replication())
                 .with_node_config({
-                    let mut cfg = RaftNodeConfig::new()
-                        .expect("Default config")
-                        .validate()
-                        .expect("Validate RaftNodeConfig successfully");
+                    let cfg = RaftNodeConfig::new().expect("Default config");
+                    let mut cfg = cfg.validate().expect("Validate RaftNodeConfig successfully");
                     cfg.cluster.initial_cluster = vec![
                         NodeMeta {
                             id: 100,
@@ -760,10 +750,8 @@ mod bootstrap_strategy_tests {
             let builder = MockBuilder::new(shutdown_rx.clone())
                 .with_membership(membership)
                 .with_node_config({
-                    let mut cfg = RaftNodeConfig::new()
-                        .expect("Default config")
-                        .validate()
-                        .expect("Validate RaftNodeConfig successfully");
+                    let cfg = RaftNodeConfig::new().expect("Default config");
+                    let mut cfg = cfg.validate().expect("Validate RaftNodeConfig successfully");
                     cfg.cluster.initial_cluster = vec![NodeMeta {
                         id: 100,
                         address: "127.0.0.1:8080".to_string(),
@@ -841,10 +829,8 @@ mod bootstrap_strategy_tests {
             .returning(|_, _, _, _| Err(d_engine_core::Error::Fatal("no snapshot".to_string())));
 
         let config = {
-            let mut cfg = RaftNodeConfig::new()
-                .expect("Default config")
-                .validate()
-                .expect("Validate RaftNodeConfig successfully");
+            let cfg = RaftNodeConfig::new().expect("Default config");
+            let mut cfg = cfg.validate().expect("Validate RaftNodeConfig successfully");
             cfg.cluster.node_id = node_id;
             cfg.cluster.initial_cluster = vec![
                 NodeMeta {

--- a/d-engine-server/src/node/test_helpers.rs
+++ b/d-engine-server/src/node/test_helpers.rs
@@ -24,10 +24,8 @@ pub fn create_test_node() -> (Node<d_engine_core::MockTypeConfig>, watch::Sender
 
     let node = MockBuilder::new(shutdown_rx.clone())
         .with_node_config({
-            let mut config = RaftNodeConfig::new()
-                .expect("Default config")
-                .validate()
-                .expect("Validate RaftNodeConfig successfully");
+            let config = RaftNodeConfig::new().expect("Default config");
+            let mut config = config.validate().expect("Validate RaftNodeConfig successfully");
             config.cluster.initial_cluster = vec![NodeMeta {
                 id: 1,
                 address: "127.0.0.1:9001".to_string(),
@@ -51,10 +49,8 @@ pub fn create_test_node_with_id(
     let node = MockBuilder::new(shutdown_rx.clone())
         .id(node_id)
         .with_node_config({
-            let mut config = RaftNodeConfig::new()
-                .expect("Default config")
-                .validate()
-                .expect("Validate RaftNodeConfig successfully");
+            let config = RaftNodeConfig::new().expect("Default config");
+            let mut config = config.validate().expect("Validate RaftNodeConfig successfully");
             config.cluster.node_id = node_id;
             config.cluster.initial_cluster = vec![NodeMeta {
                 id: node_id,

--- a/d-engine-server/src/test_utils/integration/mod.rs
+++ b/d-engine-server/src/test_utils/integration/mod.rs
@@ -226,7 +226,6 @@ pub fn setup_raft_components(
 
     // Each unit test db path will be different
     let mut node_config = RaftNodeConfig::default();
-    node_config.cluster.db_root_dir = PathBuf::from(db_path);
     node_config.cluster.initial_cluster = peers_meta.clone();
 
     let snapshot_policy = LogSizePolicy::new(
@@ -239,6 +238,7 @@ pub fn setup_raft_components(
         id,
         last_applied_pair.index,
         state_machine.clone(),
+        PathBuf::from(db_path).join("snapshots"),
         node_config.raft.snapshot.clone(),
         snapshot_policy,
         None, // No watch for tests

--- a/d-engine-server/src/test_utils/mock/mock_node_builder.rs
+++ b/d-engine-server/src/test_utils/mock/mock_node_builder.rs
@@ -319,6 +319,9 @@ impl MockBuilder {
         let (rpc_ready_tx, _rpc_ready_rx) = watch::channel(false);
         let leader_notifier = LeaderNotifier::new();
         let (_membership_tx, membership_rx) = watch::channel(MembershipSnapshot::default());
+        let data_dir = crate::node::DataDir::for_test();
+        let data_dir_lock =
+            DataDirLock::acquire(data_dir.as_path()).expect("acquire test data_dir lock");
 
         Node::<MockTypeConfig> {
             node_id: raft.node_id,
@@ -342,8 +345,8 @@ impl MockBuilder {
             _lease_cleanup_handle: None,
             shutdown_signal,
             read_lease,
-            _data_dir: crate::node::DataDir::for_test(),
-            _data_dir_lock: DataDirLock::for_test(),
+            _data_dir: data_dir,
+            _data_dir_lock: data_dir_lock,
         }
     }
 
@@ -374,6 +377,9 @@ impl MockBuilder {
         let (rpc_ready_tx, _rpc_ready_rx) = watch::channel(false);
         let leader_notifier = LeaderNotifier::new();
         let (_membership_tx, membership_rx) = watch::channel(MembershipSnapshot::default());
+        let data_dir = crate::node::DataDir::for_test();
+        let data_dir_lock =
+            DataDirLock::acquire(data_dir.as_path()).expect("acquire test data_dir lock");
 
         let node = Arc::new(Node::<MockTypeConfig> {
             node_id: raft.node_id,
@@ -397,8 +403,8 @@ impl MockBuilder {
             _lease_cleanup_handle: None,
             shutdown_signal: shutdown.clone(),
             read_lease,
-            _data_dir: crate::node::DataDir::for_test(),
-            _data_dir_lock: DataDirLock::for_test(),
+            _data_dir: data_dir,
+            _data_dir_lock: data_dir_lock,
         });
         let node_clone = node.clone();
         let listen_address = node_config_arc.cluster.listen_address;
@@ -512,14 +518,9 @@ impl MockBuilder {
     /// `data_dir` is unused — data_dir isn't a `d-engine-core` concept
     /// anymore (see #9); kept as a no-op parameter for the one call site.
     pub fn with_db_path(
-        mut self,
+        self,
         _data_dir: impl AsRef<Path>,
     ) -> Self {
-        let node_config = RaftNodeConfig::new()
-            .expect("Should succeed to init RaftNodeConfig")
-            .validate()
-            .expect("Should succeed to validate RaftNodeConfig");
-        self.node_config = Some(node_config);
         self
     }
 

--- a/d-engine-server/src/test_utils/mock/mock_node_builder.rs
+++ b/d-engine-server/src/test_utils/mock/mock_node_builder.rs
@@ -4,6 +4,7 @@ use super::MockTypeConfig;
 use crate::Node;
 use crate::membership::MembershipSnapshot;
 use crate::network::grpc;
+use crate::node::DataDirLock;
 use crate::node::LeaderNotifier;
 use bytes::Bytes;
 use d_engine_core::ElectionConfig;
@@ -341,6 +342,8 @@ impl MockBuilder {
             _lease_cleanup_handle: None,
             shutdown_signal,
             read_lease,
+            _data_dir: crate::node::DataDir::for_test(),
+            _data_dir_lock: DataDirLock::for_test(),
         }
     }
 
@@ -394,6 +397,8 @@ impl MockBuilder {
             _lease_cleanup_handle: None,
             shutdown_signal: shutdown.clone(),
             read_lease,
+            _data_dir: crate::node::DataDir::for_test(),
+            _data_dir_lock: DataDirLock::for_test(),
         });
         let node_clone = node.clone();
         let listen_address = node_config_arc.cluster.listen_address;
@@ -504,14 +509,16 @@ impl MockBuilder {
     /// Set the database root directory path
     ///
     /// Automatically updates the node configuration with the provided path.
+    /// `data_dir` is unused — data_dir isn't a `d-engine-core` concept
+    /// anymore (see #9); kept as a no-op parameter for the one call site.
     pub fn with_db_path(
         mut self,
-        db_root_dir: impl AsRef<Path>,
+        _data_dir: impl AsRef<Path>,
     ) -> Self {
-        let mut node_config = RaftNodeConfig::new().expect("Should succeed to init RaftNodeConfig");
-        node_config.cluster.db_root_dir = db_root_dir.as_ref().to_path_buf();
-        let node_config =
-            node_config.validate().expect("Should succeed to validate RaftNodeConfig");
+        let node_config = RaftNodeConfig::new()
+            .expect("Should succeed to init RaftNodeConfig")
+            .validate()
+            .expect("Should succeed to validate RaftNodeConfig");
         self.node_config = Some(node_config);
         self
     }

--- a/d-engine-server/tests/cas_operations/bank_transfer_invariant_embedded.rs
+++ b/d-engine-server/tests/cas_operations/bank_transfer_invariant_embedded.rs
@@ -12,7 +12,6 @@ use tracing_test::traced_test;
 
 use crate::common::create_node_config;
 use crate::common::get_available_ports;
-use crate::common::node_config;
 
 const BANK_KEY: &[u8] = b"bank";
 const INITIAL_BALANCE: u64 = 1_000;
@@ -51,7 +50,7 @@ fn unpack(bytes: &[u8]) -> [u64; 3] {
 async fn test_concurrent_transfers_preserve_bank_invariant()
 -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = tempfile::tempdir()?;
-    let db_root_dir = temp_dir.path().join("db");
+    let data_dir = temp_dir.path().join("db");
     let log_dir = temp_dir.path().join("logs");
 
     let mut port_guard = get_available_ports(3).await;
@@ -67,13 +66,12 @@ async fn test_concurrent_transfers_preserve_bank_invariant()
             node_id,
             ports[i],
             ports,
-            db_root_dir.to_str().unwrap(),
+            data_dir.to_str().unwrap(),
             log_dir.to_str().unwrap(),
         )
         .await;
 
-        let config = node_config(&config_str);
-        let node_db_root = config.cluster.db_root_dir.join(format!("node{node_id}"));
+        let node_db_root = data_dir.join(format!("node{node_id}"));
         let db_path = node_db_root.join("db");
         tokio::fs::create_dir_all(&db_path).await?;
 
@@ -82,6 +80,7 @@ async fn test_concurrent_transfers_preserve_bank_invariant()
         tokio::fs::write(&config_path, &config_str).await?;
 
         let engine = DefaultEmbeddedEngine::start_custom(
+            &node_db_root,
             Arc::new(storage),
             Arc::new(state_machine),
             Some(&config_path),

--- a/d-engine-server/tests/cas_operations/distributed_lock_embedded.rs
+++ b/d-engine-server/tests/cas_operations/distributed_lock_embedded.rs
@@ -11,7 +11,6 @@ use tracing_test::traced_test;
 
 use crate::common::create_node_config;
 use crate::common::get_available_ports;
-use crate::common::node_config;
 
 /// Test distributed lock using CAS with embedded mode
 ///
@@ -25,7 +24,7 @@ use crate::common::node_config;
 #[traced_test]
 async fn test_distributed_lock_embedded() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = tempfile::tempdir()?;
-    let db_root_dir = temp_dir.path().join("db");
+    let data_dir = temp_dir.path().join("db");
     let log_dir = temp_dir.path().join("logs");
 
     let mut port_guard = get_available_ports(3).await;
@@ -42,13 +41,12 @@ async fn test_distributed_lock_embedded() -> Result<(), Box<dyn std::error::Erro
             node_id,
             ports[i],
             ports,
-            db_root_dir.to_str().unwrap(),
+            data_dir.to_str().unwrap(),
             log_dir.to_str().unwrap(),
         )
         .await;
 
-        let config = node_config(&config_str);
-        let node_db_root = config.cluster.db_root_dir.join(format!("node{node_id}"));
+        let node_db_root = data_dir.join(format!("node{node_id}"));
         let db_path = node_db_root.join("db");
 
         tokio::fs::create_dir_all(&db_path).await?;
@@ -59,6 +57,7 @@ async fn test_distributed_lock_embedded() -> Result<(), Box<dyn std::error::Erro
         tokio::fs::write(&config_path, &config_str).await?;
 
         let engine = DefaultEmbeddedEngine::start_custom(
+            &node_db_root,
             Arc::new(storage),
             Arc::new(state_machine),
             Some(&config_path),

--- a/d-engine-server/tests/cas_operations/distributed_lock_standalone.rs
+++ b/d-engine-server/tests/cas_operations/distributed_lock_standalone.rs
@@ -19,7 +19,6 @@ use crate::common::reset;
 use crate::common::start_node;
 
 const TEST_DIR: &str = "cas_operations/distributed_lock";
-const DB_ROOT_DIR: &str = "./db/cas_operations/distributed_lock";
 const LOG_DIR: &str = "./logs/cas_operations/distributed_lock";
 
 /// Test distributed lock using CAS with standalone mode (gRPC)
@@ -44,11 +43,25 @@ async fn test_distributed_lock_standalone() -> Result<(), ClientApiError> {
         node_handles: Vec::new(),
     };
 
+    let temp_dir = tempfile::Builder::new()
+        .prefix("d-engine-distributed-lock-standalone-")
+        .tempdir()
+        .expect("tempdir");
+
     info!("Starting 3-node cluster for CAS lock test");
     for (i, port) in ports.iter().enumerate() {
+        let node_data_dir = temp_dir.path().join(format!("node{}", i + 1));
         let (graceful_tx, node_handle) = start_node(
+            &node_data_dir,
             node_config(
-                &create_node_config((i + 1) as u64, *port, ports, DB_ROOT_DIR, LOG_DIR).await,
+                &create_node_config(
+                    (i + 1) as u64,
+                    *port,
+                    ports,
+                    &node_data_dir.to_string_lossy(),
+                    LOG_DIR,
+                )
+                .await,
             ),
             None,
             None,

--- a/d-engine-server/tests/cas_operations/leader_failover_cas_embedded.rs
+++ b/d-engine-server/tests/cas_operations/leader_failover_cas_embedded.rs
@@ -11,7 +11,6 @@ use tracing_test::traced_test;
 
 use crate::common::create_node_config;
 use crate::common::get_available_ports;
-use crate::common::node_config;
 use crate::common::wait_for_new_leader;
 
 /// Test CAS operation behavior during leader failover (Embedded mode)
@@ -37,7 +36,7 @@ use crate::common::wait_for_new_leader;
 #[serial]
 async fn test_leader_failover_cas_embedded() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = tempfile::tempdir()?;
-    let db_root_dir = temp_dir.path().join("db");
+    let data_dir = temp_dir.path().join("db");
     let log_dir = temp_dir.path().join("logs");
 
     let mut port_guard = get_available_ports(3).await;
@@ -54,13 +53,12 @@ async fn test_leader_failover_cas_embedded() -> Result<(), Box<dyn std::error::E
             node_id,
             ports[i],
             ports,
-            db_root_dir.to_str().unwrap(),
+            data_dir.to_str().unwrap(),
             log_dir.to_str().unwrap(),
         )
         .await;
 
-        let config = node_config(&config_str);
-        let node_db_root = config.cluster.db_root_dir.join(format!("node{node_id}"));
+        let node_db_root = data_dir.join(format!("node{node_id}"));
         let db_path = node_db_root.join("db");
 
         tokio::fs::create_dir_all(&db_path).await?;
@@ -71,6 +69,7 @@ async fn test_leader_failover_cas_embedded() -> Result<(), Box<dyn std::error::E
         tokio::fs::write(&config_path, &config_str).await?;
 
         let engine = DefaultEmbeddedEngine::start_custom(
+            &node_db_root,
             Arc::new(storage),
             Arc::new(state_machine),
             Some(&config_path),

--- a/d-engine-server/tests/cas_operations/leader_failover_cas_standalone.rs
+++ b/d-engine-server/tests/cas_operations/leader_failover_cas_standalone.rs
@@ -40,7 +40,6 @@ use crate::common::start_node;
 #[traced_test]
 async fn test_leader_failover_cas_standalone() -> Result<(), ClientApiError> {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
-    let db_root_dir = temp_dir.path().join("db").to_string_lossy().to_string();
     let log_dir = temp_dir.path().join("logs").to_string_lossy().to_string();
 
     let mut port_guard = get_available_ports(3).await;
@@ -54,9 +53,18 @@ async fn test_leader_failover_cas_standalone() -> Result<(), ClientApiError> {
 
     info!("Starting 3-node cluster for CAS failover test (gRPC mode)");
     for (i, port) in ports.iter().enumerate() {
+        let node_data_dir = temp_dir.path().join(format!("node{}", i + 1));
         let (graceful_tx, node_handle) = start_node(
+            &node_data_dir,
             node_config(
-                &create_node_config((i + 1) as u64, *port, ports, &db_root_dir, &log_dir).await,
+                &create_node_config(
+                    (i + 1) as u64,
+                    *port,
+                    ports,
+                    &node_data_dir.to_string_lossy(),
+                    &log_dir,
+                )
+                .await,
             ),
             None,
             None,

--- a/d-engine-server/tests/cas_operations/snapshot_recovery_embedded.rs
+++ b/d-engine-server/tests/cas_operations/snapshot_recovery_embedded.rs
@@ -10,7 +10,6 @@ use tracing_test::traced_test;
 
 use crate::common::create_node_config;
 use crate::common::get_available_ports;
-use crate::common::node_config;
 
 /// Test CAS state survives snapshot and recovery (embedded mode)
 ///
@@ -24,7 +23,7 @@ use crate::common::node_config;
 #[traced_test]
 async fn test_snapshot_recovery_embedded() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = tempfile::tempdir()?;
-    let db_root_dir = temp_dir.path().join("db");
+    let data_dir = temp_dir.path().join("db");
     let log_dir = temp_dir.path().join("logs");
 
     let mut port_guard = get_available_ports(3).await;
@@ -42,13 +41,12 @@ async fn test_snapshot_recovery_embedded() -> Result<(), Box<dyn std::error::Err
             node_id,
             ports[i],
             ports,
-            db_root_dir.to_str().unwrap(),
+            data_dir.to_str().unwrap(),
             log_dir.to_str().unwrap(),
         )
         .await;
 
-        let config = node_config(&config_str);
-        let node_db_root = config.cluster.db_root_dir.join(format!("node{node_id}"));
+        let node_db_root = data_dir.join(format!("node{node_id}"));
         let db_path = node_db_root.join("db");
 
         tokio::fs::create_dir_all(&db_path).await?;
@@ -61,6 +59,7 @@ async fn test_snapshot_recovery_embedded() -> Result<(), Box<dyn std::error::Err
         tokio::fs::write(&config_path, &config_str).await?;
 
         let engine = DefaultEmbeddedEngine::start_custom(
+            &db_path,
             Arc::new(storage),
             Arc::new(state_machine),
             Some(&config_path),
@@ -119,6 +118,7 @@ async fn test_snapshot_recovery_embedded() -> Result<(), Box<dyn std::error::Err
     let config_path = format!("/tmp/d-engine-cas-snapshot-node{}.toml", follower_idx + 1);
 
     let new_engine = DefaultEmbeddedEngine::start_custom(
+        &db_paths[follower_idx],
         Arc::new(storage),
         Arc::new(state_machine),
         Some(&config_path),

--- a/d-engine-server/tests/cas_operations/snapshot_recovery_standalone.rs
+++ b/d-engine-server/tests/cas_operations/snapshot_recovery_standalone.rs
@@ -29,12 +29,15 @@ use tempfile::TempDir;
 #[traced_test]
 async fn test_snapshot_recovery_standalone() -> Result<(), ClientApiError> {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
-    let db_root_dir = temp_dir.path().join("db").to_string_lossy().to_string();
     let log_dir = temp_dir.path().join("logs").to_string_lossy().to_string();
 
     let mut port_guard = get_available_ports(3).await;
     port_guard.release_listeners();
     let ports = port_guard.as_slice();
+
+    let node_data_dirs: Vec<_> = (0..ports.len())
+        .map(|i| temp_dir.path().join(format!("node{}", i + 1)))
+        .collect();
 
     let mut ctx = TestContext {
         graceful_txs: Vec::new(),
@@ -44,8 +47,16 @@ async fn test_snapshot_recovery_standalone() -> Result<(), ClientApiError> {
     info!("Starting 3-node cluster for CAS snapshot recovery test");
     for (i, port) in ports.iter().enumerate() {
         let (graceful_tx, node_handle) = start_node(
+            &node_data_dirs[i],
             node_config(
-                &create_node_config((i + 1) as u64, *port, ports, &db_root_dir, &log_dir).await,
+                &create_node_config(
+                    (i + 1) as u64,
+                    *port,
+                    ports,
+                    &node_data_dirs[i].to_string_lossy(),
+                    &log_dir,
+                )
+                .await,
             ),
             None,
             None,
@@ -115,7 +126,17 @@ async fn test_snapshot_recovery_standalone() -> Result<(), ClientApiError> {
     // Step 4: Restart node 2
     info!("Step 4: Restarting node 2");
     let (graceful_tx, node_handle) = start_node(
-        node_config(&create_node_config(2, ports[1], ports, &db_root_dir, &log_dir).await),
+        &node_data_dirs[1],
+        node_config(
+            &create_node_config(
+                2,
+                ports[1],
+                ports,
+                &node_data_dirs[1].to_string_lossy(),
+                &log_dir,
+            )
+            .await,
+        ),
         None,
         None,
     )

--- a/d-engine-server/tests/cluster_lifecycle/config_loading_embedded.rs
+++ b/d-engine-server/tests/cluster_lifecycle/config_loading_embedded.rs
@@ -24,21 +24,19 @@ async fn test_start_with_no_config_path_env() {
         r#"
 [cluster]
 node_id = 1
-db_root_dir = "{}"
 
 [[cluster.initial_cluster]]
 id = 1
 address = "127.0.0.1:0"
 role = 3
 status = 3
-"#,
-        db_path.display()
+"#
     )
     .unwrap();
     drop(file);
 
     // Core test: start_with should work without CONFIG_PATH env var
-    let engine = DefaultEmbeddedEngine::start_with(config_path.to_str().unwrap())
+    let engine = DefaultEmbeddedEngine::start_with(&db_path, config_path.to_str().unwrap())
         .await
         .expect("Should start without CONFIG_PATH env");
 

--- a/d-engine-server/tests/cluster_lifecycle/scale_single_to_three_node_embedded.rs
+++ b/d-engine-server/tests/cluster_lifecycle/scale_single_to_three_node_embedded.rs
@@ -52,14 +52,15 @@ general_raft_timeout_duration_in_ms = 5000
     let node1_config_path = "/tmp/scale_test_node1.toml";
     tokio::fs::write(node1_config_path, &node1_config).await?;
 
-    let db_path = data_dir.join("node1/db");
+    let node1_data_dir = data_dir.join("node1");
+    let db_path = node1_data_dir.join("db");
 
     tokio::fs::create_dir_all(&db_path).await?;
 
     let (storage1, sm1) = RocksDBUnifiedEngine::open(&db_path)?;
 
     let engine1 = DefaultEmbeddedEngine::start_custom(
-        &db_path,
+        &node1_data_dir,
         Arc::new(storage1),
         Arc::new(sm1),
         Some(node1_config_path),
@@ -108,14 +109,15 @@ general_raft_timeout_duration_in_ms = 5000
     let node2_config_path = "/tmp/scale_test_node2.toml";
     tokio::fs::write(node2_config_path, &node2_config).await?;
 
-    let db_path2 = data_dir.join("node2/db");
+    let node2_data_dir = data_dir.join("node2");
+    let db_path2 = node2_data_dir.join("db");
 
     tokio::fs::create_dir_all(&db_path2).await?;
 
     let (storage2, sm2) = RocksDBUnifiedEngine::open(&db_path2)?;
 
     let engine2 = DefaultEmbeddedEngine::start_custom(
-        &db_path2,
+        &node2_data_dir,
         Arc::new(storage2),
         Arc::new(sm2),
         Some(node2_config_path),
@@ -152,14 +154,15 @@ general_raft_timeout_duration_in_ms = 5000
     let node3_config_path = "/tmp/scale_test_node3.toml";
     tokio::fs::write(node3_config_path, &node3_config).await?;
 
-    let db_path3 = data_dir.join("node3/db");
+    let node3_data_dir = data_dir.join("node3");
+    let db_path3 = node3_data_dir.join("db");
 
     tokio::fs::create_dir_all(&db_path3).await?;
 
     let (storage3, sm3) = RocksDBUnifiedEngine::open(&db_path3)?;
 
     let engine3 = DefaultEmbeddedEngine::start_custom(
-        &db_path3,
+        &node3_data_dir,
         Arc::new(storage3),
         Arc::new(sm3),
         Some(node3_config_path),
@@ -322,7 +325,7 @@ election_timeout_max = 600
     let (storage1, sm1) = RocksDBUnifiedEngine::open(&db_path1)?;
 
     let engine1 = DefaultEmbeddedEngine::start_custom(
-        &db_path1,
+        &node1_db_root,
         Arc::new(storage1),
         Arc::new(sm1),
         Some(node1_config_path),
@@ -384,7 +387,7 @@ election_timeout_max = 6000
     let (storage2, sm2) = RocksDBUnifiedEngine::open(&db_path2)?;
 
     let engine2 = DefaultEmbeddedEngine::start_custom(
-        &db_path2,
+        &node2_db_root,
         Arc::new(storage2),
         Arc::new(sm2),
         Some(node2_config_path),
@@ -430,7 +433,7 @@ election_timeout_max = 6000
     let (storage3, sm3) = RocksDBUnifiedEngine::open(&db_path3)?;
 
     let engine3 = DefaultEmbeddedEngine::start_custom(
-        &db_path3,
+        &node3_db_root,
         Arc::new(storage3),
         Arc::new(sm3),
         Some(node3_config_path),
@@ -606,7 +609,7 @@ election_timeout_max = 6000
     tokio::fs::write(&node1_config_path, &node1_config_str).await?;
 
     let engine1 = DefaultEmbeddedEngine::start_custom(
-        &node1_db_path,
+        &node1_db_root,
         Arc::new(node1_storage),
         Arc::new(node1_state_machine),
         Some(&node1_config_path),

--- a/d-engine-server/tests/cluster_lifecycle/scale_single_to_three_node_embedded.rs
+++ b/d-engine-server/tests/cluster_lifecycle/scale_single_to_three_node_embedded.rs
@@ -8,7 +8,6 @@ use tracing_test::traced_test;
 
 use crate::common::create_rejoin_node_config;
 use crate::common::get_available_ports;
-use crate::common::node_config;
 use crate::common::retry_until;
 
 /// Test scaling from single-node to 3-node cluster
@@ -21,7 +20,7 @@ use crate::common::retry_until;
 #[traced_test]
 async fn test_scale_single_to_cluster() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = tempfile::tempdir()?;
-    let db_root_dir = temp_dir.path().join("db");
+    let data_dir = temp_dir.path().join("db");
     let log_dir = temp_dir.path().join("logs");
 
     let mut port_guard = get_available_ports(3).await;
@@ -40,7 +39,6 @@ listen_address = '127.0.0.1:{}'
 initial_cluster = [
     {{ id = 1, name = 'n1', address = '127.0.0.1:{}', role = 3, status = 3 }}
 ]
-db_root_dir = '{}'
 log_dir = '{}'
 
 [raft]
@@ -48,21 +46,20 @@ general_raft_timeout_duration_in_ms = 5000
 "#,
         ports[0],
         ports[0],
-        db_root_dir.display(),
         log_dir.display()
     );
 
     let node1_config_path = "/tmp/scale_test_node1.toml";
     tokio::fs::write(node1_config_path, &node1_config).await?;
 
-    let config = node_config(&node1_config);
-    let db_path = config.cluster.db_root_dir.join("node1/db");
+    let db_path = data_dir.join("node1/db");
 
     tokio::fs::create_dir_all(&db_path).await?;
 
     let (storage1, sm1) = RocksDBUnifiedEngine::open(&db_path)?;
 
     let engine1 = DefaultEmbeddedEngine::start_custom(
+        &db_path,
         Arc::new(storage1),
         Arc::new(sm1),
         Some(node1_config_path),
@@ -97,7 +94,6 @@ initial_cluster = [
     {{ id = 1, name = 'n1', address = '127.0.0.1:{}', role = 3, status = 3 }},
     {{ id = 2, name = 'n2', address = '127.0.0.1:{}', role = 4, status = 1 }}
 ]
-db_root_dir = '{}'
 log_dir = '{}'
 
 [raft]
@@ -106,21 +102,20 @@ general_raft_timeout_duration_in_ms = 5000
         ports[1],
         ports[0],
         ports[1],
-        db_root_dir.display(),
         log_dir.display()
     );
 
     let node2_config_path = "/tmp/scale_test_node2.toml";
     tokio::fs::write(node2_config_path, &node2_config).await?;
 
-    let config2 = node_config(&node2_config);
-    let db_path2 = config2.cluster.db_root_dir.join("node2/db");
+    let db_path2 = data_dir.join("node2/db");
 
     tokio::fs::create_dir_all(&db_path2).await?;
 
     let (storage2, sm2) = RocksDBUnifiedEngine::open(&db_path2)?;
 
     let engine2 = DefaultEmbeddedEngine::start_custom(
+        &db_path2,
         Arc::new(storage2),
         Arc::new(sm2),
         Some(node2_config_path),
@@ -142,7 +137,6 @@ initial_cluster = [
     {{ id = 2, name = 'n2', address = '127.0.0.1:{}', role = 1, status = 3 }},
     {{ id = 3, name = 'n3', address = '127.0.0.1:{}', role = 4, status = 1 }}
 ]
-db_root_dir = '{}'
 log_dir = '{}'
 
 [raft]
@@ -152,21 +146,20 @@ general_raft_timeout_duration_in_ms = 5000
         ports[0],
         ports[1],
         ports[2],
-        db_root_dir.display(),
         log_dir.display()
     );
 
     let node3_config_path = "/tmp/scale_test_node3.toml";
     tokio::fs::write(node3_config_path, &node3_config).await?;
 
-    let config3 = node_config(&node3_config);
-    let db_path3 = config3.cluster.db_root_dir.join("node3/db");
+    let db_path3 = data_dir.join("node3/db");
 
     tokio::fs::create_dir_all(&db_path3).await?;
 
     let (storage3, sm3) = RocksDBUnifiedEngine::open(&db_path3)?;
 
     let engine3 = DefaultEmbeddedEngine::start_custom(
+        &db_path3,
         Arc::new(storage3),
         Arc::new(sm3),
         Some(node3_config_path),
@@ -285,13 +278,13 @@ async fn test_leader_failover_after_dynamic_scaling() -> Result<(), Box<dyn std:
     // reset(&format!("{TEST_DIR}_failover")).await?;
 
     let temp_dir = tempfile::tempdir()?;
-    let db_root_dir = temp_dir.path().join("db");
+    let data_dir = temp_dir.path().join("db");
     let log_dir = temp_dir.path().join("logs");
 
     let mut port_guard = get_available_ports(3).await;
     port_guard.release_listeners();
     let ports = port_guard.as_slice();
-    let db_root = format!("{}_failover", db_root_dir.display());
+    let db_root = format!("{}_failover", data_dir.display());
     let log_dir = format!("{}_failover", log_dir.display());
 
     // ============================================================================
@@ -307,7 +300,6 @@ listen_address = '127.0.0.1:{}'
 initial_cluster = [
     {{ id = 1, name = 'n1', address = '127.0.0.1:{}', role = 3, status = 3 }}
 ]
-db_root_dir = '{}'
 log_dir = '{}'
 
 [raft]
@@ -316,14 +308,13 @@ general_raft_timeout_duration_in_ms = 100
 election_timeout_min = 300
 election_timeout_max = 600
 "#,
-        ports[0], ports[0], db_root, log_dir
+        ports[0], ports[0], log_dir
     );
 
     let node1_config_path = "/tmp/failover_test_node1.toml";
     tokio::fs::write(node1_config_path, &node1_config).await?;
 
-    let config1 = node_config(&node1_config);
-    let node1_db_root = config1.cluster.db_root_dir.join("node1");
+    let node1_db_root = std::path::PathBuf::from(&db_root).join("node1");
     let db_path1 = node1_db_root.join("db");
 
     tokio::fs::create_dir_all(&db_path1).await?;
@@ -331,6 +322,7 @@ election_timeout_max = 600
     let (storage1, sm1) = RocksDBUnifiedEngine::open(&db_path1)?;
 
     let engine1 = DefaultEmbeddedEngine::start_custom(
+        &db_path1,
         Arc::new(storage1),
         Arc::new(sm1),
         Some(node1_config_path),
@@ -370,7 +362,6 @@ initial_cluster = [
     {{ id = 1, name = 'n1', address = '127.0.0.1:{}', role = 3, status = 3 }},
     {{ id = 2, name = 'n2', address = '127.0.0.1:{}', role = 4, status = 1 }}
 ]
-db_root_dir = '{db_root}'
 log_dir = '{log_dir}'
 
 [raft]
@@ -385,8 +376,7 @@ election_timeout_max = 6000
     let node2_config_path = "/tmp/failover_test_node2.toml";
     tokio::fs::write(node2_config_path, &node2_config).await?;
 
-    let config2 = node_config(&node2_config);
-    let node2_db_root = config2.cluster.db_root_dir.join("node2");
+    let node2_db_root = std::path::PathBuf::from(&db_root).join("node2");
     let db_path2 = node2_db_root.join("db");
 
     tokio::fs::create_dir_all(&db_path2).await?;
@@ -394,6 +384,7 @@ election_timeout_max = 6000
     let (storage2, sm2) = RocksDBUnifiedEngine::open(&db_path2)?;
 
     let engine2 = DefaultEmbeddedEngine::start_custom(
+        &db_path2,
         Arc::new(storage2),
         Arc::new(sm2),
         Some(node2_config_path),
@@ -401,7 +392,10 @@ election_timeout_max = 6000
     .await?;
     info!("Node 2 started as Learner");
 
-    tokio::time::sleep(Duration::from_secs(3)).await;
+    // No wait here: promotion is batched to keep the voter count odd
+    // (calculate_safe_batch_size), so a lone learner is never promoted alone
+    // — node 2 only gets promoted once node 3 also joins (see the combined
+    // wait_for_voters(&[2, 3], ..) below). Start node 3 right away.
 
     // Start Node 3 as Learner
     let node3_config = format!(
@@ -414,7 +408,6 @@ initial_cluster = [
     {{ id = 2, name = 'n2', address = '127.0.0.1:{}', role = 1, status = 3 }},
     {{ id = 3, name = 'n3', address = '127.0.0.1:{}', role = 4, status = 1 }}
 ]
-db_root_dir = '{db_root}'
 log_dir = '{log_dir}'
 
 [raft]
@@ -429,8 +422,7 @@ election_timeout_max = 6000
     let node3_config_path = "/tmp/failover_test_node3.toml";
     tokio::fs::write(node3_config_path, &node3_config).await?;
 
-    let config3 = node_config(&node3_config);
-    let node3_db_root = config3.cluster.db_root_dir.join("node3");
+    let node3_db_root = std::path::PathBuf::from(&db_root).join("node3");
     let db_path3 = node3_db_root.join("db");
 
     tokio::fs::create_dir_all(&db_path3).await?;
@@ -438,6 +430,7 @@ election_timeout_max = 6000
     let (storage3, sm3) = RocksDBUnifiedEngine::open(&db_path3)?;
 
     let engine3 = DefaultEmbeddedEngine::start_custom(
+        &db_path3,
         Arc::new(storage3),
         Arc::new(sm3),
         Some(node3_config_path),
@@ -445,8 +438,8 @@ election_timeout_max = 6000
     .await?;
     info!("Node 3 started as Learner");
 
-    // Wait for Learner promotion and cluster stabilization
-    tokio::time::sleep(Duration::from_secs(15)).await;
+    // Wait for both Learners to sync and be promoted to Voter.
+    wait_for_voters(&engine1, &[2, 3], Duration::from_secs(20)).await;
 
     // Verify Node 1 still leader
     let leader_before_failover = engine1.wait_ready(Duration::from_secs(2)).await?;
@@ -457,11 +450,19 @@ election_timeout_max = 6000
 
     // Write data in 3-node cluster
     engine1.client().put(b"phase2-key".to_vec(), b"phase2-value".to_vec()).await?;
-    tokio::time::sleep(Duration::from_millis(500)).await;
 
-    // Verify replication to all nodes
+    // Verify replication to all nodes — retry_until instead of a flat sleep:
+    // get_eventual gives no visibility-latency guarantee, so a fixed sleep is
+    // either wasted time (usual case) or a flaky gap (under load).
     for (i, engine) in [&engine1, &engine2, &engine3].iter().enumerate() {
-        let val = engine.client().get_eventual(b"phase2-key".to_vec()).await?;
+        let client = engine.client();
+        let val = retry_until(
+            20,
+            Duration::from_millis(200),
+            || client.get_eventual(b"phase2-key".to_vec()),
+            |r| matches!(r, Ok(Some(_))),
+        )
+        .await?;
         assert_eq!(
             val.as_deref(),
             Some(b"phase2-value".as_ref()),
@@ -484,24 +485,18 @@ election_timeout_max = 6000
     engine1.stop().await?;
     info!("Node 1 stopped - cluster should detect leader failure and start election");
 
-    // Check state immediately after Node 1 stops
-    tokio::time::sleep(Duration::from_secs(2)).await;
-    println!("\n========== 2s AFTER NODE 1 STOPPED ==========");
-    println!("Node 2 and Node 3 should detect leader failure");
-    println!("If they are Voters with election timers, they should start election soon");
-    println!("==============================================\n");
-
-    // Wait for election timeout + re-election
-    // With election_timeout_min=3000ms, election should complete within ~5-8 seconds
-    tokio::time::sleep(Duration::from_secs(6)).await;
-
     // ============================================================================
     // Phase 4: Verify New Leader Election
     // ============================================================================
     info!("Phase 4: Verifying new leader election");
 
-    // Check new leader from Node 2's perspective
-    let new_leader = engine2.wait_ready(Duration::from_secs(5)).await?;
+    // Check new leader from Node 2's perspective. `wait_ready` returns
+    // whatever leader is *currently cached* — including the stale pre-crash
+    // value (node 1) if no new election has completed yet — so it's the
+    // wrong primitive here. `wait_for_new_leader` waits for the cached
+    // leader_id to actually change away from the crashed node.
+    let new_leader =
+        wait_for_new_leader(&engine2, initial_leader.leader_id, Duration::from_secs(20)).await;
     info!(
         "New leader elected: Node {} (term {})",
         new_leader.leader_id, new_leader.term
@@ -538,14 +533,20 @@ election_timeout_max = 6000
         .client()
         .put(b"phase3-key".to_vec(), b"phase3-value".to_vec())
         .await?;
-    tokio::time::sleep(Duration::from_millis(500)).await;
 
     // Verify all historical data preserved on remaining nodes
     for (i, engine) in [&engine2, &engine3].iter().enumerate() {
         let node_id = if i == 0 { 2 } else { 3 };
+        let client = engine.client();
 
         // Phase 1 data (before expansion)
-        let val1 = engine.client().get_eventual(b"phase1-key".to_vec()).await?;
+        let val1 = retry_until(
+            20,
+            Duration::from_millis(200),
+            || client.get_eventual(b"phase1-key".to_vec()),
+            |r| matches!(r, Ok(Some(_))),
+        )
+        .await?;
         assert_eq!(
             val1.as_deref(),
             Some(b"phase1-value".as_ref()),
@@ -553,7 +554,13 @@ election_timeout_max = 6000
         );
 
         // Phase 2 data (during 3-node operation)
-        let val2 = engine.client().get_eventual(b"phase2-key".to_vec()).await?;
+        let val2 = retry_until(
+            20,
+            Duration::from_millis(200),
+            || client.get_eventual(b"phase2-key".to_vec()),
+            |r| matches!(r, Ok(Some(_))),
+        )
+        .await?;
         assert_eq!(
             val2.as_deref(),
             Some(b"phase2-value".as_ref()),
@@ -561,7 +568,13 @@ election_timeout_max = 6000
         );
 
         // Phase 3 data (after failover)
-        let val3 = engine.client().get_eventual(b"phase3-key".to_vec()).await?;
+        let val3 = retry_until(
+            20,
+            Duration::from_millis(200),
+            || client.get_eventual(b"phase3-key".to_vec()),
+            |r| matches!(r, Ok(Some(_))),
+        )
+        .await?;
         assert_eq!(
             val3.as_deref(),
             Some(b"phase3-value".as_ref()),
@@ -578,7 +591,7 @@ election_timeout_max = 6000
 
     // Restart Node 1 (it was crashed at end of Phase 4)
     // Node 1 will rejoin as a follower since it already had membership
-    // Must use db_root (with _failover suffix), NOT db_root_dir — all nodes use db_root
+    // Must use db_root (with _failover suffix), NOT data_dir — all nodes use db_root
     let node1_db_root = std::path::PathBuf::from(&db_root).join("node1");
     let node1_db_path = node1_db_root.join("db");
 
@@ -586,17 +599,14 @@ election_timeout_max = 6000
     let (node1_storage, node1_state_machine) = RocksDBUnifiedEngine::open(&node1_db_path)?;
 
     // Node 1 config: rejoining as existing follower
-    let node1_config_str = create_rejoin_node_config(
-        1,
-        ports[0],
-        &[(1, ports[0]), (2, ports[1]), (3, ports[2])],
-        &db_root,
-    );
+    let node1_config_str =
+        create_rejoin_node_config(1, ports[0], &[(1, ports[0]), (2, ports[1]), (3, ports[2])]);
 
     let node1_config_path = "/tmp/d-engine-test-node1-phase6.toml".to_string();
     tokio::fs::write(&node1_config_path, &node1_config_str).await?;
 
     let engine1 = DefaultEmbeddedEngine::start_custom(
+        &node1_db_path,
         Arc::new(node1_storage),
         Arc::new(node1_state_machine),
         Some(&node1_config_path),
@@ -604,7 +614,6 @@ election_timeout_max = 6000
     .await?;
 
     info!("Node 1 restarted, waiting for leader recognition");
-    tokio::time::sleep(Duration::from_secs(2)).await;
 
     // Verify Node 1 rejoined the cluster (should be a follower)
     let node1_leader = engine1.wait_ready(Duration::from_secs(5)).await?;
@@ -673,8 +682,6 @@ election_timeout_max = 6000
         .put(b"phase6-key".to_vec(), b"phase6-value".to_vec())
         .await?;
 
-    tokio::time::sleep(Duration::from_millis(500)).await;
-
     // Verify all three nodes have the new data
     for (engine, node_id) in [
         (&engine1, 1),
@@ -685,7 +692,14 @@ election_timeout_max = 6000
             continue; // Skip if it's engine2 and we're checking engine3
         }
 
-        let val = engine.client().get_eventual(b"phase6-key".to_vec()).await?;
+        let client = engine.client();
+        let val = retry_until(
+            20,
+            Duration::from_millis(200),
+            || client.get_eventual(b"phase6-key".to_vec()),
+            |r| matches!(r, Ok(Some(_))),
+        )
+        .await?;
         assert_eq!(
             val.as_deref(),
             Some(b"phase6-value".as_ref()),
@@ -704,4 +718,54 @@ election_timeout_max = 6000
 
     info!("Test completed successfully - dynamic scaling with leader failover validated");
     Ok(())
+}
+
+/// Waits until every node_id in `voters` appears in the cluster's committed
+/// Voter set, via `watch_membership()` — event-driven, fires as soon as the
+/// promoting ConfChange commits, instead of sleeping for a worst-case bound.
+async fn wait_for_voters(
+    engine: &DefaultEmbeddedEngine,
+    voters: &[u32],
+    timeout: Duration,
+) {
+    let mut membership_rx = engine.watch_membership();
+    tokio::time::timeout(timeout, async {
+        loop {
+            let ready = {
+                let snapshot = membership_rx.borrow();
+                voters.iter().all(|id| snapshot.members.contains(id))
+            };
+            if ready {
+                return;
+            }
+            membership_rx.changed().await.ok();
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("nodes {voters:?} were not promoted to Voter within {timeout:?}"));
+}
+
+/// Waits until the cached leader differs from `old_leader_id`, via
+/// `leader_change_notifier()` — event-driven. `wait_ready()` is the wrong
+/// primitive for detecting a *new* election: it returns whatever leader is
+/// currently cached, including a stale pre-failure value if no new election
+/// has completed yet.
+async fn wait_for_new_leader(
+    engine: &DefaultEmbeddedEngine,
+    old_leader_id: u32,
+    timeout: Duration,
+) -> d_engine_server::LeaderInfo {
+    let mut rx = engine.leader_change_notifier();
+    tokio::time::timeout(timeout, async {
+        loop {
+            if let Some(info) = *rx.borrow()
+                && info.leader_id != old_leader_id
+            {
+                return info;
+            }
+            rx.changed().await.ok();
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("no leader other than {old_leader_id} elected within {timeout:?}"))
 }

--- a/d-engine-server/tests/cluster_membership/join_cluster_concurrent_joins_standalone.rs
+++ b/d-engine-server/tests/cluster_membership/join_cluster_concurrent_joins_standalone.rs
@@ -75,10 +75,8 @@ async fn test_join_cluster_scenario2() -> Result<(), ClientApiError> {
     // Use a temp directory for full test isolation — auto-cleaned on drop
     let tmp_dir = tempfile::tempdir().expect("failed to create tmpdir");
     let db_dir = tmp_dir.path().join("db");
-    let snapshot_dir = tmp_dir.path().join("snapshots");
     let log_dir = tmp_dir.path().join("logs");
     let db_dir = db_dir.to_str().unwrap();
-    let snapshot_dir = snapshot_dir.to_str().unwrap();
     let log_dir = log_dir.to_str().unwrap();
 
     // MODIFICATION: Use dynamic port allocation instead of hardcoded ports
@@ -149,8 +147,6 @@ async fn test_join_cluster_scenario2() -> Result<(), ClientApiError> {
         // Configure snapshot settings
         node_config.raft.snapshot.max_log_entries_before_snapshot = 10;
         node_config.raft.snapshot.cleanup_retain_count = 2;
-        node_config.raft.snapshot.snapshots_dir =
-            PathBuf::from(format!("{snapshot_dir}/{node_id}"));
         node_config.raft.snapshot.chunk_size = 100;
 
         // Calculate snapshot metadata
@@ -163,6 +159,7 @@ async fn test_join_cluster_scenario2() -> Result<(), ClientApiError> {
             prepare_state_machine(node_id as u32, &format!("{db_dir}/cs/{node_id}")).await,
         );
         let (graceful_tx, node_handle) = start_node(
+            format!("{db_dir}/cs/{node_id}"),
             node_config,
             Some(state_machine),
             Some(storage_engines[i].clone()),
@@ -187,7 +184,7 @@ async fn test_join_cluster_scenario2() -> Result<(), ClientApiError> {
 
     // Wait for node 3 snapshot to be generated — poll up to 15s
     {
-        let snapshot_path = format!("{snapshot_dir}/3");
+        let snapshot_path = format!("{db_dir}/cs/3/snapshots");
         let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
         loop {
             if check_path_contents(&snapshot_path).unwrap_or(false) {
@@ -224,12 +221,12 @@ async fn test_join_cluster_scenario2() -> Result<(), ClientApiError> {
     let mut node_config = node_config(&config);
     node_config.raft.snapshot.max_log_entries_before_snapshot = 10;
     node_config.raft.snapshot.cleanup_retain_count = 2;
-    node_config.raft.snapshot.snapshots_dir = PathBuf::from(format!("{}/{}", snapshot_dir, 4));
     node_config.raft.snapshot.chunk_size = 100;
 
     // Create fresh Arc for node 4 state machine to ensure single ownership
     let state_machine_4 = Arc::new(prepare_state_machine(4, &format!("{db_dir}/cs/4")).await);
     let (graceful_tx4, node_n4) = start_node(
+        format!("{db_dir}/cs/4"),
         node_config,
         Some(state_machine_4),
         Some(storage_engines[3].clone()),
@@ -267,12 +264,12 @@ async fn test_join_cluster_scenario2() -> Result<(), ClientApiError> {
     let mut node_config = common::node_config(&config);
     node_config.raft.snapshot.max_log_entries_before_snapshot = 10;
     node_config.raft.snapshot.cleanup_retain_count = 2;
-    node_config.raft.snapshot.snapshots_dir = PathBuf::from(format!("{}/{}", snapshot_dir, 5));
     node_config.raft.snapshot.chunk_size = 100;
 
     // Create fresh Arc for node 5 state machine to ensure single ownership
     let state_machine_5 = Arc::new(prepare_state_machine(5, &format!("{db_dir}/cs/5")).await);
     let (graceful_tx5, node_n5) = start_node(
+        format!("{db_dir}/cs/5"),
         node_config,
         Some(state_machine_5),
         Some(storage_engines[4].clone()),
@@ -287,7 +284,7 @@ async fn test_join_cluster_scenario2() -> Result<(), ClientApiError> {
     sleep(Duration::from_secs(5)).await;
 
     // Validate that the first new node has received the snapshot
-    let snapshot_path = format!("{snapshot_dir}/4");
+    let snapshot_path = format!("{db_dir}/cs/4/snapshots");
     assert!(check_path_contents(&snapshot_path).unwrap_or(false));
 
     // Verify that the first new node has all the data by re-opening state machine
@@ -300,7 +297,7 @@ async fn test_join_cluster_scenario2() -> Result<(), ClientApiError> {
     }
 
     // Validate that the second new node has received the snapshot
-    let snapshot_path = format!("{snapshot_dir}/5");
+    let snapshot_path = format!("{db_dir}/cs/5/snapshots");
     assert!(check_path_contents(&snapshot_path).unwrap_or(false));
 
     // Verify that the second new node has all the data by re-opening state machine
@@ -362,8 +359,8 @@ async fn create_node_config(
     node_id: u64,
     port: u16,
     cluster_nodes: &[(u16, u8, u8)], // (port, role, status)
-    db_root_dir: &str,
-    log_dir: &str,
+    _data_dir: &str,
+    _log_dir: &str,
 ) -> String {
     println!("Creating configuration for node {node_id} on port {port}");
 
@@ -385,8 +382,6 @@ async fn create_node_config(
         initial_cluster = [
             {initial_cluster_entries}
         ]
-        db_root_dir = '{db_root_dir}'
-        log_dir = '{log_dir}'
         "#
     )
 }

--- a/d-engine-server/tests/cluster_membership/join_cluster_single_join_standalone.rs
+++ b/d-engine-server/tests/cluster_membership/join_cluster_single_join_standalone.rs
@@ -3,7 +3,6 @@
 //! This test verifies that a new node can successfully join an existing Raft cluster,
 //! synchronize its state via snapshot, and become a fully functional member.
 
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -30,8 +29,7 @@ use crate::common::start_node;
 
 // Constants for test configuration
 const JOIN_CLUSTER_CASE1_DIR: &str = "join_cluster/case1";
-const SNAPSHOT_DIR: &str = "./snapshots/join_cluster/case1";
-const JOIN_CLUSTER_CASE1_DB_ROOT_DIR: &str = "./db/join_cluster/case1";
+const JOIN_CLUSTER_CASE1_DATA_DIR: &str = "./db/join_cluster/case1";
 const JOIN_CLUSTER_CASE1_LOG_DIR: &str = "./logs/join_cluster/case1";
 
 #[tokio::test]
@@ -50,17 +48,17 @@ async fn test_join_cluster_scenario1() -> Result<(), ClientApiError> {
     let last_log_id: u64 = 10;
 
     let storage_engine_1 =
-        prepare_storage_engine(1, &format!("{JOIN_CLUSTER_CASE1_DB_ROOT_DIR}/cs/1"), 0);
+        prepare_storage_engine(1, &format!("{JOIN_CLUSTER_CASE1_DATA_DIR}/cs/1"), 0);
     manipulate_log(&storage_engine_1, vec![1, 2, 3], 1).await;
     init_hard_state(&storage_engine_1, 1, None);
 
     let storage_engine_2 =
-        prepare_storage_engine(2, &format!("{JOIN_CLUSTER_CASE1_DB_ROOT_DIR}/cs/2"), 0);
+        prepare_storage_engine(2, &format!("{JOIN_CLUSTER_CASE1_DATA_DIR}/cs/2"), 0);
     manipulate_log(&storage_engine_2, vec![1, 2, 3, 4], 1).await;
     init_hard_state(&storage_engine_2, 1, None);
 
     let storage_engine_3 =
-        prepare_storage_engine(3, &format!("{JOIN_CLUSTER_CASE1_DB_ROOT_DIR}/cs/3"), 0);
+        prepare_storage_engine(3, &format!("{JOIN_CLUSTER_CASE1_DATA_DIR}/cs/3"), 0);
     manipulate_log(&storage_engine_3, (1..=3).collect(), 1).await;
     init_hard_state(&storage_engine_3, 2, None);
     manipulate_log(&storage_engine_3, (4..=last_log_id).collect(), 2).await;
@@ -88,7 +86,7 @@ async fn test_join_cluster_scenario1() -> Result<(), ClientApiError> {
             node_id,
             port,
             &initial_cluster_nodes,
-            &format!("{JOIN_CLUSTER_CASE1_DB_ROOT_DIR}/cs/{node_id}"),
+            &format!("{JOIN_CLUSTER_CASE1_DATA_DIR}/cs/{node_id}"),
             JOIN_CLUSTER_CASE1_LOG_DIR,
         )
         .await;
@@ -98,8 +96,6 @@ async fn test_join_cluster_scenario1() -> Result<(), ClientApiError> {
         // Configure snapshot settings
         node_config.raft.snapshot.max_log_entries_before_snapshot = 10;
         node_config.raft.snapshot.cleanup_retain_count = 2;
-        node_config.raft.snapshot.snapshots_dir =
-            PathBuf::from(format!("{SNAPSHOT_DIR}/{node_id}"));
         node_config.raft.snapshot.chunk_size = 100;
 
         // Calculate snapshot metadata
@@ -110,7 +106,7 @@ async fn test_join_cluster_scenario1() -> Result<(), ClientApiError> {
         let state_machine = Arc::new(
             prepare_state_machine(
                 node_id as u32,
-                &format!("{JOIN_CLUSTER_CASE1_DB_ROOT_DIR}/cs/{node_id}"),
+                &format!("{JOIN_CLUSTER_CASE1_DATA_DIR}/cs/{node_id}"),
             )
             .await,
         );
@@ -122,8 +118,13 @@ async fn test_join_cluster_scenario1() -> Result<(), ClientApiError> {
         };
 
         // Start the node with its specific state machine and storage engine
-        let (graceful_tx, node_handle) =
-            start_node(node_config, Some(state_machine), Some(storage_engine)).await?;
+        let (graceful_tx, node_handle) = start_node(
+            format!("{JOIN_CLUSTER_CASE1_DATA_DIR}/cs/{node_id}"),
+            node_config,
+            Some(state_machine),
+            Some(storage_engine),
+        )
+        .await?;
 
         ctx.graceful_txs.push(graceful_tx);
         ctx.node_handles.push(node_handle);
@@ -145,7 +146,7 @@ async fn test_join_cluster_scenario1() -> Result<(), ClientApiError> {
     sleep(Duration::from_secs(3)).await;
 
     // Verify snapshot file exists on the leader (node 3)
-    let snapshot_path = format!("{SNAPSHOT_DIR}/3");
+    let snapshot_path = format!("{JOIN_CLUSTER_CASE1_DATA_DIR}/cs/3/snapshots");
     assert!(check_path_contents(&snapshot_path).unwrap_or(false));
 
     // Create cluster definition including the new node
@@ -163,7 +164,7 @@ async fn test_join_cluster_scenario1() -> Result<(), ClientApiError> {
         4,
         new_node_port,
         &full_cluster_nodes,
-        &format!("{JOIN_CLUSTER_CASE1_DB_ROOT_DIR}/cs/4"),
+        &format!("{JOIN_CLUSTER_CASE1_DATA_DIR}/cs/4"),
         JOIN_CLUSTER_CASE1_LOG_DIR,
     )
     .await;
@@ -171,16 +172,16 @@ async fn test_join_cluster_scenario1() -> Result<(), ClientApiError> {
     let mut node_config = node_config(&config);
     node_config.raft.snapshot.max_log_entries_before_snapshot = 10;
     node_config.raft.snapshot.cleanup_retain_count = 2;
-    node_config.raft.snapshot.snapshots_dir = PathBuf::from(format!("{}/{}", SNAPSHOT_DIR, 4));
     node_config.raft.snapshot.chunk_size = 100;
 
     // Create state machine and storage engine for node 4 (Arc refcount = 1)
     let node4_state_machine =
-        Arc::new(prepare_state_machine(4, &format!("{JOIN_CLUSTER_CASE1_DB_ROOT_DIR}/cs/4")).await);
+        Arc::new(prepare_state_machine(4, &format!("{JOIN_CLUSTER_CASE1_DATA_DIR}/cs/4")).await);
     let node4_storage_engine =
-        prepare_storage_engine(4, &format!("{JOIN_CLUSTER_CASE1_DB_ROOT_DIR}/cs/4"), 0);
+        prepare_storage_engine(4, &format!("{JOIN_CLUSTER_CASE1_DATA_DIR}/cs/4"), 0);
 
     let (graceful_tx4, node_n4) = start_node(
+        format!("{JOIN_CLUSTER_CASE1_DATA_DIR}/cs/4"),
         node_config,
         Some(node4_state_machine),
         Some(node4_storage_engine),
@@ -194,12 +195,12 @@ async fn test_join_cluster_scenario1() -> Result<(), ClientApiError> {
     sleep(Duration::from_secs(3)).await;
 
     // Validate that the new node has received the snapshot
-    let snapshot_path = format!("{SNAPSHOT_DIR}/4");
+    let snapshot_path = format!("{JOIN_CLUSTER_CASE1_DATA_DIR}/cs/4/snapshots");
     assert!(check_path_contents(&snapshot_path).unwrap_or(false));
 
     // Verify that the new node has all the data by opening its state machine
     let verification_sm =
-        prepare_state_machine(4, &format!("{JOIN_CLUSTER_CASE1_DB_ROOT_DIR}/cs/4")).await;
+        prepare_state_machine(4, &format!("{JOIN_CLUSTER_CASE1_DATA_DIR}/cs/4")).await;
     for i in 1..=10 {
         let value = verification_sm.get(&safe_kv(i)).unwrap();
         assert_eq!(value, Some(Bytes::from(safe_kv(i).to_vec())));
@@ -216,8 +217,8 @@ async fn create_node_config(
     node_id: u64,
     port: u16,
     cluster_nodes: &[(u16, u8, u8)], // (port, role, status)
-    db_root_dir: &str,
-    log_dir: &str,
+    _data_dir: &str,
+    _log_dir: &str,
 ) -> String {
     debug!(
         "Creating configuration for node {} on port {}",
@@ -242,8 +243,6 @@ async fn create_node_config(
         initial_cluster = [
             {initial_cluster_entries}
         ]
-        db_root_dir = '{db_root_dir}'
-        log_dir = '{log_dir}'
         "#
     )
 }

--- a/d-engine-server/tests/cluster_state_and_metadata/cluster_state_consensus_embedded.rs
+++ b/d-engine-server/tests/cluster_state_and_metadata/cluster_state_consensus_embedded.rs
@@ -98,33 +98,36 @@ listen_address = '127.0.0.1:{}'
     tokio::fs::write(node3_config_path, &node3_config).await?;
 
     // Start engines
-    let db_path1 = data_dir.join("node1/db");
+    let node1_data_dir = data_dir.join("node1");
+    let db_path1 = node1_data_dir.join("db");
     tokio::fs::create_dir_all(&db_path1).await?;
     let (storage1, sm1) = RocksDBUnifiedEngine::open(&db_path1)?;
     let engine1 = DefaultEmbeddedEngine::start_custom(
-        &db_path1,
+        &node1_data_dir,
         Arc::new(storage1),
         Arc::new(sm1),
         Some(node1_config_path),
     )
     .await?;
 
-    let db_path2 = data_dir.join("node2/db");
+    let node2_data_dir = data_dir.join("node2");
+    let db_path2 = node2_data_dir.join("db");
     tokio::fs::create_dir_all(&db_path2).await?;
     let (storage2, sm2) = RocksDBUnifiedEngine::open(&db_path2)?;
     let engine2 = DefaultEmbeddedEngine::start_custom(
-        &db_path2,
+        &node2_data_dir,
         Arc::new(storage2),
         Arc::new(sm2),
         Some(node2_config_path),
     )
     .await?;
 
-    let db_path3 = data_dir.join("node3/db");
+    let node3_data_dir = data_dir.join("node3");
+    let db_path3 = node3_data_dir.join("db");
     tokio::fs::create_dir_all(&db_path3).await?;
     let (storage3, sm3) = RocksDBUnifiedEngine::open(&db_path3)?;
     let engine3 = DefaultEmbeddedEngine::start_custom(
-        &db_path3,
+        &node3_data_dir,
         Arc::new(storage3),
         Arc::new(sm3),
         Some(node3_config_path),
@@ -243,33 +246,36 @@ general_raft_timeout_duration_in_ms = 3000
     tokio::fs::write(node3_config_path, &node3_config).await?;
 
     // Start all nodes
-    let db_path1 = data_dir.join("node1/db");
+    let node1_data_dir = data_dir.join("node1");
+    let db_path1 = node1_data_dir.join("db");
     tokio::fs::create_dir_all(&db_path1).await?;
     let (storage1, sm1) = RocksDBUnifiedEngine::open(&db_path1)?;
     let engine1 = DefaultEmbeddedEngine::start_custom(
-        &db_path1,
+        &node1_data_dir,
         Arc::new(storage1),
         Arc::new(sm1),
         Some(node1_config_path),
     )
     .await?;
 
-    let db_path2 = data_dir.join("node2/db");
+    let node2_data_dir = data_dir.join("node2");
+    let db_path2 = node2_data_dir.join("db");
     tokio::fs::create_dir_all(&db_path2).await?;
     let (storage2, sm2) = RocksDBUnifiedEngine::open(&db_path2)?;
     let engine2 = DefaultEmbeddedEngine::start_custom(
-        &db_path2,
+        &node2_data_dir,
         Arc::new(storage2),
         Arc::new(sm2),
         Some(node2_config_path),
     )
     .await?;
 
-    let db_path3 = data_dir.join("node3/db");
+    let node3_data_dir = data_dir.join("node3");
+    let db_path3 = node3_data_dir.join("db");
     tokio::fs::create_dir_all(&db_path3).await?;
     let (storage3, sm3) = RocksDBUnifiedEngine::open(&db_path3)?;
     let engine3 = DefaultEmbeddedEngine::start_custom(
-        &db_path3,
+        &node3_data_dir,
         Arc::new(storage3),
         Arc::new(sm3),
         Some(node3_config_path),
@@ -420,33 +426,36 @@ general_raft_timeout_duration_in_ms = 3000
     tokio::fs::write(node3_config_path, &node3_config).await?;
 
     // Start all nodes
-    let db_path1 = data_dir.join("node1/db");
+    let node1_data_dir = data_dir.join("node1");
+    let db_path1 = node1_data_dir.join("db");
     tokio::fs::create_dir_all(&db_path1).await?;
     let (storage1, sm1) = RocksDBUnifiedEngine::open(&db_path1)?;
     let engine1 = DefaultEmbeddedEngine::start_custom(
-        &db_path1,
+        &node1_data_dir,
         Arc::new(storage1),
         Arc::new(sm1),
         Some(node1_config_path),
     )
     .await?;
 
-    let db_path2 = data_dir.join("node2/db");
+    let node2_data_dir = data_dir.join("node2");
+    let db_path2 = node2_data_dir.join("db");
     tokio::fs::create_dir_all(&db_path2).await?;
     let (storage2, sm2) = RocksDBUnifiedEngine::open(&db_path2)?;
     let engine2 = DefaultEmbeddedEngine::start_custom(
-        &db_path2,
+        &node2_data_dir,
         Arc::new(storage2),
         Arc::new(sm2),
         Some(node2_config_path),
     )
     .await?;
 
-    let db_path3 = data_dir.join("node3/db");
+    let node3_data_dir = data_dir.join("node3");
+    let db_path3 = node3_data_dir.join("db");
     tokio::fs::create_dir_all(&db_path3).await?;
     let (storage3, sm3) = RocksDBUnifiedEngine::open(&db_path3)?;
     let engine3 = DefaultEmbeddedEngine::start_custom(
-        &db_path3,
+        &node3_data_dir,
         Arc::new(storage3),
         Arc::new(sm3),
         Some(node3_config_path),

--- a/d-engine-server/tests/cluster_state_and_metadata/cluster_state_consensus_embedded.rs
+++ b/d-engine-server/tests/cluster_state_and_metadata/cluster_state_consensus_embedded.rs
@@ -6,7 +6,6 @@
 //! - Cluster view consistency
 
 use crate::common::get_available_ports;
-use crate::common::node_config;
 use d_engine_server::DefaultEmbeddedEngine;
 use std::sync::Arc;
 use std::time::Duration;
@@ -31,7 +30,7 @@ use d_engine_server::RocksDBUnifiedEngine;
 #[traced_test]
 async fn test_multi_node_single_leader() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = tempfile::tempdir()?;
-    let db_root_dir = temp_dir.path().join("db");
+    let data_dir = temp_dir.path().join("db");
     let log_dir = temp_dir.path().join("logs");
 
     let mut port_guard = get_available_ports(3).await;
@@ -48,7 +47,6 @@ initial_cluster = [
     {{ id = 2, name = 'n2', address = '127.0.0.1:{}', role = 1, status = 3 }},
     {{ id = 3, name = 'n3', address = '127.0.0.1:{}', role = 1, status = 3 }}
 ]
-db_root_dir = '{}'
 log_dir = '{}'
 
 [raft]
@@ -57,7 +55,6 @@ general_raft_timeout_duration_in_ms = 3000
         ports[0],
         ports[1],
         ports[2],
-        db_root_dir.display(),
         log_dir.display()
     );
 
@@ -101,33 +98,33 @@ listen_address = '127.0.0.1:{}'
     tokio::fs::write(node3_config_path, &node3_config).await?;
 
     // Start engines
-    let config1 = node_config(&node1_config);
-    let db_path1 = config1.cluster.db_root_dir.join("node1/db");
+    let db_path1 = data_dir.join("node1/db");
     tokio::fs::create_dir_all(&db_path1).await?;
     let (storage1, sm1) = RocksDBUnifiedEngine::open(&db_path1)?;
     let engine1 = DefaultEmbeddedEngine::start_custom(
+        &db_path1,
         Arc::new(storage1),
         Arc::new(sm1),
         Some(node1_config_path),
     )
     .await?;
 
-    let config2 = node_config(&node2_config);
-    let db_path2 = config2.cluster.db_root_dir.join("node2/db");
+    let db_path2 = data_dir.join("node2/db");
     tokio::fs::create_dir_all(&db_path2).await?;
     let (storage2, sm2) = RocksDBUnifiedEngine::open(&db_path2)?;
     let engine2 = DefaultEmbeddedEngine::start_custom(
+        &db_path2,
         Arc::new(storage2),
         Arc::new(sm2),
         Some(node2_config_path),
     )
     .await?;
 
-    let config3 = node_config(&node3_config);
-    let db_path3 = config3.cluster.db_root_dir.join("node3/db");
+    let db_path3 = data_dir.join("node3/db");
     tokio::fs::create_dir_all(&db_path3).await?;
     let (storage3, sm3) = RocksDBUnifiedEngine::open(&db_path3)?;
     let engine3 = DefaultEmbeddedEngine::start_custom(
+        &db_path3,
         Arc::new(storage3),
         Arc::new(sm3),
         Some(node3_config_path),
@@ -196,7 +193,7 @@ listen_address = '127.0.0.1:{}'
 #[traced_test]
 async fn test_leader_info_consistency_across_cluster() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = tempfile::tempdir()?;
-    let db_root_dir = temp_dir.path().join("db");
+    let data_dir = temp_dir.path().join("db");
     let log_dir = temp_dir.path().join("logs");
 
     let mut port_guard = get_available_ports(3).await;
@@ -213,7 +210,6 @@ initial_cluster = [
     {{ id = 2, name = 'n2', address = '127.0.0.1:{}', role = 1, status = 3 }},
     {{ id = 3, name = 'n3', address = '127.0.0.1:{}', role = 1, status = 3 }}
 ]
-db_root_dir = '{}'
 log_dir = '{}'
 
 [raft]
@@ -222,7 +218,6 @@ general_raft_timeout_duration_in_ms = 3000
         ports[0],
         ports[1],
         ports[2],
-        db_root_dir.display(),
         log_dir.display()
     );
 
@@ -248,33 +243,33 @@ general_raft_timeout_duration_in_ms = 3000
     tokio::fs::write(node3_config_path, &node3_config).await?;
 
     // Start all nodes
-    let config1 = node_config(&node1_config);
-    let db_path1 = config1.cluster.db_root_dir.join("node1/db");
+    let db_path1 = data_dir.join("node1/db");
     tokio::fs::create_dir_all(&db_path1).await?;
     let (storage1, sm1) = RocksDBUnifiedEngine::open(&db_path1)?;
     let engine1 = DefaultEmbeddedEngine::start_custom(
+        &db_path1,
         Arc::new(storage1),
         Arc::new(sm1),
         Some(node1_config_path),
     )
     .await?;
 
-    let config2 = node_config(&node2_config);
-    let db_path2 = config2.cluster.db_root_dir.join("node2/db");
+    let db_path2 = data_dir.join("node2/db");
     tokio::fs::create_dir_all(&db_path2).await?;
     let (storage2, sm2) = RocksDBUnifiedEngine::open(&db_path2)?;
     let engine2 = DefaultEmbeddedEngine::start_custom(
+        &db_path2,
         Arc::new(storage2),
         Arc::new(sm2),
         Some(node2_config_path),
     )
     .await?;
 
-    let config3 = node_config(&node3_config);
-    let db_path3 = config3.cluster.db_root_dir.join("node3/db");
+    let db_path3 = data_dir.join("node3/db");
     tokio::fs::create_dir_all(&db_path3).await?;
     let (storage3, sm3) = RocksDBUnifiedEngine::open(&db_path3)?;
     let engine3 = DefaultEmbeddedEngine::start_custom(
+        &db_path3,
         Arc::new(storage3),
         Arc::new(sm3),
         Some(node3_config_path),
@@ -375,7 +370,7 @@ general_raft_timeout_duration_in_ms = 3000
 #[traced_test]
 async fn test_leader_failover_state_change() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = tempfile::tempdir()?;
-    let db_root_dir = temp_dir.path().join("db");
+    let data_dir = temp_dir.path().join("db");
     let log_dir = temp_dir.path().join("logs");
 
     let mut port_guard = get_available_ports(3).await;
@@ -392,7 +387,6 @@ initial_cluster = [
     {{ id = 2, name = 'n2', address = '127.0.0.1:{}', role = 1, status = 3 }},
     {{ id = 3, name = 'n3', address = '127.0.0.1:{}', role = 1, status = 3 }}
 ]
-db_root_dir = '{}'
 log_dir = '{}'
 
 [raft]
@@ -401,7 +395,6 @@ general_raft_timeout_duration_in_ms = 3000
         ports[0],
         ports[1],
         ports[2],
-        db_root_dir.display(),
         log_dir.display()
     );
 
@@ -427,33 +420,33 @@ general_raft_timeout_duration_in_ms = 3000
     tokio::fs::write(node3_config_path, &node3_config).await?;
 
     // Start all nodes
-    let config1 = node_config(&node1_config);
-    let db_path1 = config1.cluster.db_root_dir.join("node1/db");
+    let db_path1 = data_dir.join("node1/db");
     tokio::fs::create_dir_all(&db_path1).await?;
     let (storage1, sm1) = RocksDBUnifiedEngine::open(&db_path1)?;
     let engine1 = DefaultEmbeddedEngine::start_custom(
+        &db_path1,
         Arc::new(storage1),
         Arc::new(sm1),
         Some(node1_config_path),
     )
     .await?;
 
-    let config2 = node_config(&node2_config);
-    let db_path2 = config2.cluster.db_root_dir.join("node2/db");
+    let db_path2 = data_dir.join("node2/db");
     tokio::fs::create_dir_all(&db_path2).await?;
     let (storage2, sm2) = RocksDBUnifiedEngine::open(&db_path2)?;
     let engine2 = DefaultEmbeddedEngine::start_custom(
+        &db_path2,
         Arc::new(storage2),
         Arc::new(sm2),
         Some(node2_config_path),
     )
     .await?;
 
-    let config3 = node_config(&node3_config);
-    let db_path3 = config3.cluster.db_root_dir.join("node3/db");
+    let db_path3 = data_dir.join("node3/db");
     tokio::fs::create_dir_all(&db_path3).await?;
     let (storage3, sm3) = RocksDBUnifiedEngine::open(&db_path3)?;
     let engine3 = DefaultEmbeddedEngine::start_custom(
+        &db_path3,
         Arc::new(storage3),
         Arc::new(sm3),
         Some(node3_config_path),

--- a/d-engine-server/tests/cluster_state_and_metadata/metadata_api_standalone.rs
+++ b/d-engine-server/tests/cluster_state_and_metadata/metadata_api_standalone.rs
@@ -26,7 +26,6 @@ use crate::common::reset;
 use crate::common::start_node;
 
 const TEST_DIR: &str = "cluster_start_stop/metadata_api";
-const DB_ROOT_DIR: &str = "./db/cluster_start_stop/metadata_api";
 const LOG_DIR: &str = "./logs/cluster_start_stop/metadata_api";
 
 /// Test: GetClusterMembership returns current_leader_id after bootstrap
@@ -45,10 +44,23 @@ async fn test_metadata_returns_leader_id_after_bootstrap() -> Result<(), ClientA
 
     // Start 3-node cluster
     info!("Starting 3-node cluster");
+    let temp_dir = tempfile::Builder::new()
+        .prefix("d-engine-metadata-api-")
+        .tempdir()
+        .expect("tempdir");
     for (i, port) in ports.iter().enumerate() {
+        let node_data_dir = temp_dir.path().join(format!("node{}", i + 1));
         let (graceful_tx, node_handle) = start_node(
+            &node_data_dir,
             node_config(
-                &create_node_config((i + 1) as u64, *port, ports, DB_ROOT_DIR, LOG_DIR).await,
+                &create_node_config(
+                    (i + 1) as u64,
+                    *port,
+                    ports,
+                    &node_data_dir.to_string_lossy(),
+                    LOG_DIR,
+                )
+                .await,
             ),
             None,
             None,
@@ -110,10 +122,23 @@ async fn test_concurrent_metadata_requests_consistency() -> Result<(), ClientApi
 
     // Start 3-node cluster
     info!("Starting 3-node cluster for concurrent metadata test");
+    let temp_dir = tempfile::Builder::new()
+        .prefix("d-engine-metadata-api-")
+        .tempdir()
+        .expect("tempdir");
     for (i, port) in ports.iter().enumerate() {
+        let node_data_dir = temp_dir.path().join(format!("node{}", i + 1));
         let (graceful_tx, node_handle) = start_node(
+            &node_data_dir,
             node_config(
-                &create_node_config((i + 1) as u64, *port, ports, DB_ROOT_DIR, LOG_DIR).await,
+                &create_node_config(
+                    (i + 1) as u64,
+                    *port,
+                    ports,
+                    &node_data_dir.to_string_lossy(),
+                    LOG_DIR,
+                )
+                .await,
             ),
             None,
             None,
@@ -200,10 +225,23 @@ async fn test_metadata_updates_after_leader_change() -> Result<(), ClientApiErro
 
     // Start 3-node cluster
     info!("Starting 3-node cluster");
+    let temp_dir = tempfile::Builder::new()
+        .prefix("d-engine-metadata-api-")
+        .tempdir()
+        .expect("tempdir");
     for (i, port) in ports.iter().enumerate() {
+        let node_data_dir = temp_dir.path().join(format!("node{}", i + 1));
         let (graceful_tx, node_handle) = start_node(
+            &node_data_dir,
             node_config(
-                &create_node_config((i + 1) as u64, *port, ports, DB_ROOT_DIR, LOG_DIR).await,
+                &create_node_config(
+                    (i + 1) as u64,
+                    *port,
+                    ports,
+                    &node_data_dir.to_string_lossy(),
+                    LOG_DIR,
+                )
+                .await,
             ),
             None,
             None,

--- a/d-engine-server/tests/common/mod.rs
+++ b/d-engine-server/tests/common/mod.rs
@@ -269,14 +269,16 @@ pub async fn start_cluster(
             .prefix("d-engine-start-cluster-")
             .tempdir()
             .expect("tempdir");
-        let (tx, handle) = start_node(node_data_dir.keep(), config, None, None).await?;
-        controllers.push((tx, handle));
+        let (tx, handle) = start_node(node_data_dir.path(), config, None, None).await?;
+        // Keep the TempDir guard alive alongside its node until shutdown — it
+        // cleans up automatically on drop instead of leaking into /tmp.
+        controllers.push((tx, handle, node_data_dir));
     }
 
     // Perform test operations...
 
     // Shut down all nodes
-    for (tx, handle) in controllers {
+    for (tx, handle, _node_data_dir) in controllers {
         tx.send(()).expect("Should succeed to send shutdown");
         handle.await??;
     }
@@ -307,9 +309,9 @@ pub async fn start_node(
         Some(s) => s,
         None => {
             let storage_path = data_dir.join("storage_engine");
-            Arc::new(
-                FileStorageEngine::new(storage_path).expect("Failed to create file storage engine"),
-            )
+            Arc::new(FileStorageEngine::new(storage_path).map_err(|e| {
+                std::io::Error::other(format!("failed to create file storage engine: {e}"))
+            })?)
         }
     };
 
@@ -319,18 +321,34 @@ pub async fn start_node(
         None => {
             let state_machine_path = data_dir.join("state_machine");
             Arc::new(
-                FileStateMachine::new(state_machine_path)
-                    .await
-                    .expect("Failed to create file state machine"),
+                FileStateMachine::new(state_machine_path).await.map_err(|e| {
+                    std::io::Error::other(format!("failed to create file state machine: {e}"))
+                })?,
             )
         }
     };
 
-    let handle = tokio::spawn(async move {
+    let mut handle = tokio::spawn(async move {
         StandaloneEngine::start_node(data_dir, storage_engine, state_machine, graceful_rx, config)
             .await
             .map_err(|e| std::io::Error::other(format!("node exited with error: {e}")).into())
     });
+
+    // `start_node` blocks until shutdown once it actually starts, so a real
+    // startup failure (e.g. the data_dir lock rejecting a concurrent start)
+    // surfaces here within milliseconds. Give it a short window: if it exits
+    // that fast, something is already wrong — report it now instead of
+    // letting the caller find out much later at shutdown.
+    tokio::select! {
+        joined = &mut handle => {
+            let result = joined.map_err(|e| std::io::Error::other(format!("node task panicked: {e}")))?;
+            return match result {
+                Ok(()) => Err(std::io::Error::other("node exited before it started running").into()),
+                Err(e) => Err(e),
+            };
+        }
+        _ = time::sleep(Duration::from_millis(300)) => {}
+    }
 
     Ok((graceful_tx, handle))
 }

--- a/d-engine-server/tests/common/mod.rs
+++ b/d-engine-server/tests/common/mod.rs
@@ -28,8 +28,7 @@ use d_engine_server::HardState;
 use d_engine_server::LeaderInfo;
 use d_engine_server::LogStore;
 use d_engine_server::MetaStore;
-use d_engine_server::Node;
-use d_engine_server::NodeBuilder;
+use d_engine_server::StandaloneEngine;
 use d_engine_server::StorageEngine;
 use d_engine_server::node::RaftTypeConfig;
 use prost::Message;
@@ -100,8 +99,8 @@ pub async fn create_node_config(
     node_id: u64,
     port: u16,
     cluster_ports: &[u16],
-    db_root_dir: &str,
-    log_dir: &str,
+    _data_dir: &str,
+    _log_dir: &str,
 ) -> String {
     let initial_cluster_entries = cluster_ports
         .iter()
@@ -123,8 +122,6 @@ pub async fn create_node_config(
         initial_cluster = [
             {initial_cluster_entries}
         ]
-        db_root_dir = '{db_root_dir}'
-        log_dir = '{log_dir}'
 
         [raft.persistence]
         strategy = "MemFirst"
@@ -150,8 +147,8 @@ pub async fn create_node_config_with_role(
     port: u16,
     cluster_ports: &[u16],
     node_role: i32, // 1 = VOTER, 4 = LEARNER
-    db_root_dir: &str,
-    log_dir: &str,
+    _data_dir: &str,
+    _log_dir: &str,
 ) -> String {
     let initial_cluster_entries = cluster_ports
         .iter()
@@ -175,8 +172,6 @@ pub async fn create_node_config_with_role(
         initial_cluster = [
             {initial_cluster_entries}
         ]
-        db_root_dir = '{db_root_dir}'
-        log_dir = '{log_dir}'
 
         [raft.persistence]
         strategy = "MemFirst"
@@ -220,11 +215,6 @@ pub fn node_config(cluster_toml: &str) -> RaftNodeConfig {
             max_log_entries_before_snapshot: 1,
             cleanup_retain_count: 2,
             retained_log_entries: 1,
-            snapshots_dir: config
-                .cluster
-                .db_root_dir
-                .join("snapshots")
-                .join(config.cluster.node_id.to_string()),
             ..Default::default()
         },
         persistence: PersistenceConfig {
@@ -249,7 +239,8 @@ pub fn node_config(cluster_toml: &str) -> RaftNodeConfig {
     let append_policy = BackoffPolicy {
         max_retries: 2,
         timeout_ms: 200,
-        ..Default::default()
+        base_delay_ms: 10,
+        max_delay_ms: 100,
     };
 
     // Election retry policy - increased for test stability during concurrent node startup
@@ -274,7 +265,11 @@ pub async fn start_cluster(
     // Start all nodes
     let mut controllers = vec![];
     for config in nodes_config {
-        let (tx, handle) = start_node(config, None, None).await?;
+        let node_data_dir = tempfile::Builder::new()
+            .prefix("d-engine-start-cluster-")
+            .tempdir()
+            .expect("tempdir");
+        let (tx, handle) = start_node(node_data_dir.keep(), config, None, None).await?;
         controllers.push((tx, handle));
     }
 
@@ -288,7 +283,12 @@ pub async fn start_cluster(
 
     Ok(())
 }
+/// Starts a node the same way an external client would — through the public
+/// `StandaloneEngine::start_node` API, not the crate-internal `NodeBuilder`.
+/// These integration tests simulate external client behavior; they never
+/// touch the raw `Node` type.
 pub async fn start_node(
+    data_dir: impl AsRef<Path>,
     config: RaftNodeConfig,
     state_machine: Option<Arc<SMOF<RaftTypeConfig<FileStorageEngine, FileStateMachine>>>>,
     storage_engine: Option<Arc<SOF<RaftTypeConfig<FileStorageEngine, FileStateMachine>>>>,
@@ -300,86 +300,39 @@ pub async fn start_node(
     ClientApiError,
 > {
     let (graceful_tx, graceful_rx) = watch::channel(());
-
-    let node = build_node(config, graceful_rx, state_machine, storage_engine).await?;
-
-    let node_clone = node.clone();
-    let node_id = node.node_id();
-    let handle = tokio::spawn(async move { run_node(node_id, node_clone).await });
-
-    Ok((graceful_tx, handle))
-}
-
-async fn build_node(
-    config: RaftNodeConfig,
-    graceful_rx: watch::Receiver<()>,
-    state_machine: Option<Arc<SMOF<RaftTypeConfig<FileStorageEngine, FileStateMachine>>>>,
-    storage_engine: Option<Arc<SOF<RaftTypeConfig<FileStorageEngine, FileStateMachine>>>>,
-) -> std::result::Result<
-    Arc<Node<RaftTypeConfig<FileStorageEngine, FileStateMachine>>>,
-    ClientApiError,
-> {
-    // Prepare raft log entries
-    let mut builder = NodeBuilder::new(None, graceful_rx).node_config(config.clone());
+    let data_dir = data_dir.as_ref().to_path_buf();
 
     // Use provided storage engine or create a new one with temp directory
-    let storage_engine = if let Some(s) = storage_engine {
-        s
-    } else {
-        let storage_path = config
-            .cluster
-            .db_root_dir
-            .clone()
-            .join(config.cluster.node_id.to_string())
-            .join("storage_engine");
-        Arc::new(
-            FileStorageEngine::new(storage_path).expect("Failed to create file storage engine"),
-        )
+    let storage_engine = match storage_engine {
+        Some(s) => s,
+        None => {
+            let storage_path = data_dir.join("storage_engine");
+            Arc::new(
+                FileStorageEngine::new(storage_path).expect("Failed to create file storage engine"),
+            )
+        }
     };
-
-    builder = builder.storage_engine(storage_engine);
 
     // Use provided state machine or create a new one with temp directory
-    let state_machine = if let Some(sm) = state_machine {
-        sm
-    } else {
-        let state_machine_path = config
-            .cluster
-            .db_root_dir
-            .join(config.cluster.node_id.to_string())
-            .join("state_machine");
-        Arc::new(
-            FileStateMachine::new(state_machine_path)
-                .await
-                .expect("Failed to create file state machine"),
-        )
+    let state_machine = match state_machine {
+        Some(sm) => sm,
+        None => {
+            let state_machine_path = data_dir.join("state_machine");
+            Arc::new(
+                FileStateMachine::new(state_machine_path)
+                    .await
+                    .expect("Failed to create file state machine"),
+            )
+        }
     };
 
-    builder = builder.state_machine(state_machine);
+    let handle = tokio::spawn(async move {
+        StandaloneEngine::start_node(data_dir, storage_engine, state_machine, graceful_rx, config)
+            .await
+            .map_err(|e| std::io::Error::other(format!("node exited with error: {e}")).into())
+    });
 
-    // Build and start the node
-    let node = builder.start().await.map_err(|e| {
-        eprintln!("Failed to start node: {e:?}");
-        std::io::Error::other(format!("Failed to start node: {e}"))
-    })?;
-
-    // Return both the node and the temp directory to keep it alive
-    Ok(node)
-}
-
-async fn run_node(
-    node_id: u32,
-    node: Arc<Node<RaftTypeConfig<FileStorageEngine, FileStateMachine>>>,
-) -> std::result::Result<(), ClientApiError> {
-    println!("Run node: {node_id}",);
-    // Run the node until shutdown
-    if let Err(e) = node.run().await {
-        error!("Node error: {:?}", e);
-    }
-
-    debug!("Exiting program: {node_id}");
-    drop(node);
-    Ok(())
+    Ok((graceful_tx, handle))
 }
 
 pub fn get_root_path() -> PathBuf {
@@ -552,7 +505,6 @@ pub fn create_rejoin_node_config(
     node_id: u32,
     port: u16,
     peers: &[(u32, u16)],
-    db_root_dir: &str,
 ) -> String {
     let cluster_entries = peers
         .iter()
@@ -571,7 +523,6 @@ listen_address = '127.0.0.1:{port}'
 initial_cluster = [
     {cluster_entries}
 ]
-db_root_dir = '{db_root_dir}'
 
 [raft]
 general_raft_timeout_duration_in_ms = 5000
@@ -715,20 +666,22 @@ impl std::ops::Deref for PortGuard {
     }
 }
 
-/// Poll snapshot directory until a .tar.gz file appears or timeout expires.
+/// Poll `dir` until a .tar.gz file appears in it or timeout expires.
 /// Replaces blind sleep() calls when waiting for snapshot generation.
+///
+/// Takes the exact snapshot directory — snapshots are always at
+/// `data_dir/snapshots` (see #10), nested inside each node's own data_dir,
+/// not siblings under one shared configurable snapshots_dir.
 pub async fn wait_for_snapshot(
-    snapshots_dir: &Path,
-    node_id: u64,
+    dir: &Path,
     timeout: Duration,
 ) -> bool {
     let deadline = tokio::time::Instant::now() + timeout;
-    let dir = snapshots_dir.join(format!("node{node_id}"));
     loop {
         if tokio::time::Instant::now() > deadline {
             return false;
         }
-        let has_snapshot = std::fs::read_dir(&dir)
+        let has_snapshot = std::fs::read_dir(dir)
             .ok()
             .map(|entries| {
                 entries

--- a/d-engine-server/tests/consistent_reads/lease_read_embedded.rs
+++ b/d-engine-server/tests/consistent_reads/lease_read_embedded.rs
@@ -28,18 +28,16 @@ async fn create_test_engine_with_lease(test_name: &str) -> (DefaultEmbeddedEngin
         r#"
 [cluster]
 listen_address = "127.0.0.1:{}"
-db_root_dir = "{}"
 single_node = true
 
 [raft.read_consistency]
 state_machine_sync_timeout_ms = 2000
 "#,
-        port,
-        db_path.display()
+        port
     );
     std::fs::write(&config_path, config_content).expect("Failed to write config");
 
-    let engine = DefaultEmbeddedEngine::start_with(config_path.to_str().unwrap())
+    let engine = DefaultEmbeddedEngine::start_with(&db_path, config_path.to_str().unwrap())
         .await
         .expect("Failed to start engine");
 

--- a/d-engine-server/tests/consistent_reads/linearizable_read_batching_embedded.rs
+++ b/d-engine-server/tests/consistent_reads/linearizable_read_batching_embedded.rs
@@ -32,7 +32,6 @@ async fn create_engine_with_batching(
         r#"
 [cluster]
 listen_address = "127.0.0.1:{}"
-db_root_dir = "{}"
 single_node = true
 
 [raft.read_consistency]
@@ -41,13 +40,11 @@ state_machine_sync_timeout_ms = 5000
 [raft.read_consistency.read_batching]
 size_threshold = {}
 "#,
-        port,
-        db_path.display(),
-        size_threshold,
+        port, size_threshold,
     );
     std::fs::write(&config_path, config_content).expect("Failed to write config");
 
-    let engine = DefaultEmbeddedEngine::start_with(config_path.to_str().unwrap())
+    let engine = DefaultEmbeddedEngine::start_with(&db_path, config_path.to_str().unwrap())
         .await
         .expect("Failed to start engine");
 

--- a/d-engine-server/tests/consistent_reads/linearizable_read_consistency_embedded.rs
+++ b/d-engine-server/tests/consistent_reads/linearizable_read_consistency_embedded.rs
@@ -5,7 +5,7 @@
 //!
 //! Uses embedded mode with DefaultEmbeddedEngine for production-ready testing.
 
-use crate::common::{create_node_config, get_available_ports, node_config};
+use crate::common::{create_node_config, get_available_ports};
 use d_engine_server::DefaultEmbeddedEngine;
 use d_engine_server::RocksDBUnifiedEngine;
 use std::sync::Arc;
@@ -27,18 +27,16 @@ async fn create_test_engine(test_name: &str) -> (DefaultEmbeddedEngine, TempDir)
         r#"
 [cluster]
 listen_address = "127.0.0.1:{}"
-db_root_dir = "{}"
 single_node = true
 
 [raft.read_consistency]
 state_machine_sync_timeout_ms = 2000
 "#,
-        port,
-        db_path.display()
+        port
     );
     std::fs::write(&config_path, config_content).expect("Failed to write config");
 
-    let engine = DefaultEmbeddedEngine::start_with(config_path.to_str().unwrap())
+    let engine = DefaultEmbeddedEngine::start_with(&db_path, config_path.to_str().unwrap())
         .await
         .expect("Failed to start engine");
 
@@ -296,7 +294,7 @@ async fn test_linearizable_read_sequential_writes() {
 async fn test_read_index_fixed_with_concurrent_writes_multi_node()
 -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = tempfile::tempdir()?;
-    let db_root_dir = temp_dir.path().join("db");
+    let data_dir = temp_dir.path().join("db");
     let log_dir = temp_dir.path().join("logs");
 
     let mut port_guard = get_available_ports(3).await;
@@ -311,16 +309,15 @@ async fn test_read_index_fixed_with_concurrent_writes_multi_node()
             node_id,
             ports[i],
             ports,
-            db_root_dir.to_str().unwrap(),
+            data_dir.to_str().unwrap(),
             log_dir.to_str().unwrap(),
         )
         .await;
         let config_str = format!(
             "{base_config_str}\n[raft.read_consistency]\nstate_machine_sync_timeout_ms = 5000\n",
         );
-        let config = node_config(&config_str);
 
-        let node_db_root = config.cluster.db_root_dir.join(format!("node{node_id}"));
+        let node_db_root = data_dir.join(format!("node{node_id}"));
         let db_path = node_db_root.join("db");
 
         tokio::fs::create_dir_all(&db_path).await?;
@@ -331,6 +328,7 @@ async fn test_read_index_fixed_with_concurrent_writes_multi_node()
         tokio::fs::write(&config_path, &config_str).await?;
 
         let engine = DefaultEmbeddedEngine::start_custom(
+            &db_path,
             Arc::new(storage),
             Arc::new(state_machine),
             Some(&config_path),

--- a/d-engine-server/tests/drain_batching/select_fairness_embedded.rs
+++ b/d-engine-server/tests/drain_batching/select_fairness_embedded.rs
@@ -31,19 +31,17 @@ async fn create_test_engine(test_name: &str) -> (DefaultEmbeddedEngine, TempDir)
         r#"
 [cluster]
 listen_address = "127.0.0.1:{}"
-db_root_dir = "{}"
 single_node = true
 
 [raft.batching]
 max_batch_size = 100
 
 "#,
-        port,
-        db_path.display()
+        port
     );
     std::fs::write(&config_path, config_content).expect("Failed to write config");
 
-    let engine = DefaultEmbeddedEngine::start_with(config_path.to_str().unwrap())
+    let engine = DefaultEmbeddedEngine::start_with(&db_path, config_path.to_str().unwrap())
         .await
         .expect("Failed to start engine");
 

--- a/d-engine-server/tests/embedded_client/embedded_client_operations.rs
+++ b/d-engine-server/tests/embedded_client/embedded_client_operations.rs
@@ -30,14 +30,12 @@ async fn create_test_engine_default_config(test_name: &str) -> (DefaultEmbeddedE
         r#"
 [cluster]
 listen_address = "127.0.0.1:{}"
-db_root_dir = "{}"
 single_node = true
 "#,
-        port,
-        db_path.display()
+        port
     );
     std::fs::write(&config_path, config_content).expect("Failed to write config");
-    let engine = DefaultEmbeddedEngine::start_with(config_path.to_str().unwrap())
+    let engine = DefaultEmbeddedEngine::start_with(&db_path, config_path.to_str().unwrap())
         .await
         .expect("Failed to start engine");
     engine.wait_ready(Duration::from_secs(5)).await.expect("Engine not ready");
@@ -57,15 +55,13 @@ async fn create_test_engine(test_name: &str) -> (DefaultEmbeddedEngine, TempDir)
         r#"
 [cluster]
 listen_address = "127.0.0.1:{}"
-db_root_dir = "{}"
 single_node = true
 "#,
-        port,
-        db_path.display()
+        port
     );
     std::fs::write(&config_path, config_content).expect("Failed to write config");
 
-    let engine = DefaultEmbeddedEngine::start_with(config_path.to_str().unwrap())
+    let engine = DefaultEmbeddedEngine::start_with(&db_path, config_path.to_str().unwrap())
         .await
         .expect("Failed to start engine");
 
@@ -729,7 +725,6 @@ async fn create_watch_engine(
         r#"
 [cluster]
 listen_address = "127.0.0.1:{}"
-db_root_dir = "{}"
 single_node = true
 
 [raft]
@@ -747,14 +742,14 @@ enabled = true
 event_queue_size = 1000
 watcher_buffer_size = 10
 "#,
-        port,
-        db_path.display()
+        port
     );
     std::fs::write(&config_path, config_content).expect("Failed to write watch config");
 
-    let engine = d_engine_server::DefaultEmbeddedEngine::start_with(config_path.to_str().unwrap())
-        .await
-        .expect("Failed to start watch engine");
+    let engine =
+        d_engine_server::DefaultEmbeddedEngine::start_with(&db_path, config_path.to_str().unwrap())
+            .await
+            .expect("Failed to start watch engine");
 
     engine.wait_ready(Duration::from_secs(5)).await.expect("Watch engine not ready");
 

--- a/d-engine-server/tests/failover_and_recovery/leader_failover_embedded.rs
+++ b/d-engine-server/tests/failover_and_recovery/leader_failover_embedded.rs
@@ -11,7 +11,6 @@ use tracing_test::traced_test;
 
 use crate::common::create_node_config;
 use crate::common::get_available_ports;
-use crate::common::node_config;
 use crate::common::wait_for_new_leader;
 
 /// Test 3-node cluster leader failover with DefaultEmbeddedEngine API
@@ -25,7 +24,7 @@ use crate::common::wait_for_new_leader;
 #[traced_test]
 async fn test_embedded_leader_failover() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = tempfile::tempdir()?;
-    let db_root_dir = temp_dir.path().join("db");
+    let data_dir = temp_dir.path().join("db");
     let log_dir = temp_dir.path().join("logs");
 
     let mut port_guard = get_available_ports(3).await;
@@ -43,14 +42,13 @@ async fn test_embedded_leader_failover() -> Result<(), Box<dyn std::error::Error
             node_id,
             ports[i],
             ports,
-            db_root_dir.to_str().unwrap(),
+            data_dir.to_str().unwrap(),
             log_dir.to_str().unwrap(),
         )
         .await;
-        let config = node_config(&config_str);
 
         // Each node needs its own storage directory to avoid RocksDB lock conflicts
-        let node_db_root = config.cluster.db_root_dir.join(format!("node{node_id}"));
+        let node_db_root = data_dir.join(format!("node{node_id}"));
         let db_path = node_db_root.join("db");
 
         tokio::fs::create_dir_all(&db_path).await?;
@@ -63,6 +61,7 @@ async fn test_embedded_leader_failover() -> Result<(), Box<dyn std::error::Error
         configs.push((config_str, config_path));
 
         let engine = DefaultEmbeddedEngine::start_custom(
+            &node_db_root,
             Arc::new(storage),
             Arc::new(state_machine),
             Some(&configs[i].1),
@@ -233,9 +232,8 @@ async fn test_embedded_node_rejoin() -> Result<(), Box<dyn std::error::Error>> {
             log_dir.to_str().unwrap(),
         )
         .await;
-        let config = node_config(&config_str);
 
-        let node_db_root = config.cluster.db_root_dir.join(format!("node{node_id}"));
+        let node_db_root = db_root.join(format!("node{node_id}"));
         let db_path = node_db_root.join("db");
 
         tokio::fs::create_dir_all(&db_path).await?;
@@ -248,6 +246,7 @@ async fn test_embedded_node_rejoin() -> Result<(), Box<dyn std::error::Error>> {
         configs.push((config_str, config_path));
 
         let engine = DefaultEmbeddedEngine::start_custom(
+            &node_db_root,
             Arc::new(storage),
             Arc::new(state_machine),
             Some(&configs[i].1),
@@ -302,8 +301,7 @@ async fn test_embedded_node_rejoin() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // Restart the killed follower
-    let config = node_config(&killed_config.0);
-    let node_db_root = config.cluster.db_root_dir.join(format!("node{follower_id}"));
+    let node_db_root = db_root.join(format!("node{follower_id}"));
     let db_path = node_db_root.join("db");
 
     // Retry opening DB to tolerate async cleanup delays under parallel test load.
@@ -329,6 +327,7 @@ async fn test_embedded_node_rejoin() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let restarted_engine = DefaultEmbeddedEngine::start_custom(
+        &node_db_root,
         Arc::new(storage),
         Arc::new(state_machine),
         Some(&killed_config.1),
@@ -391,9 +390,8 @@ async fn test_minority_failure_blocks_writes() -> Result<(), Box<dyn std::error:
             log_dir.to_str().unwrap(),
         )
         .await;
-        let config = node_config(&config_str);
 
-        let node_db_root = config.cluster.db_root_dir.join(format!("node{node_id}"));
+        let node_db_root = db_root.join(format!("node{node_id}"));
         let db_path = node_db_root.join("db");
 
         tokio::fs::create_dir_all(&db_path).await?;
@@ -404,6 +402,7 @@ async fn test_minority_failure_blocks_writes() -> Result<(), Box<dyn std::error:
         tokio::fs::write(&config_path, &config_str).await?;
 
         let engine = DefaultEmbeddedEngine::start_custom(
+            &node_db_root,
             Arc::new(storage),
             Arc::new(state_machine),
             Some(&config_path),

--- a/d-engine-server/tests/failover_and_recovery/leader_failover_standalone.rs
+++ b/d-engine-server/tests/failover_and_recovery/leader_failover_standalone.rs
@@ -24,12 +24,15 @@ use crate::common::wait_for_stable_leader;
 #[traced_test]
 async fn test_3_node_failover() -> Result<(), ClientApiError> {
     let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
-    let db_root_dir = temp_dir.path().join("db").to_string_lossy().to_string();
     let log_dir = temp_dir.path().join("logs").to_string_lossy().to_string();
 
     let mut port_guard = get_available_ports(3).await;
     port_guard.release_listeners();
     let ports = port_guard.as_slice();
+
+    let node_data_dirs: Vec<_> = (0..ports.len())
+        .map(|i| temp_dir.path().join(format!("node{}", i + 1)))
+        .collect();
 
     let mut ctx = TestContext {
         graceful_txs: Vec::new(),
@@ -40,8 +43,16 @@ async fn test_3_node_failover() -> Result<(), ClientApiError> {
     info!("Starting 3-node cluster");
     for (i, port) in ports.iter().enumerate() {
         let (graceful_tx, node_handle) = start_node(
+            &node_data_dirs[i],
             node_config(
-                &create_node_config((i + 1) as u64, *port, ports, &db_root_dir, &log_dir).await,
+                &create_node_config(
+                    (i + 1) as u64,
+                    *port,
+                    ports,
+                    &node_data_dirs[i].to_string_lossy(),
+                    &log_dir,
+                )
+                .await,
             ),
             None,
             None,
@@ -133,7 +144,17 @@ async fn test_3_node_failover() -> Result<(), ClientApiError> {
     // Restart node 1 and verify it rejoins cluster
     info!("Restarting node 1");
     let (graceful_tx, node_handle) = start_node(
-        node_config(&create_node_config(1, ports[0], ports, &db_root_dir, &log_dir).await),
+        &node_data_dirs[0],
+        node_config(
+            &create_node_config(
+                1,
+                ports[0],
+                ports,
+                &node_data_dirs[0].to_string_lossy(),
+                &log_dir,
+            )
+            .await,
+        ),
         None,
         None,
     )
@@ -171,7 +192,6 @@ async fn test_3_node_failover() -> Result<(), ClientApiError> {
 #[serial]
 async fn test_minority_failure() -> Result<(), ClientApiError> {
     let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
-    let db_root_dir = temp_dir.path().join("db").to_string_lossy().to_string();
     let log_dir = temp_dir.path().join("logs").to_string_lossy().to_string();
 
     let mut port_guard = get_available_ports(3).await;
@@ -185,9 +205,18 @@ async fn test_minority_failure() -> Result<(), ClientApiError> {
     // Start 3-node cluster
     info!("Starting 3-node cluster for minority failure test");
     for (i, port) in ports.iter().enumerate() {
+        let node_data_dir = temp_dir.path().join(format!("node{}", i + 1));
         let (graceful_tx, node_handle) = start_node(
+            &node_data_dir,
             node_config(
-                &create_node_config((i + 1) as u64, *port, ports, &db_root_dir, &log_dir).await,
+                &create_node_config(
+                    (i + 1) as u64,
+                    *port,
+                    ports,
+                    &node_data_dir.to_string_lossy(),
+                    &log_dir,
+                )
+                .await,
             ),
             None,
             None,

--- a/d-engine-server/tests/failover_and_recovery/sm_metadata_atomicity_embedded.rs
+++ b/d-engine-server/tests/failover_and_recovery/sm_metadata_atomicity_embedded.rs
@@ -75,7 +75,8 @@ async fn start_single_node(
     .await;
     tokio::fs::write(config_path, &config_str).await?;
 
-    let db_path = db_root.join("node1").join("db");
+    let node1_data_dir = db_root.join("node1");
+    let db_path = node1_data_dir.join("db");
     tokio::fs::create_dir_all(&db_path).await?;
 
     let (storage, sm) = RocksDBUnifiedEngine::open(&db_path)?;
@@ -83,7 +84,7 @@ async fn start_single_node(
     let sm_arc = Arc::new(sm);
 
     let engine = DefaultEmbeddedEngine::start_custom(
-        &db_path,
+        &node1_data_dir,
         Arc::clone(&storage_arc),
         Arc::clone(&sm_arc),
         Some(config_path),

--- a/d-engine-server/tests/failover_and_recovery/sm_metadata_atomicity_embedded.rs
+++ b/d-engine-server/tests/failover_and_recovery/sm_metadata_atomicity_embedded.rs
@@ -28,7 +28,6 @@ use tracing_test::traced_test;
 
 use crate::common::create_node_config;
 use crate::common::get_available_ports;
-use crate::common::node_config;
 
 /// Recursively copies `src` into `dst`, creating `dst` if needed.
 fn copy_dir_all(
@@ -76,8 +75,7 @@ async fn start_single_node(
     .await;
     tokio::fs::write(config_path, &config_str).await?;
 
-    let config = node_config(&config_str);
-    let db_path = config.cluster.db_root_dir.join("node1").join("db");
+    let db_path = db_root.join("node1").join("db");
     tokio::fs::create_dir_all(&db_path).await?;
 
     let (storage, sm) = RocksDBUnifiedEngine::open(&db_path)?;
@@ -85,6 +83,7 @@ async fn start_single_node(
     let sm_arc = Arc::new(sm);
 
     let engine = DefaultEmbeddedEngine::start_custom(
+        &db_path,
         Arc::clone(&storage_arc),
         Arc::clone(&sm_arc),
         Some(config_path),

--- a/d-engine-server/tests/failover_and_recovery/sm_wal_disabled_crash_recovery_embedded.rs
+++ b/d-engine-server/tests/failover_and_recovery/sm_wal_disabled_crash_recovery_embedded.rs
@@ -9,7 +9,6 @@ use tracing_test::traced_test;
 use crate::common::create_node_config;
 use crate::common::create_rejoin_node_config;
 use crate::common::get_available_ports;
-use crate::common::node_config;
 use crate::common::wait_for_new_leader;
 
 /// Recursively copies `src` into `dst`, creating `dst` if needed.
@@ -82,9 +81,8 @@ async fn test_follower_sm_recovers_after_abrupt_crash() -> Result<(), Box<dyn st
             log_dir.to_str().unwrap(),
         )
         .await;
-        let config = node_config(&config_str);
 
-        let node_db_root = config.cluster.db_root_dir.join(format!("node{node_id}"));
+        let node_db_root = db_root.join(format!("node{node_id}"));
         let db_path = node_db_root.join("db");
         tokio::fs::create_dir_all(&db_path).await?;
 
@@ -98,6 +96,7 @@ async fn test_follower_sm_recovers_after_abrupt_crash() -> Result<(), Box<dyn st
         let sm_for_crash = Arc::new(state_machine);
 
         let engine = DefaultEmbeddedEngine::start_custom(
+            db_paths.last().unwrap(),
             Arc::new(storage),
             Arc::clone(&sm_for_crash),
             Some(&configs[i].1),
@@ -205,15 +204,12 @@ async fn test_follower_sm_recovers_after_abrupt_crash() -> Result<(), Box<dyn st
     // otherwise it times out and disrupts the cluster before the leader's first
     // heartbeat can reach it (see create_rejoin_node_config's doc comment).
     let peers: Vec<(u32, u16)> = (0..3).map(|i| ((i + 1) as u32, ports[i])).collect();
-    let rejoin_config_str = create_rejoin_node_config(
-        follower_id as u32,
-        ports[follower_idx],
-        &peers,
-        db_root.to_str().unwrap(),
-    );
+    let rejoin_config_str =
+        create_rejoin_node_config(follower_id as u32, ports[follower_idx], &peers);
     tokio::fs::write(&crashed_config.1, &rejoin_config_str).await?;
 
     let restarted = DefaultEmbeddedEngine::start_custom(
+        &crash_snapshot_path,
         Arc::new(storage),
         Arc::new(state_machine),
         Some(&crashed_config.1),
@@ -296,9 +292,8 @@ async fn test_leader_sm_recovers_after_abrupt_crash() -> Result<(), Box<dyn std:
             log_dir.to_str().unwrap(),
         )
         .await;
-        let config = node_config(&config_str);
 
-        let node_db_root = config.cluster.db_root_dir.join(format!("node{node_id}"));
+        let node_db_root = db_root.join(format!("node{node_id}"));
         let db_path = node_db_root.join("db");
         tokio::fs::create_dir_all(&db_path).await?;
 
@@ -312,6 +307,7 @@ async fn test_leader_sm_recovers_after_abrupt_crash() -> Result<(), Box<dyn std:
         let sm_for_crash = Arc::new(state_machine);
 
         let engine = DefaultEmbeddedEngine::start_custom(
+            db_paths.last().unwrap(),
             Arc::new(storage),
             Arc::clone(&sm_for_crash),
             Some(&configs[i].1),
@@ -432,6 +428,7 @@ async fn test_leader_sm_recovers_after_abrupt_crash() -> Result<(), Box<dyn std:
     let (storage, state_machine) = RocksDBUnifiedEngine::open(&crashed_leader_snapshot_path)?;
 
     let rejoined = DefaultEmbeddedEngine::start_custom(
+        &crashed_leader_snapshot_path,
         Arc::new(storage),
         Arc::new(state_machine),
         Some(&crashed_leader_config.1),

--- a/d-engine-server/tests/integration_test.rs
+++ b/d-engine-server/tests/integration_test.rs
@@ -15,6 +15,9 @@ mod drain_batching;
 mod embedded_client;
 #[cfg(feature = "rocksdb")]
 mod failover_and_recovery;
+#[cfg(feature = "rocksdb")]
+mod reliability;
+
 mod leader_election;
 mod replication_and_sync;
 

--- a/d-engine-server/tests/leader_election/leader_election_log_term_index_standalone.rs
+++ b/d-engine-server/tests/leader_election/leader_election_log_term_index_standalone.rs
@@ -45,7 +45,7 @@ async fn test_leader_election_based_on_log_term_and_index() -> Result<(), Client
     reset(ELECTION_CASE1_DIR).await?;
 
     let temp_dir = tempfile::tempdir()?;
-    let db_root_dir = temp_dir.path().join("db");
+    let data_dir = temp_dir.path().join("db");
     let log_dir = temp_dir.path().join("logs");
 
     let mut port_guard = get_available_ports(3).await;
@@ -53,14 +53,14 @@ async fn test_leader_election_based_on_log_term_and_index() -> Result<(), Client
     let ports = port_guard.as_slice();
 
     // Prepare raft logs
-    let r1 = prepare_storage_engine(1, &format!("{}/cs/1", db_root_dir.display()), 0);
+    let r1 = prepare_storage_engine(1, &format!("{}/cs/1", data_dir.display()), 0);
     manipulate_log(&r1, (1..=10).collect(), 2).await;
     init_hard_state(&r1, 2, None);
-    let r2 = prepare_storage_engine(2, &format!("{}/cs/2", db_root_dir.display()), 0);
+    let r2 = prepare_storage_engine(2, &format!("{}/cs/2", data_dir.display()), 0);
     manipulate_log(&r2, (1..=2).collect(), 2).await;
     init_hard_state(&r2, 3, None);
     manipulate_log(&r2, (3..=8).collect(), 3).await;
-    let r3 = prepare_storage_engine(3, &format!("{}/cs/3", db_root_dir.display()), 0);
+    let r3 = prepare_storage_engine(3, &format!("{}/cs/3", data_dir.display()), 0);
     init_hard_state(&r3, 0, None);
 
     // Start cluster nodes
@@ -70,11 +70,12 @@ async fn test_leader_election_based_on_log_term_and_index() -> Result<(), Client
     };
 
     for (i, port) in ports.iter().enumerate() {
+        let node_data_dir = format!("{}/cs/{}", data_dir.display(), i + 1);
         let config = create_node_config(
             (i + 1) as u64,
             *port,
             ports,
-            &format!("{}/cs/{}", db_root_dir.display(), i + 1),
+            &node_data_dir,
             &log_dir.display().to_string(),
         )
         .await;
@@ -85,7 +86,8 @@ async fn test_leader_election_based_on_log_term_and_index() -> Result<(), Client
             _ => Some(r3.clone()),
         };
 
-        let (graceful_tx, node_handle) = start_node(node_config(&config), None, raft_log).await?;
+        let (graceful_tx, node_handle) =
+            start_node(&node_data_dir, node_config(&config), None, raft_log).await?;
 
         ctx.graceful_txs.push(graceful_tx);
         ctx.node_handles.push(node_handle);

--- a/d-engine-server/tests/readonly_and_learner_mode/learner_readonly_sync_embedded.rs
+++ b/d-engine-server/tests/readonly_and_learner_mode/learner_readonly_sync_embedded.rs
@@ -12,11 +12,10 @@ use tracing::info;
 use tracing_test::traced_test;
 
 use crate::common::get_available_ports;
-use crate::common::node_config;
 use crate::common::reset;
 
 const TEST_DIR: &str = "embedded/readonly";
-const DB_ROOT_DIR: &str = "./db/embedded/readonly";
+const DATA_DIR: &str = "./db/embedded/readonly";
 const LOG_DIR: &str = "./logs/embedded/readonly";
 
 /// Test: Embedded Mode - ReadOnly Learner Node
@@ -79,26 +78,25 @@ initial_cluster = [
     {{ id = 1, name = 'n1', address = '127.0.0.1:{}', role = 1, status = 3 }},  # NODE_ROLE_FOLLOWER, NODE_STATUS_ACTIVE
     {{ id = 2, name = 'n2', address = '127.0.0.1:{}', role = 1, status = 3 }}   # NODE_ROLE_FOLLOWER, NODE_STATUS_ACTIVE
 ]
-db_root_dir = '{}'
 log_dir = '{}'
 
 [raft]
 general_raft_timeout_duration_in_ms = 5000
 "#,
-        ports[0], ports[0], ports[1], DB_ROOT_DIR, LOG_DIR
+        ports[0], ports[0], ports[1], LOG_DIR
     );
 
     let node1_config_path = "/tmp/analytics_embedded_node1.toml";
     tokio::fs::write(node1_config_path, &node1_config).await?;
 
-    let config1 = node_config(&node1_config);
-    let db_path1 = config1.cluster.db_root_dir.join("node1/db");
+    let db_path1 = std::path::PathBuf::from(DATA_DIR).join("node1/db");
 
     tokio::fs::create_dir_all(&db_path1).await?;
 
     let (storage1, sm1) = RocksDBUnifiedEngine::open(&db_path1)?;
 
     let engine1 = DefaultEmbeddedEngine::start_custom(
+        &db_path1,
         Arc::new(storage1),
         Arc::new(sm1),
         Some(node1_config_path),
@@ -115,26 +113,25 @@ initial_cluster = [
     {{ id = 1, name = 'n1', address = '127.0.0.1:{}', role = 1, status = 3 }},  # NODE_ROLE_FOLLOWER, NODE_STATUS_ACTIVE
     {{ id = 2, name = 'n2', address = '127.0.0.1:{}', role = 1, status = 3 }}   # NODE_ROLE_FOLLOWER, NODE_STATUS_ACTIVE
 ]
-db_root_dir = '{}'
 log_dir = '{}'
 
 [raft]
 general_raft_timeout_duration_in_ms = 5000
 "#,
-        ports[1], ports[0], ports[1], DB_ROOT_DIR, LOG_DIR
+        ports[1], ports[0], ports[1], LOG_DIR
     );
 
     let node2_config_path = "/tmp/analytics_embedded_node2.toml";
     tokio::fs::write(node2_config_path, &node2_config).await?;
 
-    let config2 = node_config(&node2_config);
-    let db_path2 = config2.cluster.db_root_dir.join("node2/db");
+    let db_path2 = std::path::PathBuf::from(DATA_DIR).join("node2/db");
 
     tokio::fs::create_dir_all(&db_path2).await?;
 
     let (storage2, sm2) = RocksDBUnifiedEngine::open(&db_path2)?;
 
     let engine2 = DefaultEmbeddedEngine::start_custom(
+        &db_path2,
         Arc::new(storage2),
         Arc::new(sm2),
         Some(node2_config_path),
@@ -182,26 +179,25 @@ initial_cluster = [
     {{ id = 2, name = 'n2', address = '127.0.0.1:{}', role = 1, status = 3 }},  # NODE_ROLE_FOLLOWER, NODE_STATUS_ACTIVE
     {{ id = 3, name = 'n3', address = '127.0.0.1:{}', role = 4, status = 2 }}   # NODE_ROLE_LEARNER, NODE_STATUS_READ_ONLY
 ]
-db_root_dir = '{}'
 log_dir = '{}'
 
 [raft]
 general_raft_timeout_duration_in_ms = 5000
 "#,
-        ports[2], ports[0], ports[1], ports[2], DB_ROOT_DIR, LOG_DIR
+        ports[2], ports[0], ports[1], ports[2], LOG_DIR
     );
 
     let node3_config_path = "/tmp/analytics_embedded_node3.toml";
     tokio::fs::write(node3_config_path, &node3_config).await?;
 
-    let config3 = node_config(&node3_config);
-    let db_path3 = config3.cluster.db_root_dir.join("node3/db");
+    let db_path3 = std::path::PathBuf::from(DATA_DIR).join("node3/db");
 
     tokio::fs::create_dir_all(&db_path3).await?;
 
     let (storage3, sm3) = RocksDBUnifiedEngine::open(&db_path3)?;
 
     let engine3 = DefaultEmbeddedEngine::start_custom(
+        &db_path3,
         Arc::new(storage3),
         Arc::new(sm3),
         Some(node3_config_path),

--- a/d-engine-server/tests/readonly_and_learner_mode/learner_readonly_sync_standalone.rs
+++ b/d-engine-server/tests/readonly_and_learner_mode/learner_readonly_sync_standalone.rs
@@ -67,14 +67,21 @@ use crate::common::test_put_get;
 #[traced_test]
 async fn test_readonly_mode_learner_standalone() -> Result<(), ClientApiError> {
     const TEST_DIR: &str = "cluster_start_stop/analytics_rpc";
-    const DB_ROOT_DIR: &str = "./db/cluster_start_stop/analytics_rpc";
     const LOG_DIR: &str = "./logs/cluster_start_stop/analytics_rpc";
 
     reset(TEST_DIR).await?;
 
+    let temp_dir = tempfile::Builder::new()
+        .prefix("d-engine-learner-readonly-sync-standalone-")
+        .tempdir()
+        .expect("tempdir");
+
     let mut port_guard = get_available_ports(4).await;
     port_guard.release_listeners();
     let ports = port_guard.as_slice();
+    let node_data_dirs: Vec<_> = (0..ports.len())
+        .map(|i| temp_dir.path().join(format!("node{}", i + 1)))
+        .collect();
 
     // Phase 1: Start initial 3-node primary cluster (nodes 1, 2, 3 = Voter+Active)
     println!("\n╔════════════════════════════════════════════════════════════╗");
@@ -89,8 +96,16 @@ async fn test_readonly_mode_learner_standalone() -> Result<(), ClientApiError> {
 
     for (i, port) in ports[..3].iter().enumerate() {
         let (graceful_tx, node_handle) = start_node(
+            &node_data_dirs[i],
             node_config(
-                &create_node_config((i + 1) as u64, *port, &ports[..3], DB_ROOT_DIR, LOG_DIR).await,
+                &create_node_config(
+                    (i + 1) as u64,
+                    *port,
+                    &ports[..3],
+                    &node_data_dirs[i].to_string_lossy(),
+                    LOG_DIR,
+                )
+                .await,
             ),
             None,
             None,
@@ -130,16 +145,16 @@ initial_cluster = [
     {{ id = 3, name = 'n3', address = '127.0.0.1:{}', role = 1, status = 3 }},
     {{ id = 4, name = 'n4', address = '127.0.0.1:{}', role = 4, status = 2 }}
 ]
-db_root_dir = '{}'
 log_dir = '{}'
 
 [raft]
 general_raft_timeout_duration_in_ms = 5000
 "#,
-        ports[3], ports[0], ports[1], ports[2], ports[3], DB_ROOT_DIR, LOG_DIR
+        ports[3], ports[0], ports[1], ports[2], ports[3], LOG_DIR
     );
 
-    let (graceful_tx4, node_n4) = start_node(node_config(&node4_config), None, None).await?;
+    let (graceful_tx4, node_n4) =
+        start_node(&node_data_dirs[3], node_config(&node4_config), None, None).await?;
     ctx.graceful_txs.push(graceful_tx4);
     ctx.node_handles.push(node_n4);
 

--- a/d-engine-server/tests/reliability/data_dir_lock_crash_recovery_embedded.rs
+++ b/d-engine-server/tests/reliability/data_dir_lock_crash_recovery_embedded.rs
@@ -1,0 +1,141 @@
+use std::io::BufRead;
+use std::io::Write;
+use std::time::Duration;
+
+use d_engine_server::DefaultEmbeddedEngine;
+
+use crate::common::get_available_ports;
+
+const CHILD_ENV_VAR: &str = "D_ENGINE_TEST_LOCK_CHILD";
+const DATA_DIR_ENV_VAR: &str = "D_ENGINE_TEST_DATA_DIR";
+const READY_MARKER: &str = "LOCK_ACQUIRED";
+
+/// A node process holding the data_dir lock crashes (SIGKILL, no clean
+/// shutdown). The OS must release the flock on process exit — otherwise a
+/// crashed node would permanently block itself (or any replacement) from
+/// ever restarting against the same data_dir.
+#[tokio::test]
+async fn test_lock_released_after_process_crash() {
+    // Child branch: re-invocation of this same test binary, acting as the
+    // "process that crashes". Selected via env var set by the parent below.
+    if std::env::var(CHILD_ENV_VAR).is_ok() {
+        let data_dir = std::env::var(DATA_DIR_ENV_VAR).expect("parent sets data_dir");
+        let _engine = DefaultEmbeddedEngine::start(&data_dir)
+            .await
+            .expect("child should acquire the data_dir lock");
+
+        println!("{READY_MARKER}");
+        // Don't rely on LineWriter's current auto-flush-on-'\n' behavior for
+        // piped (non-tty) stdout — it's an implementation detail under
+        // active discussion (rust-lang/rust#60673), not a stable contract.
+        std::io::stdout().flush().ok();
+
+        loop {
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+        }
+    }
+
+    // Parent branch: spawn the child, wait for it to hold the lock, kill -9
+    // it, then prove the same data_dir can be started again.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let mut child_ports = get_available_ports(1).await;
+    child_ports.release_listeners();
+    let child_addr = format!("127.0.0.1:{}", child_ports[0]);
+
+    let exe = std::env::current_exe().unwrap();
+    // Full module path, not the bare fn name: this binary aggregates every
+    // tests/*/*.rs file via `mod` in integration_test.rs, so a bare name
+    // would match zero tests instead of exactly one. `module_path!()` includes
+    // this test binary's own crate-root segment ("integration_test::"), which
+    // libtest's own test names never include — strip it before matching.
+    let raw_module_path = module_path!();
+    let module_path = raw_module_path
+        .split_once("::")
+        .map(|(_, rest)| rest)
+        .unwrap_or(raw_module_path);
+    let filter = format!("{module_path}::test_lock_released_after_process_crash");
+
+    let mut child = std::process::Command::new(&exe)
+        .args([filter.as_str(), "--exact", "--nocapture"])
+        .env(CHILD_ENV_VAR, "1")
+        .env(DATA_DIR_ENV_VAR, temp_dir.path())
+        .env("RAFT__CLUSTER__NODE_ID", "1")
+        .env("RAFT__CLUSTER__LISTEN_ADDRESS", &child_addr)
+        .stdout(std::process::Stdio::piped())
+        // Own pipe instead of inheriting the parent's stderr fd: without this,
+        // the child's tracing output can land on that shared fd after this test
+        // function returns (child dies a beat later than `child.wait()` sees),
+        // which nextest flags as "leaky" output on the parent test.
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn child process");
+    // Drain and discard — we only need the fd detached, not the content.
+    let child_stderr = child.stderr.take().expect("child stderr piped");
+    std::thread::spawn(move || {
+        let mut reader = std::io::BufReader::new(child_stderr);
+        let mut line = String::new();
+        while reader.read_line(&mut line).unwrap_or(0) > 0 {
+            line.clear();
+        }
+    });
+
+    wait_for_line(&mut child, READY_MARKER, Duration::from_secs(10));
+
+    child.kill().expect("SIGKILL child"); // std::process::Child::kill() == SIGKILL on Unix
+    child.wait().expect("reap child");
+
+    // Same data_dir, fresh port (avoids relying on TIME_WAIT semantics of
+    // the killed child's listener) — data_dir is what's under test here.
+    let mut restart_ports = get_available_ports(1).await;
+    restart_ports.release_listeners();
+    unsafe {
+        std::env::set_var("RAFT__CLUSTER__NODE_ID", "1");
+        std::env::set_var(
+            "RAFT__CLUSTER__LISTEN_ADDRESS",
+            format!("127.0.0.1:{}", restart_ports[0]),
+        );
+    }
+    let result = DefaultEmbeddedEngine::start(temp_dir.path()).await;
+    unsafe {
+        std::env::remove_var("RAFT__CLUSTER__NODE_ID");
+        std::env::remove_var("RAFT__CLUSTER__LISTEN_ADDRESS");
+    }
+
+    assert!(
+        result.is_ok(),
+        "data_dir lock must release after the holder crashes: {:?}",
+        result.err()
+    );
+    result.unwrap().stop().await.ok();
+}
+
+/// Blocks until `expected` appears on the child's stdout, or times out.
+/// On timeout, actively kills the child so a failed assertion never leaves
+/// a hung process or zombie behind in CI.
+fn wait_for_line(
+    child: &mut std::process::Child,
+    expected: &str,
+    timeout: Duration,
+) {
+    let stdout = child.stdout.take().expect("child stdout piped");
+    let (tx, rx) = std::sync::mpsc::channel();
+    let expected_owned = expected.to_string();
+
+    std::thread::spawn(move || {
+        let mut reader = std::io::BufReader::new(stdout);
+        let mut line = String::new();
+        while reader.read_line(&mut line).unwrap_or(0) > 0 {
+            if line.trim() == expected_owned {
+                let _ = tx.send(());
+                return;
+            }
+            line.clear();
+        }
+    });
+
+    if rx.recv_timeout(timeout).is_err() {
+        let _ = child.kill();
+        let _ = child.wait();
+        panic!("child never reported '{expected}' within {timeout:?}");
+    }
+}

--- a/d-engine-server/tests/reliability/data_dir_lock_rejects_concurrent_start_embedded.rs
+++ b/d-engine-server/tests/reliability/data_dir_lock_rejects_concurrent_start_embedded.rs
@@ -1,0 +1,74 @@
+use std::time::Duration;
+
+use d_engine_server::DefaultEmbeddedEngine;
+
+use crate::common::get_available_ports;
+
+/// Purpose: a second `start()` on an already-locked data_dir must fail
+/// cleanly (no panic, no hang), and the first, already-running engine must
+/// stay fully functional — the failed second attempt must not affect it.
+/// This is the copy-paste-shared-directory mistake the lock exists to catch.
+#[tokio::test]
+async fn test_second_start_on_same_data_dir_fails_first_unaffected() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let mut ports = get_available_ports(2).await;
+    ports.release_listeners();
+
+    unsafe {
+        std::env::set_var("RAFT__CLUSTER__NODE_ID", "1");
+        std::env::set_var(
+            "RAFT__CLUSTER__LISTEN_ADDRESS",
+            format!("127.0.0.1:{}", ports[0]),
+        );
+    }
+    let engine1 = DefaultEmbeddedEngine::start(temp_dir.path())
+        .await
+        .expect("first start must succeed");
+    unsafe {
+        std::env::remove_var("RAFT__CLUSTER__NODE_ID");
+        std::env::remove_var("RAFT__CLUSTER__LISTEN_ADDRESS");
+    }
+    engine1
+        .wait_ready(Duration::from_secs(5))
+        .await
+        .expect("first engine must become ready");
+
+    unsafe {
+        std::env::set_var("RAFT__CLUSTER__NODE_ID", "1");
+        std::env::set_var(
+            "RAFT__CLUSTER__LISTEN_ADDRESS",
+            format!("127.0.0.1:{}", ports[1]),
+        );
+    }
+    let second = DefaultEmbeddedEngine::start(temp_dir.path()).await;
+    unsafe {
+        std::env::remove_var("RAFT__CLUSTER__NODE_ID");
+        std::env::remove_var("RAFT__CLUSTER__LISTEN_ADDRESS");
+    }
+    // Must fail with the data_dir lock's own error — not a RocksDB-level `LOCK`
+    // error. This proves the lock is acquired (and checked) before storage is
+    // ever touched, giving a clear rejection instead of a confusing DB error.
+    match second {
+        Ok(_) => panic!("second start on a locked data_dir must fail"),
+        Err(d_engine_core::Error::System(d_engine_core::SystemError::NodeStartFailed(msg))) => {
+            assert!(
+                msg.contains("already in use"),
+                "expected a data_dir-in-use message, got: {msg}"
+            );
+        }
+        Err(other) => panic!(
+            "expected Err(SystemError::NodeStartFailed(_)) from the data_dir lock, got: {other:?}"
+        ),
+    }
+
+    // The failed second attempt must not have touched the first engine's state.
+    let client = engine1.client();
+    let put = client.put(b"k".to_vec(), b"v".to_vec()).await;
+    assert!(
+        put.is_ok(),
+        "first engine must remain usable: {:?}",
+        put.err()
+    );
+
+    engine1.stop().await.ok();
+}

--- a/d-engine-server/tests/reliability/data_dir_lock_released_after_stop_embedded.rs
+++ b/d-engine-server/tests/reliability/data_dir_lock_released_after_stop_embedded.rs
@@ -1,0 +1,54 @@
+use std::time::Duration;
+
+use d_engine_server::DefaultEmbeddedEngine;
+
+use crate::common::get_available_ports;
+
+/// Purpose: after a clean `stop()` (not a crash), the lock must release so a
+/// restarted node can reopen the same data_dir. This is the common case —
+/// most restarts are graceful. It also proves `stop()` truly drops every
+/// `Arc<Node<T>>` clone; a lingering background-task reference would keep
+/// the lock held and make this fail.
+#[tokio::test]
+async fn test_restart_after_clean_stop_reacquires_lock() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let mut ports = get_available_ports(2).await;
+    ports.release_listeners();
+
+    unsafe {
+        std::env::set_var("RAFT__CLUSTER__NODE_ID", "1");
+        std::env::set_var(
+            "RAFT__CLUSTER__LISTEN_ADDRESS",
+            format!("127.0.0.1:{}", ports[0]),
+        );
+    }
+    let engine1 = DefaultEmbeddedEngine::start(temp_dir.path())
+        .await
+        .expect("first start must succeed");
+    unsafe {
+        std::env::remove_var("RAFT__CLUSTER__NODE_ID");
+        std::env::remove_var("RAFT__CLUSTER__LISTEN_ADDRESS");
+    }
+    engine1.wait_ready(Duration::from_secs(5)).await.expect("first engine ready");
+    engine1.stop().await.expect("clean stop must succeed");
+
+    unsafe {
+        std::env::set_var("RAFT__CLUSTER__NODE_ID", "1");
+        std::env::set_var(
+            "RAFT__CLUSTER__LISTEN_ADDRESS",
+            format!("127.0.0.1:{}", ports[1]),
+        );
+    }
+    let engine2 = DefaultEmbeddedEngine::start(temp_dir.path()).await;
+    unsafe {
+        std::env::remove_var("RAFT__CLUSTER__NODE_ID");
+        std::env::remove_var("RAFT__CLUSTER__LISTEN_ADDRESS");
+    }
+
+    assert!(
+        engine2.is_ok(),
+        "restart after clean stop must succeed: {:?}",
+        engine2.err()
+    );
+    engine2.unwrap().stop().await.ok();
+}

--- a/d-engine-server/tests/reliability/data_dir_lock_released_after_storage_init_failure_embedded.rs
+++ b/d-engine-server/tests/reliability/data_dir_lock_released_after_storage_init_failure_embedded.rs
@@ -1,0 +1,80 @@
+use d_engine_server::DefaultEmbeddedEngine;
+
+use crate::common::get_available_ports;
+
+/// The data_dir lock is acquired before storage is opened. If storage init
+/// then fails, the lock must still be released — otherwise a single bad
+/// storage error would permanently wedge the data_dir, blocking even a
+/// corrected retry.
+///
+/// Trigger: pre-create a regular file at `data_dir/storage` — `DataDir`'s
+/// directory validation (which normally creates the subdirectory RocksDB
+/// needs) fails on it, since a file can't be written into like a directory.
+/// This failure happens after the lock is acquired but before RocksDB is
+/// ever touched, exactly the window the expert review flagged.
+#[tokio::test]
+async fn test_lock_released_after_storage_init_failure() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        temp_dir.path().join("storage"),
+        b"blocks storage subdir creation",
+    )
+    .unwrap();
+
+    let mut ports = get_available_ports(2).await;
+    ports.release_listeners();
+
+    unsafe {
+        std::env::set_var("RAFT__CLUSTER__NODE_ID", "1");
+        std::env::set_var(
+            "RAFT__CLUSTER__LISTEN_ADDRESS",
+            format!("127.0.0.1:{}", ports[0]),
+        );
+    }
+    let first = DefaultEmbeddedEngine::start(temp_dir.path()).await;
+    unsafe {
+        std::env::remove_var("RAFT__CLUSTER__NODE_ID");
+        std::env::remove_var("RAFT__CLUSTER__LISTEN_ADDRESS");
+    }
+    assert!(
+        first.is_err(),
+        "start must fail: storage subdir creation is blocked by a file"
+    );
+    // Must NOT be the data_dir-lock-conflict error — that would mean storage
+    // init never even ran, defeating the point of this test.
+    assert!(
+        !matches!(
+            first,
+            Err(d_engine_core::Error::System(
+                d_engine_core::SystemError::NodeStartFailed(_)
+            ))
+        ),
+        "first attempt must fail on storage init itself, not a lock conflict: {:?}",
+        first.err()
+    );
+
+    // Second attempt, same data_dir, still blocked by the same file. If the
+    // first attempt's lock leaked, this fails with the lock-conflict error
+    // instead of the same storage error — proving release (or not).
+    unsafe {
+        std::env::set_var("RAFT__CLUSTER__NODE_ID", "1");
+        std::env::set_var(
+            "RAFT__CLUSTER__LISTEN_ADDRESS",
+            format!("127.0.0.1:{}", ports[1]),
+        );
+    }
+    let second = DefaultEmbeddedEngine::start(temp_dir.path()).await;
+    unsafe {
+        std::env::remove_var("RAFT__CLUSTER__NODE_ID");
+        std::env::remove_var("RAFT__CLUSTER__LISTEN_ADDRESS");
+    }
+    match second {
+        Ok(_) => panic!("start should still fail: the blocking file is still in place"),
+        Err(d_engine_core::Error::System(d_engine_core::SystemError::NodeStartFailed(msg))) => {
+            panic!("lock from the first failed attempt was never released: {msg}");
+        }
+        Err(_) => {
+            // Same storage-init failure as the first attempt — the lock was released.
+        }
+    }
+}

--- a/d-engine-server/tests/reliability/mod.rs
+++ b/d-engine-server/tests/reliability/mod.rs
@@ -1,0 +1,10 @@
+//! # Startup Reliability Tests
+//!
+//! Verifies data_dir startup guarantees that are orthogonal to Raft consensus
+//! itself — e.g. the exclusive lock preventing two processes from sharing a
+//! data_dir, and that it survives (releases cleanly after) a process crash.
+
+mod data_dir_lock_crash_recovery_embedded;
+mod data_dir_lock_rejects_concurrent_start_embedded;
+mod data_dir_lock_released_after_stop_embedded;
+mod data_dir_lock_released_after_storage_init_failure_embedded;

--- a/d-engine-server/tests/replication_and_sync/append_entries_out_of_sync_standalone.rs
+++ b/d-engine-server/tests/replication_and_sync/append_entries_out_of_sync_standalone.rs
@@ -37,7 +37,7 @@ use crate::common::start_node;
 use crate::common::test_put_get;
 
 const TEST_CASE_DIR: &str = "append_entries/case1";
-const DB_ROOT_DIR: &str = "./db/append_entries/case1";
+const DATA_DIR: &str = "./db/append_entries/case1";
 const LOG_DIR: &str = "./logs/append_entries/case1";
 
 #[tracing::instrument]
@@ -57,9 +57,9 @@ async fn test_out_of_sync_peer_scenario() -> Result<(), ClientApiError> {
     println!("Prepare state machine and logs");
 
     let raft_logs = [
-        prepare_storage_engine(1, &format!("{DB_ROOT_DIR}/cs/1"), 0),
-        prepare_storage_engine(2, &format!("{DB_ROOT_DIR}/cs/2"), 0),
-        prepare_storage_engine(3, &format!("{DB_ROOT_DIR}/cs/3"), 0),
+        prepare_storage_engine(1, &format!("{DATA_DIR}/cs/1"), 0),
+        prepare_storage_engine(2, &format!("{DATA_DIR}/cs/2"), 0),
+        prepare_storage_engine(3, &format!("{DATA_DIR}/cs/3"), 0),
     ];
 
     manipulate_log(&raft_logs[0], vec![1, 2, 3], 1).await;
@@ -79,9 +79,11 @@ async fn test_out_of_sync_peer_scenario() -> Result<(), ClientApiError> {
 
     println!("{:?}", ports);
     for (i, port) in ports.iter().enumerate() {
+        let node_data_dir = format!("{DATA_DIR}/cs/{}", i + 1);
         let (graceful_tx, node_handle) = start_node(
+            &node_data_dir,
             node_config(
-                &create_node_config((i + 1) as u64, *port, ports, DB_ROOT_DIR, LOG_DIR).await,
+                &create_node_config((i + 1) as u64, *port, ports, &node_data_dir, LOG_DIR).await,
             ),
             None, // Let build_node create state machines for each node
             Some(raft_logs[i].clone()),

--- a/d-engine-server/tests/snapshot_and_recovery/snapshot_concurrent_replication_embedded.rs
+++ b/d-engine-server/tests/snapshot_and_recovery/snapshot_concurrent_replication_embedded.rs
@@ -54,9 +54,8 @@ async fn test_learner_snapshot_concurrent_replication() -> Result<(), Box<dyn st
     const TOTAL_ENTRIES: u64 = BASELINE_ENTRIES + CONCURRENT_ENTRIES;
 
     let temp_dir = tempfile::tempdir()?;
-    let db_root_dir = temp_dir.path().join("db");
+    let data_dir = temp_dir.path().join("db");
     let log_dir = temp_dir.path().join("logs");
-    let snapshots_dir = temp_dir.path().join("snapshots");
 
     let mut port_guard = get_available_ports(4).await;
     port_guard.release_listeners();
@@ -80,7 +79,6 @@ initial_cluster = [
     {{ id = 2, name = 'n2', address = '127.0.0.1:{}', role = 1, status = 3 }},
     {{ id = 3, name = 'n3', address = '127.0.0.1:{}', role = 1, status = 3 }}
 ]
-db_root_dir = '{}'
 log_dir = '{}'
 
 [raft]
@@ -89,31 +87,28 @@ general_raft_timeout_duration_in_ms = 5000
 [raft.snapshot]
 max_log_entries_before_snapshot = {}
 retained_log_entries = {}
-snapshots_dir = '{}'
 "#,
             node_id,
             ports[node_id - 1],
             ports[0],
             ports[1],
             ports[2],
-            db_root_dir.join(format!("node{node_id}")).display(),
             log_dir.join(format!("node{node_id}")).display(),
             SNAPSHOT_THRESHOLD,
-            RETAINED_LOGS,
-            snapshots_dir.join(format!("node{node_id}")).display()
+            RETAINED_LOGS
         );
 
         let config_path = format!("/tmp/learner_snap_node{node_id}.toml");
         tokio::fs::write(&config_path, &config).await?;
 
-        let db_path = db_root_dir.join(format!("node{node_id}/db"));
+        let db_path = data_dir.join(format!("node{node_id}/db"));
 
         tokio::fs::create_dir_all(&db_path).await?;
-        tokio::fs::create_dir_all(snapshots_dir.join(format!("node{node_id}"))).await?;
 
         let (storage, sm) = RocksDBUnifiedEngine::open(&db_path)?;
 
         let engine = DefaultEmbeddedEngine::start_custom(
+            &db_path,
             Arc::new(storage),
             Arc::new(sm),
             Some(&config_path),
@@ -160,9 +155,9 @@ snapshots_dir = '{}'
         .find(|e| e.is_leader())
         .map(|e| e.node_id())
         .expect("Should have a leader");
+    let leader_snapshots_dir = data_dir.join(format!("node{leader_id}/db/snapshots"));
     assert!(
-        crate::common::wait_for_snapshot(&snapshots_dir, leader_id as u64, Duration::from_secs(10))
-            .await,
+        crate::common::wait_for_snapshot(&leader_snapshots_dir, Duration::from_secs(10)).await,
         "Leader (Node {leader_id}) failed to generate snapshot within 10s"
     );
 
@@ -180,7 +175,6 @@ initial_cluster = [
     {{ id = 3, name = 'n3', address = '127.0.0.1:{}', role = 3, status = 3 }},
     {{ id = 4, name = 'n4', address = '127.0.0.1:{}', role = 4, status = 2 }}
 ]
-db_root_dir = '{}'
 log_dir = '{}'
 
 [raft]
@@ -189,31 +183,28 @@ general_raft_timeout_duration_in_ms = 5000
 [raft.snapshot]
 max_log_entries_before_snapshot = {}
 retained_log_entries = {}
-snapshots_dir = '{}'
 "#,
         ports[3],
         ports[0],
         ports[1],
         ports[2],
         ports[3],
-        db_root_dir.join("node4").display(),
         log_dir.join("node4").display(),
         SNAPSHOT_THRESHOLD,
-        RETAINED_LOGS,
-        snapshots_dir.join("node4").display()
+        RETAINED_LOGS
     );
 
     let learner_config_path = "/tmp/learner_snap_node4.toml".to_string();
     tokio::fs::write(&learner_config_path, &learner_config).await?;
 
-    let learner_db_path = db_root_dir.join("node4/db");
+    let learner_db_path = data_dir.join("node4/db");
 
     tokio::fs::create_dir_all(&learner_db_path).await?;
-    tokio::fs::create_dir_all(snapshots_dir.join("node4")).await?;
 
     let (learner_storage, learner_sm) = RocksDBUnifiedEngine::open(&learner_db_path)?;
 
     let learner_engine = DefaultEmbeddedEngine::start_custom(
+        &learner_db_path,
         Arc::new(learner_storage),
         Arc::new(learner_sm),
         Some(&learner_config_path),
@@ -345,7 +336,7 @@ snapshots_dir = '{}'
     }
 
     info!("Phase 6: Checking snapshot files on Learner...");
-    let learner_snapshot_dir = snapshots_dir.join("node4");
+    let learner_snapshot_dir = data_dir.join("node4/db/snapshots");
     if learner_snapshot_dir.exists()
         && let Ok(entries) = std::fs::read_dir(&learner_snapshot_dir)
     {

--- a/d-engine-server/tests/snapshot_and_recovery/snapshot_concurrent_writes_embedded.rs
+++ b/d-engine-server/tests/snapshot_and_recovery/snapshot_concurrent_writes_embedded.rs
@@ -64,9 +64,8 @@ use crate::common::get_available_ports;
 #[traced_test]
 async fn test_leader_snapshot_concurrent_writes() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = tempfile::tempdir()?;
-    let db_root_dir = temp_dir.path().join("db");
+    let data_dir = temp_dir.path().join("db");
     let log_dir = temp_dir.path().join("logs");
-    let snapshots_dir = temp_dir.path().join("snapshots");
 
     let mut port_guard = get_available_ports(3).await;
     port_guard.release_listeners();
@@ -88,7 +87,6 @@ initial_cluster = [
     {{ id = 2, name = 'n2', address = '127.0.0.1:{}', role = 1, status = 3 }},
     {{ id = 3, name = 'n3', address = '127.0.0.1:{}', role = 1, status = 3 }}
 ]
-db_root_dir = '{}'
 log_dir = '{}'
 
 [raft]
@@ -97,29 +95,26 @@ general_raft_timeout_duration_in_ms = 5000
 [raft.snapshot]
 max_log_entries_before_snapshot = 100
 retained_log_entries = 10
-snapshots_dir = '{}'
 "#,
             node_id,
             ports[node_id as usize - 1],
             ports[0],
             ports[1],
             ports[2],
-            db_root_dir.display(),
-            log_dir.display(),
-            snapshots_dir.join(format!("node{node_id}")).display()
+            log_dir.display()
         );
 
         let config_path = format!("/tmp/snapshot_concurrent_node{node_id}.toml");
         tokio::fs::write(&config_path, &config).await?;
 
-        let db_path = db_root_dir.join(format!("node{node_id}/db"));
+        let db_path = data_dir.join(format!("node{node_id}/db"));
 
         tokio::fs::create_dir_all(&db_path).await?;
-        tokio::fs::create_dir_all(snapshots_dir.join(format!("node{node_id}"))).await?;
 
         let (storage, sm) = RocksDBUnifiedEngine::open(&db_path)?;
 
         let engine = DefaultEmbeddedEngine::start_custom(
+            &db_path,
             Arc::new(storage),
             Arc::new(sm),
             Some(&config_path),
@@ -257,9 +252,10 @@ snapshots_dir = '{}'
     // Wait a bit more to ensure snapshot is fully written
     tokio::time::sleep(Duration::from_secs(1)).await;
 
-    // Check snapshot directory exists and contains files
+    // Check snapshot directory exists and contains files. Snapshots are
+    // always at data_dir/snapshots (not independently configurable).
     let leader_id = engines[leader_idx].node_id();
-    let leader_snapshot_dir = snapshots_dir.join(format!("node{leader_id}"));
+    let leader_snapshot_dir = data_dir.join(format!("node{leader_id}/db")).join("snapshots");
 
     assert!(
         leader_snapshot_dir.exists(),

--- a/d-engine-server/tests/snapshot_and_recovery/snapshot_correctness_after_install_embedded.rs
+++ b/d-engine-server/tests/snapshot_and_recovery/snapshot_correctness_after_install_embedded.rs
@@ -63,8 +63,7 @@ async fn test_follower_catchup_within_retained_buffer_and_data_consistency()
     const CATCHUP_ENTRIES: u64 = 20; // must be < RETAINED_LOGS to stay in retained buffer
 
     let temp_dir = tempfile::tempdir()?;
-    let db_root_dir = temp_dir.path().join("db");
-    let snapshots_dir = temp_dir.path().join("snapshots");
+    let data_dir = temp_dir.path().join("db");
 
     let mut port_guard = get_available_ports(3).await;
     port_guard.release_listeners();
@@ -85,7 +84,6 @@ initial_cluster = [
     {{ id = 2, name = 'n2', address = '127.0.0.1:{}', role = 1, status = 3 }},
     {{ id = 3, name = 'n3', address = '127.0.0.1:{}', role = 1, status = 3 }}
 ]
-db_root_dir = '{}'
 
 [raft]
 general_raft_timeout_duration_in_ms = 5000
@@ -93,27 +91,24 @@ general_raft_timeout_duration_in_ms = 5000
 [raft.snapshot]
 max_log_entries_before_snapshot = {SNAPSHOT_THRESHOLD}
 retained_log_entries = {RETAINED_LOGS}
-snapshots_dir = '{}'
 "#,
             ports[node_id as usize - 1],
             ports[0],
             ports[1],
             ports[2],
-            db_root_dir.join(format!("node{node_id}")).display(),
-            snapshots_dir.join(format!("node{node_id}")).display(),
         );
 
         let config_path = temp_dir.path().join(format!("node{node_id}.toml"));
         tokio::fs::write(&config_path, &config).await?;
 
-        let db_path = db_root_dir.join(format!("node{node_id}/db"));
+        let db_path = data_dir.join(format!("node{node_id}/db"));
         tokio::fs::create_dir_all(&db_path).await?;
-        tokio::fs::create_dir_all(snapshots_dir.join(format!("node{node_id}"))).await?;
 
         node_paths.push((config_path.clone(), db_path.clone()));
 
         let (storage, sm) = RocksDBUnifiedEngine::open(&db_path)?;
         let engine = DefaultEmbeddedEngine::start_custom(
+            &db_path,
             Arc::new(storage),
             Arc::new(sm),
             Some(config_path.to_str().unwrap()),
@@ -145,8 +140,9 @@ snapshots_dir = '{}'
     }
 
     let leader_id = leader_info.leader_id as u64;
+    let leader_snapshots_dir = data_dir.join(format!("node{leader_id}/db/snapshots"));
     assert!(
-        wait_for_snapshot(&snapshots_dir, leader_id, Duration::from_secs(15)).await,
+        wait_for_snapshot(&leader_snapshots_dir, Duration::from_secs(15)).await,
         "Leader snapshot must exist after {INITIAL_ENTRIES} entries"
     );
     info!(
@@ -189,6 +185,7 @@ snapshots_dir = '{}'
     info!("Restarting follower node {follower_node_id} from persisted DB");
     let (storage, sm) = RocksDBUnifiedEngine::open(&follower_db_path)?;
     let restarted = DefaultEmbeddedEngine::start_custom(
+        &follower_db_path,
         Arc::new(storage),
         Arc::new(sm),
         Some(follower_config_path.to_str().unwrap()),

--- a/d-engine-server/tests/snapshot_and_recovery/snapshot_follower_generation_embedded.rs
+++ b/d-engine-server/tests/snapshot_and_recovery/snapshot_follower_generation_embedded.rs
@@ -71,9 +71,8 @@ async fn test_follower_snapshot_generation_during_replication()
     const TOTAL_ENTRIES: u64 = BASELINE_ENTRIES + CONCURRENT_ENTRIES;
 
     let temp_dir = tempfile::tempdir()?;
-    let db_root_dir = temp_dir.path().join("db");
+    let data_dir = temp_dir.path().join("db");
     let log_dir = temp_dir.path().join("logs");
-    let snapshots_dir = temp_dir.path().join("snapshots");
 
     let mut port_guard = get_available_ports(3).await;
     port_guard.release_listeners();
@@ -97,7 +96,6 @@ initial_cluster = [
     {{ id = 2, name = 'n2', address = '127.0.0.1:{}', role = 1, status = 3 }},
     {{ id = 3, name = 'n3', address = '127.0.0.1:{}', role = 1, status = 3 }}
 ]
-db_root_dir = '{}'
 log_dir = '{}'
 
 [raft]
@@ -106,30 +104,27 @@ general_raft_timeout_duration_in_ms = 10000
 [raft.snapshot]
 max_log_entries_before_snapshot = {}
 retained_log_entries = {}
-snapshots_dir = '{}'
 "#,
             node_id,
             ports[node_id as usize - 1],
             ports[0],
             ports[1],
             ports[2],
-            db_root_dir.join(format!("node{node_id}")).display(),
             log_dir.join(format!("node{node_id}")).display(),
             SNAPSHOT_THRESHOLD,
             RETAINED_LOGS,
-            snapshots_dir.join(format!("node{node_id}")).display(),
         );
 
         let config_path = format!("/tmp/follower_snap_node{node_id}.toml");
         tokio::fs::write(&config_path, &config).await?;
 
-        let db_path = db_root_dir.join(format!("node{node_id}/db"));
+        let db_path = data_dir.join(format!("node{node_id}/db"));
 
         tokio::fs::create_dir_all(&db_path).await?;
-        tokio::fs::create_dir_all(snapshots_dir.join(format!("node{node_id}"))).await?;
 
         let (storage, sm) = RocksDBUnifiedEngine::open(&db_path)?;
         let engine = DefaultEmbeddedEngine::start_custom(
+            &db_path,
             Arc::new(storage),
             Arc::new(sm),
             Some(&config_path),
@@ -179,8 +174,9 @@ snapshots_dir = '{}'
         "Phase 2: Verifying snapshot triggered on Follower Node {} (max wait 15s)...",
         follower_id
     );
+    let follower_snapshots_dir = data_dir.join(format!("node{follower_id}/db/snapshots"));
     assert!(
-        wait_for_snapshot(&snapshots_dir, follower_id as u64, Duration::from_secs(15)).await,
+        wait_for_snapshot(&follower_snapshots_dir, Duration::from_secs(15)).await,
         "Follower Node {follower_id} did not generate snapshot within 15s — \
          check_and_trigger_snapshot() in ApplyCompleted may be broken (fix #270)"
     );

--- a/d-engine-server/tests/snapshot_and_recovery/snapshot_generation_standalone.rs
+++ b/d-engine-server/tests/snapshot_and_recovery/snapshot_generation_standalone.rs
@@ -17,7 +17,6 @@
 //! - last_commit_index is 10
 //! - Node 1 and 2's log-3's term is 2
 
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -45,9 +44,8 @@ use crate::common::start_node;
 use crate::common::test_put_get;
 
 // Constants for test configuration
-const SNAPSHOT_DIR: &str = "./snapshots/snapshot/case1";
 const SNAPSHOT_CASE1_DIR: &str = "snapshot/case1";
-const SNAPSHOT_CASE1_DB_ROOT_DIR: &str = "./db/snapshot/case1";
+const SNAPSHOT_CASE1_DATA_DIR: &str = "./db/snapshot/case1";
 const SNAPSHOT_CASE1_LOG_DIR: &str = "./logs/snapshot/case1";
 
 /// The current test relies on the following snapshot configuration:
@@ -64,14 +62,14 @@ async fn test_snapshot_scenario() -> Result<(), ClientApiError> {
     let ports = port_guard.as_slice();
 
     // Prepare state machine directories (do not pre-allocate Arc to avoid ownership issues)
-    prepare_state_machine(1, &format!("{SNAPSHOT_CASE1_DB_ROOT_DIR}/cs/1")).await;
-    prepare_state_machine(2, &format!("{SNAPSHOT_CASE1_DB_ROOT_DIR}/cs/2")).await;
-    prepare_state_machine(3, &format!("{SNAPSHOT_CASE1_DB_ROOT_DIR}/cs/3")).await;
+    prepare_state_machine(1, &format!("{SNAPSHOT_CASE1_DATA_DIR}/cs/1")).await;
+    prepare_state_machine(2, &format!("{SNAPSHOT_CASE1_DATA_DIR}/cs/2")).await;
+    prepare_state_machine(3, &format!("{SNAPSHOT_CASE1_DATA_DIR}/cs/3")).await;
 
     // Prepare raft logs
-    let r1 = prepare_storage_engine(1, &format!("{SNAPSHOT_CASE1_DB_ROOT_DIR}/cs/1"), 0);
-    let r2 = prepare_storage_engine(2, &format!("{SNAPSHOT_CASE1_DB_ROOT_DIR}/cs/2"), 0);
-    let r3 = prepare_storage_engine(3, &format!("{SNAPSHOT_CASE1_DB_ROOT_DIR}/cs/3"), 0);
+    let r1 = prepare_storage_engine(1, &format!("{SNAPSHOT_CASE1_DATA_DIR}/cs/1"), 0);
+    let r2 = prepare_storage_engine(2, &format!("{SNAPSHOT_CASE1_DATA_DIR}/cs/2"), 0);
+    let r3 = prepare_storage_engine(3, &format!("{SNAPSHOT_CASE1_DATA_DIR}/cs/3"), 0);
 
     let last_log_id: u64 = 10;
     manipulate_log(&r1, vec![1, 2, 3], 1).await;
@@ -90,11 +88,12 @@ async fn test_snapshot_scenario() -> Result<(), ClientApiError> {
 
     for (i, port) in ports.iter().enumerate() {
         let node_id = (i + 1) as u64;
+        let node_data_dir = format!("{}/cs/{}", SNAPSHOT_CASE1_DATA_DIR, i + 1);
         let config = create_node_config(
             node_id,
             *port,
             ports,
-            &format!("{}/cs/{}", SNAPSHOT_CASE1_DB_ROOT_DIR, i + 1),
+            &node_data_dir,
             SNAPSHOT_CASE1_LOG_DIR,
         )
         .await;
@@ -103,7 +102,7 @@ async fn test_snapshot_scenario() -> Result<(), ClientApiError> {
         let state_machine = Arc::new(
             prepare_state_machine(
                 node_id as u32,
-                &format!("{SNAPSHOT_CASE1_DB_ROOT_DIR}/cs/{node_id}"),
+                &format!("{SNAPSHOT_CASE1_DATA_DIR}/cs/{node_id}"),
             )
             .await,
         );
@@ -115,13 +114,10 @@ async fn test_snapshot_scenario() -> Result<(), ClientApiError> {
             _ => None,
         };
 
-        let mut node_config = node_config(&config);
-
-        node_config.raft.snapshot.snapshots_dir =
-            PathBuf::from(format!("{SNAPSHOT_DIR}/{node_id}"));
+        let node_config = node_config(&config);
 
         let (graceful_tx, node_handle) =
-            start_node(node_config, Some(state_machine), raft_log).await?;
+            start_node(&node_data_dir, node_config, Some(state_machine), raft_log).await?;
 
         ctx.graceful_txs.push(graceful_tx);
         ctx.node_handles.push(node_handle);
@@ -139,8 +135,8 @@ async fn test_snapshot_scenario() -> Result<(), ClientApiError> {
     sleep(Duration::from_secs(3)).await;
 
     // Verify snapshot file exists on leader (node 3)
-    let snapshot_path = "./snapshots/snapshot/case1/3";
-    assert!(check_path_contents(snapshot_path).unwrap_or(false));
+    let snapshot_path = format!("{SNAPSHOT_CASE1_DATA_DIR}/cs/3/snapshots");
+    assert!(check_path_contents(&snapshot_path).unwrap_or(false));
 
     // Verify state machine data via client API (snapshot has been applied to leader)
     let mut client_manager = ClientManager::new(&create_bootstrap_urls(ports)).await?;

--- a/d-engine-server/tests/snapshot_and_recovery/snapshot_interrupted_transfer_embedded.rs
+++ b/d-engine-server/tests/snapshot_and_recovery/snapshot_interrupted_transfer_embedded.rs
@@ -57,8 +57,7 @@ async fn test_snapshot_receiver_truncates_stale_temp_file() -> Result<(), Box<dy
     const BASELINE_ENTRIES: u64 = 150;
 
     let temp_dir = tempfile::tempdir()?;
-    let db_root_dir = temp_dir.path().join("db");
-    let snapshots_dir = temp_dir.path().join("snapshots");
+    let data_dir = temp_dir.path().join("db");
 
     let mut port_guard = get_available_ports(4).await;
     port_guard.release_listeners();
@@ -77,7 +76,6 @@ initial_cluster = [
     {{ id = 2, name = 'n2', address = '127.0.0.1:{}', role = 1, status = 3 }},
     {{ id = 3, name = 'n3', address = '127.0.0.1:{}', role = 1, status = 3 }}
 ]
-db_root_dir = '{}'
 
 [raft]
 general_raft_timeout_duration_in_ms = 5000
@@ -85,25 +83,22 @@ general_raft_timeout_duration_in_ms = 5000
 [raft.snapshot]
 max_log_entries_before_snapshot = {SNAPSHOT_THRESHOLD}
 retained_log_entries = {RETAINED_LOGS}
-snapshots_dir = '{}'
 "#,
             ports[node_id as usize - 1],
             ports[0],
             ports[1],
             ports[2],
-            db_root_dir.join(format!("node{node_id}")).display(),
-            snapshots_dir.join(format!("node{node_id}")).display(),
         );
 
         let config_path = temp_dir.path().join(format!("node{node_id}.toml"));
         tokio::fs::write(&config_path, &config).await?;
 
-        let db_path = db_root_dir.join(format!("node{node_id}/db"));
+        let db_path = data_dir.join(format!("node{node_id}/db"));
         tokio::fs::create_dir_all(&db_path).await?;
-        tokio::fs::create_dir_all(snapshots_dir.join(format!("node{node_id}"))).await?;
 
         let (storage, sm) = RocksDBUnifiedEngine::open(&db_path)?;
         let engine = DefaultEmbeddedEngine::start_custom(
+            &db_path,
             Arc::new(storage),
             Arc::new(sm),
             Some(config_path.to_str().unwrap()),
@@ -130,14 +125,17 @@ snapshots_dir = '{}'
     }
 
     let leader_id = leader_info.leader_id as u64;
+    let leader_snapshots_dir = data_dir.join(format!("node{leader_id}/db/snapshots"));
     assert!(
-        wait_for_snapshot(&snapshots_dir, leader_id, Duration::from_secs(15)).await,
+        wait_for_snapshot(&leader_snapshots_dir, Duration::from_secs(15)).await,
         "Leader snapshot must exist before learner starts"
     );
     info!("Leader snapshot ready");
 
-    // Inject stale temp file — simulates a Learner that was killed mid-transfer
-    let node4_snap_dir = snapshots_dir.join("node4");
+    // Inject stale temp file — simulates a Learner that was killed mid-transfer.
+    // Must be the Learner's real snapshot dir: data_dir/node4/db/snapshots
+    // (snapshots are always at data_dir/snapshots, not independently configurable).
+    let node4_snap_dir = data_dir.join("node4/db/snapshots");
     tokio::fs::create_dir_all(&node4_snap_dir).await?;
     let stale_path = node4_snap_dir.join("temp-snapshot.part.tar.gz");
     tokio::fs::write(&stale_path, vec![0xAAu8; 4096]).await?;
@@ -158,7 +156,6 @@ initial_cluster = [
     {{ id = 3, name = 'n3', address = '127.0.0.1:{}', role = 1, status = 3 }},
     {{ id = 4, name = 'n4', address = '127.0.0.1:{}', role = 4, status = 2 }}
 ]
-db_root_dir = '{}'
 
 [raft]
 general_raft_timeout_duration_in_ms = 5000
@@ -166,25 +163,19 @@ general_raft_timeout_duration_in_ms = 5000
 [raft.snapshot]
 max_log_entries_before_snapshot = {SNAPSHOT_THRESHOLD}
 retained_log_entries = {RETAINED_LOGS}
-snapshots_dir = '{}'
 "#,
-        ports[3],
-        ports[0],
-        ports[1],
-        ports[2],
-        ports[3],
-        db_root_dir.join("node4").display(),
-        node4_snap_dir.display(),
+        ports[3], ports[0], ports[1], ports[2], ports[3],
     );
 
     let learner_config_path = temp_dir.path().join("node4.toml");
     tokio::fs::write(&learner_config_path, &learner_config).await?;
 
-    let learner_db_path = db_root_dir.join("node4/db");
+    let learner_db_path = data_dir.join("node4/db");
     tokio::fs::create_dir_all(&learner_db_path).await?;
 
     let (learner_storage, learner_sm) = RocksDBUnifiedEngine::open(&learner_db_path)?;
     let learner_engine = DefaultEmbeddedEngine::start_custom(
+        &learner_db_path,
         Arc::new(learner_storage),
         Arc::new(learner_sm),
         Some(learner_config_path.to_str().unwrap()),
@@ -218,7 +209,7 @@ snapshots_dir = '{}'
         "stale temp-snapshot.part.tar.gz must have been replaced by the final snapshot file"
     );
     assert!(
-        wait_for_snapshot(&snapshots_dir, 4, Duration::from_secs(5)).await,
+        wait_for_snapshot(&node4_snap_dir, Duration::from_secs(5)).await,
         "final snapshot file must exist on Learner"
     );
 

--- a/d-engine-server/tests/snapshot_and_recovery/snapshot_leader_change_during_transfer_embedded.rs
+++ b/d-engine-server/tests/snapshot_and_recovery/snapshot_leader_change_during_transfer_embedded.rs
@@ -53,8 +53,7 @@ async fn test_snapshot_transfer_resumes_after_leader_change()
     const BASELINE_ENTRIES: u64 = 80;
 
     let temp_dir = tempfile::tempdir()?;
-    let db_root_dir = temp_dir.path().join("db");
-    let snapshots_dir = temp_dir.path().join("snapshots");
+    let data_dir = temp_dir.path().join("db");
 
     let mut port_guard = get_available_ports(4).await;
     port_guard.release_listeners();
@@ -73,7 +72,6 @@ initial_cluster = [
     {{ id = 2, name = 'n2', address = '127.0.0.1:{}', role = 1, status = 3 }},
     {{ id = 3, name = 'n3', address = '127.0.0.1:{}', role = 1, status = 3 }}
 ]
-db_root_dir = '{}'
 
 [raft]
 general_raft_timeout_duration_in_ms = 5000
@@ -85,25 +83,22 @@ election_timeout_max = 3000
 [raft.snapshot]
 max_log_entries_before_snapshot = {SNAPSHOT_THRESHOLD}
 retained_log_entries = {RETAINED_LOGS}
-snapshots_dir = '{}'
 "#,
             ports[node_id as usize - 1],
             ports[0],
             ports[1],
             ports[2],
-            db_root_dir.join(format!("node{node_id}")).display(),
-            snapshots_dir.join(format!("node{node_id}")).display(),
         );
 
         let config_path = temp_dir.path().join(format!("node{node_id}.toml"));
         tokio::fs::write(&config_path, &config).await?;
 
-        let db_path = db_root_dir.join(format!("node{node_id}/db"));
+        let db_path = data_dir.join(format!("node{node_id}/db"));
         tokio::fs::create_dir_all(&db_path).await?;
-        tokio::fs::create_dir_all(snapshots_dir.join(format!("node{node_id}"))).await?;
 
         let (storage, sm) = RocksDBUnifiedEngine::open(&db_path)?;
         let engine = DefaultEmbeddedEngine::start_custom(
+            &db_path,
             Arc::new(storage),
             Arc::new(sm),
             Some(config_path.to_str().unwrap()),
@@ -130,13 +125,9 @@ snapshots_dir = '{}'
             .await?;
     }
 
+    let old_leader_snapshots_dir = data_dir.join(format!("node{old_leader_id}/db/snapshots"));
     assert!(
-        wait_for_snapshot(
-            &snapshots_dir,
-            old_leader_id as u64,
-            Duration::from_secs(15)
-        )
-        .await,
+        wait_for_snapshot(&old_leader_snapshots_dir, Duration::from_secs(15)).await,
         "Leader snapshot must exist before learner starts"
     );
     info!("Leader (Node {old_leader_id}) snapshot ready, log purge in effect");
@@ -153,7 +144,6 @@ initial_cluster = [
     {{ id = 3, name = 'n3', address = '127.0.0.1:{}', role = 1, status = 3 }},
     {{ id = 4, name = 'n4', address = '127.0.0.1:{}', role = 4, status = 2 }}
 ]
-db_root_dir = '{}'
 
 [raft]
 general_raft_timeout_duration_in_ms = 5000
@@ -165,26 +155,19 @@ election_timeout_max = 3000
 [raft.snapshot]
 max_log_entries_before_snapshot = {SNAPSHOT_THRESHOLD}
 retained_log_entries = {RETAINED_LOGS}
-snapshots_dir = '{}'
 "#,
-        ports[3],
-        ports[0],
-        ports[1],
-        ports[2],
-        ports[3],
-        db_root_dir.join("node4").display(),
-        snapshots_dir.join("node4").display(),
+        ports[3], ports[0], ports[1], ports[2], ports[3],
     );
 
     let learner_config_path = temp_dir.path().join("node4.toml");
     tokio::fs::write(&learner_config_path, &learner_config).await?;
 
-    let learner_db_path = db_root_dir.join("node4/db");
+    let learner_db_path = data_dir.join("node4/db");
     tokio::fs::create_dir_all(&learner_db_path).await?;
-    tokio::fs::create_dir_all(snapshots_dir.join("node4")).await?;
 
     let (learner_storage, learner_sm) = RocksDBUnifiedEngine::open(&learner_db_path)?;
     let learner_engine = DefaultEmbeddedEngine::start_custom(
+        &learner_db_path,
         Arc::new(learner_storage),
         Arc::new(learner_sm),
         Some(learner_config_path.to_str().unwrap()),

--- a/d-engine-server/tests/watch_and_subscriptions/watch_events_embedded.rs
+++ b/d-engine-server/tests/watch_and_subscriptions/watch_events_embedded.rs
@@ -38,6 +38,7 @@ watcher_buffer_size = 10
     let (storage, state_machine) = RocksDBUnifiedEngine::open(&db_path)?;
 
     let engine = DefaultEmbeddedEngine::start_custom(
+        &db_path,
         Arc::new(storage),
         Arc::new(state_machine),
         Some(config_path.to_str().unwrap()),
@@ -120,6 +121,7 @@ listen_address = "127.0.0.1:{port}"
     let (storage, state_machine) = RocksDBUnifiedEngine::open(&db_path)?;
 
     let engine = DefaultEmbeddedEngine::start_custom(
+        &db_path,
         Arc::new(storage),
         Arc::new(state_machine),
         Some(config_path.to_str().unwrap()),
@@ -362,6 +364,7 @@ watcher_buffer_size = 10
     let (storage, state_machine) = RocksDBUnifiedEngine::open(&db_path)?;
 
     let engine = DefaultEmbeddedEngine::start_custom(
+        &db_path,
         Arc::new(storage),
         Arc::new(state_machine),
         Some(config_path.to_str().unwrap()),

--- a/d-engine-server/tests/watch_and_subscriptions/watch_events_grpc_standalone.rs
+++ b/d-engine-server/tests/watch_and_subscriptions/watch_events_grpc_standalone.rs
@@ -76,7 +76,7 @@ async fn setup_standalone_cluster()
 
         // Start node
         let (graceful_tx, node_handle) =
-            start_node(config, Some(state_machine), Some(storage)).await?;
+            start_node(&node_dir, config, Some(state_machine), Some(storage)).await?;
 
         graceful_txs.push(graceful_tx);
         node_handles.push(node_handle);

--- a/d-engine-server/tests/watch_and_subscriptions/watch_membership_embedded.rs
+++ b/d-engine-server/tests/watch_and_subscriptions/watch_membership_embedded.rs
@@ -186,11 +186,12 @@ async fn start_engine(
     config_path: &str,
 ) -> Result<DefaultEmbeddedEngine, Box<dyn std::error::Error>> {
     tokio::fs::write(config_path, toml).await?;
-    let db_path = db_root.join(format!("node{node_id}/db"));
+    let node_data_dir = db_root.join(format!("node{node_id}"));
+    let db_path = node_data_dir.join("db");
     tokio::fs::create_dir_all(&db_path).await?;
     let (storage, sm) = RocksDBUnifiedEngine::open(&db_path)?;
     Ok(DefaultEmbeddedEngine::start_custom(
-        &db_path,
+        &node_data_dir,
         Arc::new(storage),
         Arc::new(sm),
         Some(config_path),

--- a/d-engine-server/tests/watch_and_subscriptions/watch_membership_embedded.rs
+++ b/d-engine-server/tests/watch_and_subscriptions/watch_membership_embedded.rs
@@ -90,7 +90,7 @@ fn node_toml(
     all_ports: &[u16],
     roles: &[i32],
     statuses: &[i32],
-    db_root: &str,
+    _db_root: &str,
     log_dir: &str,
 ) -> String {
     let members = all_ports
@@ -115,7 +115,6 @@ listen_address = '127.0.0.1:{port}'
 initial_cluster = [
     {members}
 ]
-db_root_dir = '{db_root}'
 log_dir = '{log_dir}'
 
 [raft]
@@ -190,10 +189,13 @@ async fn start_engine(
     let db_path = db_root.join(format!("node{node_id}/db"));
     tokio::fs::create_dir_all(&db_path).await?;
     let (storage, sm) = RocksDBUnifiedEngine::open(&db_path)?;
-    Ok(
-        DefaultEmbeddedEngine::start_custom(Arc::new(storage), Arc::new(sm), Some(config_path))
-            .await?,
+    Ok(DefaultEmbeddedEngine::start_custom(
+        &db_path,
+        Arc::new(storage),
+        Arc::new(sm),
+        Some(config_path),
     )
+    .await?)
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────────

--- a/d-engine-server/tests/watch_and_subscriptions/watch_membership_standalone.rs
+++ b/d-engine-server/tests/watch_and_subscriptions/watch_membership_standalone.rs
@@ -99,7 +99,7 @@ async fn test_grpc_watch_membership_receives_snapshot_on_learner_join()
         )
         .await;
         let config = node_config(&toml);
-        let (tx, handle) = start_node(config, None, None).await?;
+        let (tx, handle) = start_node(&node_dir, config, None, None).await?;
         graceful_txs.push(tx);
         node_handles.push(handle);
     }
@@ -157,7 +157,7 @@ async fn test_grpc_watch_membership_receives_snapshot_on_learner_join()
         )
         .await;
         let config = node_config(&toml);
-        let (tx, handle) = start_node(config, None, None).await?;
+        let (tx, handle) = start_node(&node_dir, config, None, None).await?;
         graceful_txs.push(tx);
         node_handles.push(handle);
     }

--- a/d-engine-server/tests/watch_and_subscriptions/watch_performance_gate_embedded.rs
+++ b/d-engine-server/tests/watch_and_subscriptions/watch_performance_gate_embedded.rs
@@ -49,7 +49,7 @@ watcher_buffer_size = 100
         RocksDBUnifiedEngine::open(&db_path).expect("Failed to open unified DB");
 
     let engine = DefaultEmbeddedEngine::start_custom(
-        &db_path,
+        temp_dir.path(),
         Arc::new(storage),
         Arc::new(state_machine),
         Some(config_path.to_str().unwrap()),

--- a/d-engine-server/tests/watch_and_subscriptions/watch_performance_gate_embedded.rs
+++ b/d-engine-server/tests/watch_and_subscriptions/watch_performance_gate_embedded.rs
@@ -49,6 +49,7 @@ watcher_buffer_size = 100
         RocksDBUnifiedEngine::open(&db_path).expect("Failed to open unified DB");
 
     let engine = DefaultEmbeddedEngine::start_custom(
+        &db_path,
         Arc::new(storage),
         Arc::new(state_machine),
         Some(config_path.to_str().unwrap()),

--- a/d-engine/src/docs/examples/single-node-expansion.md
+++ b/d-engine/src/docs/examples/single-node-expansion.md
@@ -53,7 +53,7 @@ listen_address = "0.0.0.0:9081"
 initial_cluster = [
     { id = 1, address = "0.0.0.0:9081", role = 2, status = 2 }
 ]
-db_root_dir = "./db"
+
 ```
 
 **Config field reference**:
@@ -92,7 +92,7 @@ initial_cluster = [
     { id = 1, address = "0.0.0.0:9081", role = 2, status = 2 },  # Existing leader
     { id = 2, address = "0.0.0.0:9082", role = 3, status = 0 },  # Self: Learner
 ]
-db_root_dir = "./db"
+
 ```
 
 **Key fields**:
@@ -144,7 +144,7 @@ initial_cluster = [
     { id = 2, address = "0.0.0.0:9082", role = 1, status = 2 },  # Follower (promoted), ACTIVE
     { id = 3, address = "0.0.0.0:9083", role = 3, status = 0 },  # Self: Learner, PROMOTABLE
 ]
-db_root_dir = "./db"
+
 ```
 
 **Key**: Node 2 listed as `role = 1, status = 2` assumes it's already promoted to Follower and ACTIVE.
@@ -237,7 +237,7 @@ initial_cluster = [
     { id = 1, address = "192.168.1.10:9081", role = 2, status = 2 },
     { id = 2, address = "192.168.1.11:9082", role = 3, status = 0 },
 ]
-db_root_dir = "./db"
+
 ```
 
 **Network requirements**:

--- a/d-engine/src/docs/quick-start-5min.md
+++ b/d-engine/src/docs/quick-start-5min.md
@@ -37,15 +37,12 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 ## Step 2: Create Config File (1 minute)
 
-Create `d-engine.toml` with only the settings you need — omitted fields use built-in defaults:
+For a single node, no config file is needed — jump to Step 3.
 
-```toml
-[cluster]
-db_root_dir = "./data/single-node"
-```
-
-For all available options with descriptions and defaults, see
-[`d_engine_core::config`](https://docs.rs/d-engine-core/latest/d_engine_core/config/).
+For multi-node clusters or custom settings, create `d-engine.toml` with only the
+fields you need. All omitted fields use built-in defaults. See
+[`d_engine_core::config`](https://docs.rs/d-engine-core/latest/d_engine_core/config/)
+for the full list.
 
 ## Step 3: Write Your First d-engine App (2 minutes)
 
@@ -201,21 +198,26 @@ No manual `tokio::spawn()`, no leaked tasks.
 ### DefaultEmbeddedEngine
 
 ```rust,ignore
-// Explicit data directory (highest priority)
+// Explicit data directory (required)
 DefaultEmbeddedEngine::start(data_dir: impl AsRef<Path>) -> Result<Self>
 
-// Use explicit config file
-DefaultEmbeddedEngine::start_with(config_path: impl AsRef<Path>) -> Result<Self>
+// Explicit data directory + config file for non-path settings
+DefaultEmbeddedEngine::start_with(
+    data_dir: impl AsRef<Path>,
+    config_path: impl AsRef<Path>
+) -> Result<Self>
 
 // Start with programmatic config — no config file needed
 EmbeddedEngine::<YourTypeConfig>::start_node(
-    config: RaftNodeConfig,
+    data_dir: impl AsRef<Path>,
     storage: Arc<impl StorageEngine>,
-    state_machine: Arc<impl StateMachine>
+    state_machine: Arc<impl StateMachine>,
+    config: RaftNodeConfig
 ) -> Result<Self>
 
 // Advanced (custom storage + state machine with optional config file)
 EmbeddedEngine::<YourTypeConfig>::start_custom(
+    data_dir: impl AsRef<Path>,
     storage: Arc<impl StorageEngine>,
     state_machine: Arc<impl StateMachine>,
     config_path: Option<&str>
@@ -324,9 +326,8 @@ match engine.wait_ready(Duration::from_secs(10)).await {
 # Check permissions
 ls -la ./data
 
-# Or update d-engine.toml to use /tmp
-[cluster]
-db_root_dir = "/tmp/d-engine"
+# Or pass a writable path to the constructor
+EmbeddedEngine::start("/tmp/d-engine").await?;
 ```
 
 ### "Address already in use"

--- a/d-engine/src/docs/quick-start-5min.md
+++ b/d-engine/src/docs/quick-start-5min.md
@@ -57,8 +57,8 @@ use std::time::Duration;
 async fn main() -> Result<(), Box<dyn Error>> {
     println!("Starting d-engine...\n");
 
-    // Start embedded engine with config file
-    let engine = DefaultEmbeddedEngine::start_with("d-engine.toml").await?;
+    // Start embedded engine — single node, no config file needed
+    let engine = DefaultEmbeddedEngine::start("./data").await?;
 
     // Wait for leader election (single-node: instant)
     let leader = engine.wait_ready(Duration::from_secs(5)).await?;
@@ -113,17 +113,18 @@ Done!
 ### Behind the Scenes
 
 ```rust,ignore
-DefaultEmbeddedEngine::start_with("d-engine.toml").await?
+DefaultEmbeddedEngine::start("./data").await?
 ```
 
 This one line:
 
-1. Reads config from `d-engine.toml`
-2. Created `./data/single-node/db/` (single RocksDB instance)
-3. Initialized 4 column families: `logs`, `meta`, `state_machine`, `state_machine_meta`
-4. Built Raft node with node_id=1
-5. Spawned `node.run()` in background (Raft protocol)
-6. Returned immediately (non-blocking)
+1. Created `./data/storage/` (`logs`, `meta`) and `./data/state_machine/`
+   (`state_machine`, `state_machine_meta`) — two separate RocksDB instances by
+   default, for workload isolation. (Set `[storage] unified_db = true` for one
+   shared instance at `./data/db/` instead.)
+2. Built Raft node with node_id=1
+3. Spawned `node.run()` in background (Raft protocol)
+4. Returned immediately (non-blocking)
 
 ```rust,ignore
 engine.wait_ready(Duration::from_secs(5)).await?
@@ -182,7 +183,7 @@ See docs for TTL, multi-key operations, and advanced consistency control.
 ### 3. Automatic Lifecycle Management
 
 ```rust,ignore
-let engine = DefaultEmbeddedEngine::start_with("d-engine.toml").await?;
+let engine = DefaultEmbeddedEngine::start("./data").await?;
 // ↑ Internally spawns node.run() in background
 
 engine.stop().await?;
@@ -271,8 +272,8 @@ let engine = DefaultEmbeddedEngine::start("./data").await?;
 ### Pattern 2: Explicit config file
 
 ```rust,ignore
-// Use specific config file
-let engine = DefaultEmbeddedEngine::start_with("d-engine.toml").await?;
+// Use specific config file for non-path settings (node_id, cluster topology, etc.)
+let engine = DefaultEmbeddedEngine::start_with("./data", "d-engine.toml").await?;
 ```
 
 ### Pattern 3: Monitor Leader Changes
@@ -391,7 +392,7 @@ For advanced usage:
 
 ## Key Takeaways
 
-- ✅ **2-line startup**: `start_with()` → `wait_ready()`
+- ✅ **2-line startup**: `start()` → `wait_ready()`
 - ✅ **Zero boilerplate**: No manual spawn, no shutdown channels
 - ✅ **Event-driven**: No polling, <1ms notification latency
 - ✅ **Production-ready**: Auto-creates directories, graceful shutdown

--- a/d-engine/src/docs/server_guide/customize-state-machine.md
+++ b/d-engine/src/docs/server_guide/customize-state-machine.md
@@ -230,18 +230,23 @@ async fn test_performance() -> Result<(), Error> {
 
 Run performance tests locally: `cargo test -- --ignored`
 
-## 5. Register with NodeBuilder
+## 5. Use It
 
 ```rust,ignore
-use d_engine::NodeBuilder;
+use d_engine::{EmbeddedEngine, FileStorageEngine};
 
-let custom_sm = Arc::new(CustomStateMachine::new().await?);
+let storage_engine = Arc::new(FileStorageEngine::new("./data/storage").await?);
+let state_machine = Arc::new(CustomStateMachine::new().await?);
 
-NodeBuilder::new(config, shutdown_rx)
-    .state_machine(custom_sm)  // Required component
-    .start()
-    .await?;
+let engine = EmbeddedEngine::start_custom(
+    "./data",       // data_dir
+    storage_engine,
+    state_machine,
+    None,           // optional config file
+).await?;
 ```
+
+Running a standalone gRPC server instead of embedding? Use `StandaloneEngine::run_custom` — same arguments, plus a shutdown signal.
 
 ## 6. Production Examples
 

--- a/d-engine/src/docs/server_guide/customize-storage-engine.md
+++ b/d-engine/src/docs/server_guide/customize-storage-engine.md
@@ -173,19 +173,23 @@ async fn test_performance() -> Result<(), Error> {
 
 ```
 
-## 5. Register with NodeBuilder
+## 5. Use It
 
 ```rust,ignore
-use d_engine::NodeBuilder;
+use d_engine::{EmbeddedEngine, FileStateMachine};
 
 let storage_engine = Arc::new(CustomStorageEngine::new().await?);
+let state_machine = Arc::new(FileStateMachine::new("./data/state_machine").await?);
 
-NodeBuilder::new(config, shutdown_rx)
-    .storage_engine(storage_engine)  // Required component
-    .start()
-    .await?;
-
+let engine = EmbeddedEngine::start_custom(
+    "./data",       // data_dir
+    storage_engine,
+    state_machine,
+    None,           // optional config file
+).await?;
 ```
+
+Running a standalone gRPC server instead of embedding? Use `StandaloneEngine::run_custom` — same arguments, plus a shutdown signal.
 
 ## 6. Production Examples
 

--- a/d-engine/src/lib.rs
+++ b/d-engine/src/lib.rs
@@ -17,8 +17,8 @@ pub use d_engine_client::*;
 pub mod prelude {
     #[cfg(feature = "server")]
     pub use d_engine_server::{
-        EmbeddedClient, EmbeddedEngine, Error, FileStateMachine, FileStorageEngine, Node,
-        NodeBuilder, Result, StandaloneEngine, StateMachine, StorageEngine,
+        EmbeddedClient, EmbeddedEngine, Error, FileStateMachine, FileStorageEngine, Node, Result,
+        StandaloneEngine, StateMachine, StorageEngine,
     };
 
     #[cfg(feature = "rocksdb")]

--- a/examples/quick-start-embedded/README.md
+++ b/examples/quick-start-embedded/README.md
@@ -11,7 +11,7 @@ Minimal example of embedding d-engine in a Rust application.
 
 ## Prerequisites
 
-- Rust 1.88+ ([install](https://rustup.rs/))
+- Rust 1.89+ ([install](https://rustup.rs/))
 - ~500MB disk space
 
 ## Quick Start (5 minutes)

--- a/examples/quick-start-embedded/d-engine.toml
+++ b/examples/quick-start-embedded/d-engine.toml
@@ -1,6 +1,5 @@
 # d-engine quick-start configuration
 # Minimal single-node setup
-
-[cluster]
-# Where to store data
-db_root_dir = "./data/single-node"
+#
+# data_dir is passed as an explicit argument to start_with() in main.rs,
+# not configured here.

--- a/examples/quick-start-embedded/src/main.rs
+++ b/examples/quick-start-embedded/src/main.rs
@@ -20,9 +20,9 @@ async fn main() -> std::result::Result<(), Box<dyn StdError>> {
 
     println!("🚀 Starting d-engine...");
 
-    // Start embedded engine with explicit config
-    // Config file specifies data directory and other settings
-    let engine = DefaultEmbeddedEngine::start_with("d-engine.toml").await?;
+    // Start embedded engine: data_dir is an explicit runtime argument (never
+    // config-file-sourced), config file covers everything else.
+    let engine = DefaultEmbeddedEngine::start_with("./data/single-node", "d-engine.toml").await?;
 
     // Wait for leader election (single-node: instant)
     let leader = engine.wait_ready(Duration::from_secs(5)).await?;

--- a/examples/service-discovery-embedded/server.rs
+++ b/examples/service-discovery-embedded/server.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Starting embedded d-engine for service discovery...\n");
 
-    let engine = DefaultEmbeddedEngine::start_with("d-engine.toml").await?;
+    let engine = DefaultEmbeddedEngine::start_with("./data", "d-engine.toml").await?;
 
     let leader = engine.wait_ready(Duration::from_secs(5)).await?;
     println!(

--- a/examples/single-node-expansion/README.md
+++ b/examples/single-node-expansion/README.md
@@ -115,7 +115,7 @@ listen_address = "0.0.0.0:9081"
 initial_cluster = [
     { id = 1, address = "0.0.0.0:9081", role = 2, status = 2 }  # Leader
 ]
-db_root_dir = "./db"
+# data_dir is passed as an explicit argument to start_node(), not in [cluster].
 ```
 
 **Node 2** (`config/n2.toml`):
@@ -128,7 +128,7 @@ initial_cluster = [
     { id = 1, address = "0.0.0.0:9081", role = 2, status = 2 },  # Existing leader
     { id = 2, address = "0.0.0.0:9082", role = 3, status = 0 },  # Self: Learner
 ]
-db_root_dir = "./db"
+# data_dir is passed as an explicit argument to start_node(), not in [cluster].
 ```
 
 **Node 3** (`config/n3.toml`):
@@ -142,7 +142,7 @@ initial_cluster = [
     { id = 2, address = "0.0.0.0:9082", role = 1, status = 2 },  # Follower (promoted)
     { id = 3, address = "0.0.0.0:9083", role = 3, status = 0 },  # Self: Learner
 ]
-db_root_dir = "./db"
+# data_dir is passed as an explicit argument to start_node(), not in [cluster].
 ```
 
 **Role values:** `1=Follower, 2=Leader, 3=Learner`  

--- a/examples/single-node-expansion/README.md
+++ b/examples/single-node-expansion/README.md
@@ -115,7 +115,7 @@ listen_address = "0.0.0.0:9081"
 initial_cluster = [
     { id = 1, address = "0.0.0.0:9081", role = 2, status = 2 }  # Leader
 ]
-# data_dir is passed as an explicit argument to start_node(), not in [cluster].
+# data_dir is passed as an explicit argument to run_custom(), not in [cluster].
 ```
 
 **Node 2** (`config/n2.toml`):
@@ -128,7 +128,7 @@ initial_cluster = [
     { id = 1, address = "0.0.0.0:9081", role = 2, status = 2 },  # Existing leader
     { id = 2, address = "0.0.0.0:9082", role = 3, status = 0 },  # Self: Learner
 ]
-# data_dir is passed as an explicit argument to start_node(), not in [cluster].
+# data_dir is passed as an explicit argument to run_custom(), not in [cluster].
 ```
 
 **Node 3** (`config/n3.toml`):
@@ -142,7 +142,7 @@ initial_cluster = [
     { id = 2, address = "0.0.0.0:9082", role = 1, status = 2 },  # Follower (promoted)
     { id = 3, address = "0.0.0.0:9083", role = 3, status = 0 },  # Self: Learner
 ]
-# data_dir is passed as an explicit argument to start_node(), not in [cluster].
+# data_dir is passed as an explicit argument to run_custom(), not in [cluster].
 ```
 
 **Role values:** `1=Follower, 2=Leader, 3=Learner`  

--- a/examples/single-node-expansion/config/n1.toml
+++ b/examples/single-node-expansion/config/n1.toml
@@ -10,8 +10,6 @@ initial_cluster = [
     { id = 1, address = "0.0.0.0:9081", role = 3, status = 3 }, # role=3 (Leader), status=3 (Active)
 ]
 
-db_root_dir = "./db"
-log_dir = "./logs"
 
 
 [raft]
@@ -34,7 +32,6 @@ max_buffered_entries = 10000
 enable = false
 max_log_entries_before_snapshot = 10000
 snapshot_cool_down_since_last_check = { secs = 60 }
-snapshots_dir = "./snapshots/"
 retained_log_entries = 3
 
 # == Network Control Plane ==

--- a/examples/single-node-expansion/config/n2.toml
+++ b/examples/single-node-expansion/config/n2.toml
@@ -13,8 +13,6 @@ initial_cluster = [
     { id = 2, address = "0.0.0.0:9082", role = 4, status = 1 }, # Self: Learner, Joining
 ]
 
-db_root_dir = "./db"
-log_dir = "./logs"
 
 
 [raft]
@@ -38,7 +36,6 @@ max_buffered_entries = 10000
 enable = false
 max_log_entries_before_snapshot = 10000
 snapshot_cool_down_since_last_check = { secs = 60 }
-snapshots_dir = "./snapshots/"
 retained_log_entries = 3
 
 # == Network Control Plane ==

--- a/examples/single-node-expansion/config/n3.toml
+++ b/examples/single-node-expansion/config/n3.toml
@@ -15,8 +15,6 @@ initial_cluster = [
     { id = 3, address = "0.0.0.0:9083", role = 4, status = 1 }, # Self: Learner, Joining
 ]
 
-db_root_dir = "./db"
-log_dir = "./logs"
 
 
 [raft]
@@ -40,7 +38,6 @@ max_buffered_entries = 10000
 enable = false
 max_log_entries_before_snapshot = 10000
 snapshot_cool_down_since_last_check = { secs = 60 }
-snapshots_dir = "./snapshots/"
 retained_log_entries = 3
 
 # == Network Control Plane ==

--- a/examples/single-node-expansion/src/main.rs
+++ b/examples/single-node-expansion/src/main.rs
@@ -1,4 +1,4 @@
-use d_engine::NodeBuilder;
+use d_engine::StandaloneEngine;
 // use d_engine::FileStateMachine;
 // use d_engine::FileStorageEngine;
 use d_engine::RocksDBUnifiedEngine;
@@ -100,16 +100,16 @@ async fn start_dengine_server(
     // Option 2: ROCKSDB (unified engine — single DB instance, 4 column families)
     let (storage_engine, state_machine) = RocksDBUnifiedEngine::open(db_path.join("db")).unwrap();
 
-    // Start Node
-    let node = NodeBuilder::new(None, graceful_rx.clone())
-        .storage_engine(Arc::new(storage_engine))
-        .state_machine(Arc::new(state_machine))
-        .start()
-        .await
-        .expect("start node failed.");
-
-    // Start Node
-    if let Err(e) = node.run().await {
+    // Start Node — blocks until shutdown.
+    if let Err(e) = StandaloneEngine::run_custom(
+        &db_path,
+        Arc::new(storage_engine),
+        Arc::new(state_machine),
+        graceful_rx,
+        None::<&str>,
+    )
+    .await
+    {
         error!("node stops: {:?}", e);
     } else {
         info!("node stops.");

--- a/examples/sled-cluster/config/n1.toml
+++ b/examples/sled-cluster/config/n1.toml
@@ -6,8 +6,6 @@ initial_cluster = [
     { id = 2, address = "0.0.0.0:9082", role = 1, status = 3 },
     { id = 3, address = "0.0.0.0:9083", role = 1, status = 3 },
 ]
-db_root_dir = "./db"
-log_dir = "./logs"
 
 [raft]
 general_raft_timeout_duration_in_ms = 100
@@ -26,7 +24,6 @@ flush_policy = { Batch = { idle_flush_interval_ms = 100 } }
 enable = false
 max_log_entries_before_snapshot = 10000
 snapshot_cool_down_since_last_check = { secs = 60 }
-snapshots_dir = "./snapshots/"
 retained_log_entries = 3
 
 # == Network Control Plane (voting, heartbeat, etc.) ==

--- a/examples/sled-cluster/config/n2.toml
+++ b/examples/sled-cluster/config/n2.toml
@@ -6,8 +6,6 @@ initial_cluster = [
     { id = 2, address = "0.0.0.0:9082", role = 1, status = 3 },
     { id = 3, address = "0.0.0.0:9083", role = 1, status = 3 },
 ]
-db_root_dir = "./db"
-log_dir = "./logs"
 
 
 [raft]
@@ -26,7 +24,6 @@ flush_policy = { Batch = { idle_flush_interval_ms = 100 } }
 enable = false
 max_log_entries_before_snapshot = 10000
 snapshot_cool_down_since_last_check = { secs = 60 }
-snapshots_dir = "./snapshots/"
 retained_log_entries = 3
 
 

--- a/examples/sled-cluster/config/n3.toml
+++ b/examples/sled-cluster/config/n3.toml
@@ -6,8 +6,6 @@ initial_cluster = [
     { id = 2, address = "0.0.0.0:9082", role = 1, status = 3 },
     { id = 3, address = "0.0.0.0:9083", role = 1, status = 3 },
 ]
-db_root_dir = "./db"
-log_dir = "./logs"
 
 [raft]
 general_raft_timeout_duration_in_ms = 100
@@ -27,7 +25,6 @@ flush_policy = { Batch = { idle_flush_interval_ms = 100 } }
 enable = false
 max_log_entries_before_snapshot = 10000
 snapshot_cool_down_since_last_check = { secs = 60 }
-snapshots_dir = "./snapshots/"
 retained_log_entries = 3
 
 # == Network Control Plane (voting, heartbeat, etc.) ==

--- a/examples/sled-cluster/src/main.rs
+++ b/examples/sled-cluster/src/main.rs
@@ -1,4 +1,4 @@
-use d_engine::NodeBuilder;
+use d_engine::StandaloneEngine;
 use sled_demo::{SledStateMachine, SledStorageEngine};
 use std::env;
 use std::error::Error;
@@ -70,16 +70,16 @@ async fn start_dengine_server(
     let state_machine =
         Arc::new(SledStateMachine::new(db_path.join("state_machine"), node_id).unwrap());
 
-    // Start Node
-    let node = NodeBuilder::new(None, graceful_rx.clone())
-        .storage_engine(storage_engine)
-        .state_machine(state_machine)
-        .start()
-        .await
-        .expect("start node failed.");
-
-    // Start Node
-    if let Err(e) = node.run().await {
+    // Start Node — blocks until shutdown.
+    if let Err(e) = StandaloneEngine::run_custom(
+        &db_path,
+        storage_engine,
+        state_machine,
+        graceful_rx,
+        None::<&str>,
+    )
+    .await
+    {
         error!("node stops: {:?}", e);
     } else {
         info!("node stops.");

--- a/examples/three-nodes-embedded/Makefile
+++ b/examples/three-nodes-embedded/Makefile
@@ -60,6 +60,7 @@ start-node1:
 		--port 8081 \
 		--health-port 10001 \
 		--config-path "config/n1.toml" \
+		--data-dir "db/1" \
 		2>&1 | sed 's/^/[Node1] /' & \
 	PID=$$!; \
 	wait $$PID; \
@@ -75,6 +76,7 @@ start-node2:
 		--port 8082 \
 		--health-port 10002 \
 		--config-path "config/n2.toml" \
+		--data-dir "db/2" \
 		2>&1 | sed 's/^/[Node2] /' & \
 	PID=$$!; \
 	wait $$PID; \
@@ -90,6 +92,7 @@ start-node3:
 		--port 8083 \
 		--health-port 10003 \
 		--config-path "config/n3.toml" \
+		--data-dir "db/3" \
 		2>&1 | sed 's/^/[Node3] /' & \
 	PID=$$!; \
 	wait $$PID; \

--- a/examples/three-nodes-embedded/config/n1.toml
+++ b/examples/three-nodes-embedded/config/n1.toml
@@ -6,7 +6,6 @@ initial_cluster = [
     { id = 2, address = "0.0.0.0:9082", role = 1, status = 3 },
     { id = 3, address = "0.0.0.0:9083", role = 1, status = 3 },
 ]
-db_root_dir = "./db/1"
 
 [raft.snapshot]
-enable = false
+enable = true

--- a/examples/three-nodes-embedded/config/n2.toml
+++ b/examples/three-nodes-embedded/config/n2.toml
@@ -6,7 +6,6 @@ initial_cluster = [
     { id = 2, address = "0.0.0.0:9082", role = 1, status = 3 },
     { id = 3, address = "0.0.0.0:9083", role = 1, status = 3 },
 ]
-db_root_dir = "./db/2"
 
 [raft.snapshot]
-enable = false
+enable = true

--- a/examples/three-nodes-embedded/config/n3.toml
+++ b/examples/three-nodes-embedded/config/n3.toml
@@ -6,7 +6,6 @@ initial_cluster = [
     { id = 2, address = "0.0.0.0:9082", role = 1, status = 3 },
     { id = 3, address = "0.0.0.0:9083", role = 1, status = 3 },
 ]
-db_root_dir = "./db/3"
 
 [raft.snapshot]
-enable = false
+enable = true

--- a/examples/three-nodes-embedded/src/main.rs
+++ b/examples/three-nodes-embedded/src/main.rs
@@ -31,6 +31,8 @@ struct Cli {
     health_port: u16,
     #[clap(long)]
     config_path: String,
+    #[clap(long)]
+    data_dir: String,
 }
 
 #[tokio::main]
@@ -57,7 +59,7 @@ async fn main() {
     // d-engine Integration (Start & Wait for Leader Election)
     // ============================================================
     let engine = Arc::new(
-        DefaultEmbeddedEngine::start_with(&cli.config_path)
+        DefaultEmbeddedEngine::start_with(&cli.data_dir, &cli.config_path)
             .await
             .expect("Failed to start engine"),
     );

--- a/examples/three-nodes-standalone/README.md
+++ b/examples/three-nodes-standalone/README.md
@@ -4,7 +4,7 @@
 
 Production-ready setup with automatic failover and data replication.
 
-````bash
+```bash
 # Build (ensure cargo is installed)
 make build
 
@@ -16,6 +16,7 @@ make start-node1  # Launch node 1
 make start-node2  # Launch node 2
 make start-node3  # Launch node 3
 make clean        # Clean all build artifacts and logs
+```
 
 ### Manual Startup (Advanced)
 
@@ -25,16 +26,18 @@ For manual control, run these in separate terminal sessions:
 
 ```bash
 CONFIG_PATH=config/n1 \
+DB_PATH="./db/1" \
 LOG_DIR="./logs/1" \
 RUST_LOG=demo=debug,d_engine=debug \
 RUST_BACKTRACE=1 \
 target/release/demo
-````
+```
 
 **Node 2:**
 
 ```bash
 CONFIG_PATH=config/n2 \
+DB_PATH="./db/2" \
 LOG_DIR="./logs/2" \
 RUST_LOG=demo=debug,d_engine=debug \
 target/release/demo
@@ -44,6 +47,7 @@ target/release/demo
 
 ```bash
 CONFIG_PATH=config/n3 \
+DB_PATH="./db/3" \
 LOG_DIR="./logs/3" \
 RUST_LOG=demo=debug,d_engine=debug \
 target/release/demo

--- a/examples/three-nodes-standalone/config/n1.toml
+++ b/examples/three-nodes-standalone/config/n1.toml
@@ -6,8 +6,6 @@ initial_cluster = [
     { id = 2, address = "0.0.0.0:9082", role = 1, status = 3 },
     { id = 3, address = "0.0.0.0:9083", role = 1, status = 3 },
 ]
-db_root_dir = "./db/1"
-log_dir = "./logs"
 
 
 [raft]
@@ -49,10 +47,9 @@ flush_policy = { Batch = { idle_flush_interval_ms = 1000 } }
 max_buffered_entries = 10000
 
 [raft.snapshot]
-enable = false
+enable = true
 max_log_entries_before_snapshot = 10000
 snapshot_cool_down_since_last_check = { secs = 60 }
-snapshots_dir = "./snapshots/"
 retained_log_entries = 3
 
 # == TTL Lease Configuration ==

--- a/examples/three-nodes-standalone/config/n2.toml
+++ b/examples/three-nodes-standalone/config/n2.toml
@@ -6,8 +6,6 @@ initial_cluster = [
     { id = 2, address = "0.0.0.0:9082", role = 1, status = 3 },
     { id = 3, address = "0.0.0.0:9083", role = 1, status = 3 },
 ]
-db_root_dir = "./db/2"
-log_dir = "./logs"
 
 
 [raft]
@@ -49,10 +47,9 @@ flush_policy = { Batch = { idle_flush_interval_ms = 1000 } }
 max_buffered_entries = 10000
 
 [raft.snapshot]
-enable = false
+enable = true
 max_log_entries_before_snapshot = 10000
 snapshot_cool_down_since_last_check = { secs = 60 }
-snapshots_dir = "./snapshots/"
 retained_log_entries = 3
 
 # == TTL Lease Configuration ==

--- a/examples/three-nodes-standalone/config/n3.toml
+++ b/examples/three-nodes-standalone/config/n3.toml
@@ -6,8 +6,6 @@ initial_cluster = [
     { id = 2, address = "0.0.0.0:9082", role = 1, status = 3 },
     { id = 3, address = "0.0.0.0:9083", role = 1, status = 3 },
 ]
-db_root_dir = "./db/3"
-log_dir = "./logs"
 
 
 [raft]
@@ -49,10 +47,9 @@ flush_policy = { Batch = { idle_flush_interval_ms = 1000 } }
 max_buffered_entries = 10000
 
 [raft.snapshot]
-enable = false
+enable = true
 max_log_entries_before_snapshot = 10000
 snapshot_cool_down_since_last_check = { secs = 60 }
-snapshots_dir = "./snapshots/"
 retained_log_entries = 3
 
 # == TTL Lease Configuration ==

--- a/examples/three-nodes-standalone/docker/config/n1.toml
+++ b/examples/three-nodes-standalone/docker/config/n1.toml
@@ -6,8 +6,6 @@ initial_cluster = [
     { id = 2, address = "192.168.0.12:9082", role = 1, status = 3 },
     { id = 3, address = "192.168.0.13:9083", role = 1, status = 3 },
 ]
-db_root_dir = "./db/1"
-log_dir = "./logs"
 
 
 [raft]
@@ -52,7 +50,6 @@ max_buffered_entries = 10000
 enable = false
 max_log_entries_before_snapshot = 10000
 snapshot_cool_down_since_last_check = { secs = 60 }
-snapshots_dir = "./snapshots/"
 retained_log_entries = 3
 
 # == TTL Lease Configuration ==

--- a/examples/three-nodes-standalone/docker/config/n2.toml
+++ b/examples/three-nodes-standalone/docker/config/n2.toml
@@ -6,8 +6,6 @@ initial_cluster = [
     { id = 2, address = "192.168.0.12:9082", role = 1, status = 3 },
     { id = 3, address = "192.168.0.13:9083", role = 1, status = 3 },
 ]
-db_root_dir = "./db/2"
-log_dir = "./logs"
 
 
 [raft]
@@ -52,7 +50,6 @@ max_buffered_entries = 10000
 enable = false
 max_log_entries_before_snapshot = 10000
 snapshot_cool_down_since_last_check = { secs = 60 }
-snapshots_dir = "./snapshots/"
 retained_log_entries = 3
 
 # == TTL Lease Configuration ==

--- a/examples/three-nodes-standalone/docker/config/n3.toml
+++ b/examples/three-nodes-standalone/docker/config/n3.toml
@@ -6,8 +6,6 @@ initial_cluster = [
     { id = 2, address = "192.168.0.12:9082", role = 1, status = 3 },
     { id = 3, address = "192.168.0.13:9083", role = 1, status = 3 },
 ]
-db_root_dir = "./db/3"
-log_dir = "./logs"
 
 
 [raft]
@@ -52,7 +50,6 @@ max_buffered_entries = 10000
 enable = false
 max_log_entries_before_snapshot = 10000
 snapshot_cool_down_since_last_check = { secs = 60 }
-snapshots_dir = "./snapshots/"
 retained_log_entries = 3
 
 # == TTL Lease Configuration ==

--- a/examples/three-nodes-standalone/docker/docker-compose.yml
+++ b/examples/three-nodes-standalone/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - ${SSH_KEYS_PATH:-./jepsen/sshkeys}:/root/.ssh
       - ${CONFIG_PATH:-../config}:/app/config
       - ${LOGS_PATH:-./output/logs}:/app/logs
-      - ${DB_PATH:-./output/db}:/app/db
+      - ${DB_PATH:-./output/db}/1:/app/db
       # - ${SNAPSHOTS_PATH:-./output/snapshots}:/app/snapshots
 
   node2:
@@ -42,6 +42,11 @@ services:
     ports:
       - "2022:22"
       - "9082:9082"
+    volumes:
+      - ${SSH_KEYS_PATH:-./jepsen/sshkeys}:/root/.ssh
+      - ${CONFIG_PATH:-../config}:/app/config
+      - ${LOGS_PATH:-./output/logs}:/app/logs
+      - ${DB_PATH:-./output/db}/2:/app/db
 
   node3:
     <<: *node-base
@@ -60,6 +65,11 @@ services:
     ports:
       - "2023:22"
       - "9083:9083"
+    volumes:
+      - ${SSH_KEYS_PATH:-./jepsen/sshkeys}:/root/.ssh
+      - ${CONFIG_PATH:-../config}:/app/config
+      - ${LOGS_PATH:-./output/logs}:/app/logs
+      - ${DB_PATH:-./output/db}/3:/app/db
 
   jepsen:
     image: jepsen:2.0

--- a/examples/three-nodes-standalone/src/main.rs
+++ b/examples/three-nodes-standalone/src/main.rs
@@ -27,6 +27,10 @@ async fn main() {
         .map(|path| format!("{path}.toml"))
         .unwrap_or_else(|_| "d-engine.toml".to_string());
 
+    let data_dir = env::var("DB_PATH")
+        .map_err(|_| "DB_PATH environment variable not set")
+        .expect("Set data dir successfully.");
+
     let metrics_port: u16 = env::var("METRICS_PORT")
         .map(|v| v.parse::<u16>().expect("METRICS_PORT must be a valid port"))
         .unwrap_or(9000); // default 9000 if not set
@@ -54,7 +58,8 @@ async fn main() {
     let (graceful_tx, graceful_rx) = watch::channel(());
 
     // Start the server (wait for its initialization to complete)
-    let server_handler = tokio::spawn(start_dengine_server(config_path, graceful_rx.clone()));
+    let server_handler =
+        tokio::spawn(start_dengine_server(data_dir, config_path, graceful_rx.clone()));
 
     // Wait for the server to initialize (adjust the waiting time according to the actual logic)
     tokio::time::sleep(Duration::from_secs(1)).await;
@@ -86,6 +91,7 @@ async fn main() {
 }
 
 async fn start_dengine_server(
+    data_dir: String,
     config_path: String,
     graceful_rx: watch::Receiver<()>,
 ) {
@@ -94,9 +100,9 @@ async fn start_dengine_server(
     println!("║  Config: {config_path:<28} ║");
     println!("╚════════════════════════════════════════╝");
 
-    // StandaloneEngine with explicit config path
+    // StandaloneEngine with explicit data_dir and config path
     // Blocks until shutdown signal received
-    if let Err(e) = StandaloneEngine::run_with(&config_path, graceful_rx).await {
+    if let Err(e) = StandaloneEngine::run_with(&data_dir, &config_path, graceful_rx).await {
         error!("Server stopped with error: {:?}", e);
     } else {
         info!("Server stopped gracefully");


### PR DESCRIPTION
## What Does This PR Do?

Moves `data_dir` out of config into an explicit, required constructor argument on every engine entry point; fixes `snapshots_dir` to always derive from `data_dir` instead of a separately-configurable (and buggy, shared-`/tmp`) path; adds an OS-level startup lock so two processes can't share a `data_dir`; and removes `NodeBuilder` from the public API (`start_custom`/`run_custom` already cover custom storage/state machine integration).

**Type:**

- [x] Bug Fix (with test)
- [ ] Feature (issue #___ approved)
- [x] Documentation
- [x] Test/Coverage
- [ ] Performance (with benchmark)

---

## Why Is This Needed?

**For bugs:** `snapshots_dir` was independently configurable and defaulted to a shared path — running multiple standalone nodes on one machine caused real cross-node snapshot corruption. Separately, `data_dir`'s lock was acquired *after* storage was already opened, so two racing processes could both get partway into opening the same RocksDB directory before either checked the lock. Both are fixed by making `data_dir` a single, explicit, locked source of truth instead of a config-file value with independent overrides.

---

## Checklist

**Required:**

- [x] `make test` passes
- [x] Added tests for new code
- [x] Commits squashed to 1-2 logical units

**If changing APIs:**

- [x] Updated relevant docs
- [x] Explained why complexity is justified

---

## Testing

**How tested:**

- Unit tests: `DataDirLock`/`DataDir` (acquire, matches, released-on-drop, released-on-storage-init-failure), `initial_cluster` shorthand parsing (13 cases)
- Integration tests: 13 standalone tests that previously shared one `data_dir` across a multi-node loop (real bug, now isolated); 6 snapshot tests whose path assertions pointed at the removed `snapshots_dir` field
- Manual testing: none — fully covered by automated tests

**For bug fixes:**

- [x] Added test that fails without this fix (e.g. `data_dir_lock_rejects_concurrent_start`, `wait_for_snapshot` path assertions)

---

## Does This Follow d-engine's Principles?

- [x] Solves a real problem for most users (not just my edge case) — multi-node-per-machine snapshot corruption is a common deployment pattern
- [x] Keeps implementation simple — one less config field to get wrong, `data_dir` always unambiguous
- [x] Doesn't bloat the API surface — net reduction: `NodeBuilder` no longer public, `snapshots_dir`/`data_dir` no longer config fields

---

## Reviewer Notes

Focus on: lock-acquisition ordering in `embedded.rs`/`standalone.rs` (`start`/`start_with`/`run`/`run_with` — lock before storage open), and the `NodeBuilder` visibility change (`d-engine-server/src/node/builder.rs` + `MIGRATION_GUIDE.md`). Rest is mechanical fallout (config field removal → ~120 call sites).

**Estimated review complexity:**

- [ ] Quick (< 100 lines)
- [ ] Medium (< 300 lines)
- [x] Deep (> 300 lines)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Breaking Changes**
  - Startup APIs now require an explicit data directory.
  - Removed database, log, and configurable snapshot directory settings.
  - Custom startup now uses engine APIs; `NodeBuilder` is no longer public.
  - Minimum supported Rust version is now 1.89.

- **New Features**
  - Data directories are validated and protected against concurrent use.
  - Snapshots are stored automatically under each node’s data directory.
  - Cluster configuration supports shorthand node definitions and detects duplicate listen addresses.

- **Documentation**
  - Updated migration guidance, quick starts, examples, and configuration references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->