### PR TITLE
fix #438: leader doesn't detect a peer's graceful stream shutdown (EOF)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,9 +1215,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.17.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0b564323a0fb6d54b864f625ae139de9612e27edb944dda37c109f05aac531"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]

--- a/d-engine-core/Cargo.toml
+++ b/d-engine-core/Cargo.toml
@@ -55,7 +55,7 @@ tokio-stream = "0.1.16"
 # Packing/unpacking TAR archives
 astral-tokio-tar = "0.6"
 rand = "0.9"
-lru = "0.17"
+lru = "0.18"
 memmap2 = "0.9.5"
 crc32fast = "1.4.2"
 # used in stream

--- a/d-engine-core/src/raft.rs
+++ b/d-engine-core/src/raft.rs
@@ -268,15 +268,8 @@ where
 
                 // P0: shutdown received;
                 _ = self.shutdown_signal.changed() => {
-                    info!("[Raft:{}] shutdown signal received.", self.node_id);
-                    // Close IO thread BEFORE returning (before runtime shutdown)
-                    // This ensures RocksDB file lock is released before tokio runtime shuts down
-                    self.ctx.storage.raft_log.close().await;
-                    // Unblock any tasks stuck in event_tx.send().await (e.g. gRPC stream handlers).
-                    // Without this, serve_with_shutdown never completes and Arc<Node> is never
-                    // released, keeping Arc<DB> alive and the RocksDB LOCK held indefinitely.
-                    self.event_rx.close();
-                    return Ok(());
+                    return self.handle_shutdown().await;
+
                 }
 
                 // P1: Tick: start Heartbeat(replication) or start Election
@@ -326,6 +319,18 @@ where
                 tick.as_mut().reset(new_deadline);
             }
         }
+    }
+
+    async fn handle_shutdown(&mut self) -> Result<()> {
+        info!("[Raft:{}] shutdown signal received.", self.node_id);
+        // Close IO thread BEFORE returning (before runtime shutdown)
+        // This ensures RocksDB file lock is released before tokio runtime shuts down
+        self.ctx.storage.raft_log.close().await;
+        // Unblock any tasks stuck in event_tx.send().await (e.g. gRPC stream handlers).
+        // Without this, serve_with_shutdown never completes and Arc<Node> is never
+        // released, keeping Arc<DB> alive and the RocksDB LOCK held indefinitely.
+        self.event_rx.close();
+        Ok(())
     }
 
     /// Drain all pending inbound events (up to max_batch_size).

--- a/d-engine-core/src/raft_role/leader_state.rs
+++ b/d-engine-core/src/raft_role/leader_state.rs
@@ -68,6 +68,7 @@ use d_engine_proto::server::replication::AppendEntriesRequest;
 use d_engine_proto::server::replication::AppendEntriesResponse;
 use d_engine_proto::server::replication::append_entries_response;
 use d_engine_proto::server::storage::SnapshotMetadata;
+use futures::StreamExt;
 use rand::distr::SampleString;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -2029,86 +2030,96 @@ impl<T: TypeConfig> LeaderState<T> {
             let stream_sender = stream.sender;
             let mut stream_receiver = stream.receiver;
 
-            // Shared flag: both recv task and main loop can detect stream breakage
+            // Flag set by the main loop below when the stream becomes unusable — either
+            // because recv_handle terminated (EOF or error) or because a send failed.
             let stream_broken = Arc::new(AtomicBool::new(false));
-            let recv_broken = stream_broken.clone();
-
             // Spawn recv task to monitor ACKs and detect stream disconnection
             let recv_internal_event_tx = internal_event_tx.clone();
-            let recv_handle = tokio::spawn(async move {
-                use futures::StreamExt;
-                while let Some(result) = stream_receiver.next().await {
-                    match result {
-                        Ok(response) => {
+
+            let mut recv_handle = tokio::spawn(async move {
+                loop {
+                    match stream_receiver.next().await {
+                        Some(Ok(response)) => {
                             let _ = recv_internal_event_tx.send(InternalEvent::AppendResult {
                                 follower_id: peer_id,
                                 result: Ok(response),
                             });
                         }
-                        Err(status) => {
+                        Some(Err(status)) => {
                             warn!(peer_id, "Bidi stream recv error: {:?}", status);
-                            recv_broken.store(true, Ordering::Release);
-                            let _ = recv_internal_event_tx
-                                .send(InternalEvent::PeerStreamError { peer_id });
+                            break;
+                        }
+                        None => {
+                            debug!(peer_id, "Bidi stream ended (EOF)");
                             break;
                         }
                     }
                 }
-                debug!(peer_id, "Recv task exiting (stream closed)");
             });
 
             // Main worker loop: process replication tasks
-            while let Some(task) = task_rx.recv().await {
-                // Check stream health before processing task
-                if stream_broken.load(Ordering::Acquire) {
-                    debug!(peer_id, "Stream broken detected, reconnecting...");
-                    break;
-                }
-
-                match task {
-                    ReplicationTask::Append(request) => {
-                        if snapshot_in_progress.load(Ordering::Acquire) {
-                            debug!(
-                                peer_id,
-                                "Skipping AppendEntries while snapshot is in progress"
-                            );
-                            continue;
-                        }
-                        // Push batch directly into the persistent bidi stream (non-blocking)
-                        if stream_sender.send(request).await.is_err() {
-                            warn!(peer_id, "Bidi stream sender closed, reconnecting");
-                            stream_broken.store(true, Ordering::Release);
-                            let _ =
-                                internal_event_tx.send(InternalEvent::PeerStreamError { peer_id });
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = &mut recv_handle => {
+                        debug!(peer_id, "Replication stream receiver exited, reconnecting");
+                        stream_broken.store(true, Ordering::Release);
+                        let _ = internal_event_tx.send(InternalEvent::PeerStreamError { peer_id });
+                        break;
+                    }
+                    task = task_rx.recv() => {
+                        let Some(task) = task else { break };
+                        if stream_broken.load(Ordering::Acquire) {
+                            debug!(peer_id, "Stream broken detected, reconnecting...");
                             break;
                         }
-                    }
-                    ReplicationTask::Snapshot(metadata) => {
-                        if snapshot_in_progress.load(Ordering::Acquire) {
-                            debug!(
-                                peer_id,
-                                "Skipping duplicate Snapshot task (already in progress)"
-                            );
-                            continue;
-                        }
-                        snapshot_in_progress.store(true, Ordering::Release);
-                        // Spawn snapshot transfer; bidi stream stays open
-                        let flag = snapshot_in_progress.clone();
-                        let t = transport.clone();
-                        let smh = state_machine_handler.clone();
-                        let m = membership.clone();
-                        let c = snapshot_config.clone();
-                        let tx = internal_event_tx.clone();
-                        tokio::spawn(async move {
-                            let result = t.send_snapshot(peer_id, metadata, smh, m, c).await;
-                            let success = result.is_ok();
-                            if !success {
-                                warn!(peer_id, "Snapshot push failed: {:?}", result);
+
+                        match task {
+                            ReplicationTask::Append(request) => {
+                                if snapshot_in_progress.load(Ordering::Acquire) {
+                                    debug!(
+                                        peer_id,
+                                        "Skipping AppendEntries while snapshot is in progress"
+                                    );
+                                    continue;
+                                }
+                                // Push batch directly into the persistent bidi stream (non-blocking)
+                                if stream_sender.send(request).await.is_err() {
+                                    warn!(peer_id, "Bidi stream sender closed, reconnecting");
+                                    stream_broken.store(true, Ordering::Release);
+                                    let _ =
+                                        internal_event_tx.send(InternalEvent::PeerStreamError { peer_id });
+                                    break;
+                                }
                             }
-                            flag.store(false, Ordering::Release);
-                            let _ =
-                                tx.send(InternalEvent::SnapshotPushCompleted { peer_id, success });
-                        });
+                            ReplicationTask::Snapshot(metadata) => {
+                                if snapshot_in_progress.load(Ordering::Acquire) {
+                                    debug!(
+                                        peer_id,
+                                        "Skipping duplicate Snapshot task (already in progress)"
+                                    );
+                                    continue;
+                                }
+                                snapshot_in_progress.store(true, Ordering::Release);
+                                // Spawn snapshot transfer; bidi stream stays open
+                                let flag = snapshot_in_progress.clone();
+                                let t = transport.clone();
+                                let smh = state_machine_handler.clone();
+                                let m = membership.clone();
+                                let c = snapshot_config.clone();
+                                let tx = internal_event_tx.clone();
+                                tokio::spawn(async move {
+                                    let result = t.send_snapshot(peer_id, metadata, smh, m, c).await;
+                                    let success = result.is_ok();
+                                    if !success {
+                                        warn!(peer_id, "Snapshot push failed: {:?}", result);
+                                    }
+                                    flag.store(false, Ordering::Release);
+                                    let _ =
+                                        tx.send(InternalEvent::SnapshotPushCompleted { peer_id, success });
+                                });
+                            }
+                        }
                     }
                 }
             }

--- a/d-engine-core/src/raft_role/leader_state_test/worker_lifecycle_test.rs
+++ b/d-engine-core/src/raft_role/leader_state_test/worker_lifecycle_test.rs
@@ -447,3 +447,156 @@ async fn test_replication_worker_exits_when_handle_dropped() {
         count_at_drop, count_after_wait
     );
 }
+
+/// A bidi stream recv error must surface as `PeerStreamError` so the Raft loop
+/// resets `next_index` and re-sends unACKed entries.
+///
+/// # Why it matters
+/// A broken ACK stream means in-flight AppendEntries were never acknowledged;
+/// without `PeerStreamError` the leader would wrongly advance its commit index.
+///
+/// # Covered branch
+/// `Some(Err(status))` in the recv task (post-#438 refactor), which now `break`s
+/// and relies on the main loop's `recv_handle` arm for shared disconnect handling.
+#[tokio::test]
+#[traced_test]
+async fn test_replication_worker_recv_stream_error_emits_peer_stream_error() {
+    let (_graceful_tx, graceful_rx) = watch::channel(());
+    let mut ctx = mock_raft_context(
+        "/tmp/test_replication_worker_recv_stream_error_emits_peer_stream_error",
+        graceful_rx,
+        None,
+    );
+
+    ctx.membership = Arc::new(two_peer_membership());
+
+    ctx.handlers
+        .replication_handler
+        .expect_prepare_batch_requests()
+        .times(1)
+        .returning(|_, _, _, _, _| {
+            Ok(crate::PrepareResult {
+                append_requests: vec![(2, stub_request())],
+                snapshot_targets: vec![],
+            })
+        });
+
+    // The worker reconnects after a broken stream. The first stream yields an
+    // immediate recv error to exercise the recv path; later reconnects park on a
+    // pending ACK stream so the worker stops reconnecting and the test stays quiet.
+    let open_count = Arc::new(AtomicUsize::new(0));
+    let open_count_clone = Arc::clone(&open_count);
+    let mut transport = MockTransport::<MockTypeConfig>::new();
+    transport.expect_open_replication_stream().times(..).returning(move |_, _, _| {
+        let attempt = open_count_clone.fetch_add(1, Ordering::SeqCst) + 1;
+        // Keep a live sender receiver so the sender path stays healthy; this test
+        // targets the recv path only and must not hit the sender-closed branch.
+        let (sender, mut send_receiver) = tokio::sync::mpsc::channel::<AppendEntriesRequest>(128);
+        tokio::spawn(async move { while send_receiver.recv().await.is_some() {} });
+        let receiver = if attempt == 1 {
+            futures::stream::iter(vec![Err::<AppendEntriesResponse, tonic::Status>(
+                tonic::Status::unavailable("recv stream broken"),
+            )])
+            .boxed()
+        } else {
+            futures::stream::pending::<Result<AppendEntriesResponse, tonic::Status>>().boxed()
+        };
+        Ok(crate::ReplicationStream { sender, receiver })
+    });
+    ctx.transport = Arc::new(transport);
+
+    let mut raft_log = MockRaftLog::new();
+    raft_log.expect_last_entry_id().returning(|| 0);
+    raft_log.expect_flush().returning(|| Ok(()));
+    raft_log.expect_save_hard_state().returning(|_| Ok(()));
+    ctx.storage.raft_log = Arc::new(raft_log);
+
+    let mut state = LeaderState::<MockTypeConfig>::new(1, ctx.node_config.clone());
+    state.init_cluster_metadata(&ctx.membership).await.unwrap();
+
+    let (internal_event_tx, mut internal_event_rx) = mpsc::unbounded_channel();
+    state.process_batch(one_entry_batch(), &internal_event_tx, &ctx).await.unwrap();
+
+    let event = tokio::time::timeout(std::time::Duration::from_secs(2), internal_event_rx.recv())
+        .await
+        .expect("timed out waiting for PeerStreamError")
+        .expect("event channel closed before PeerStreamError");
+    assert!(
+        matches!(event, InternalEvent::PeerStreamError { peer_id: 2 }),
+        "expected PeerStreamError for peer 2, got {event:?}"
+    );
+}
+
+/// A bidi stream send failure must surface as `PeerStreamError` so the Raft loop
+/// resets `next_index` and re-sends unACKed entries.
+///
+/// # Why it matters
+/// A closed sender means the AppendEntries batch never reached the follower;
+/// without `PeerStreamError` the leader would wrongly advance its commit index.
+///
+/// # Covered branch
+/// `stream_sender.send(request).await.is_err()`. The ACK stream is kept pending so
+/// the biased `select!` cannot resolve the `recv_handle` arm before the Append task.
+#[tokio::test]
+#[traced_test]
+async fn test_replication_worker_sender_closed_emits_peer_stream_error() {
+    let (_graceful_tx, graceful_rx) = watch::channel(());
+    let mut ctx = mock_raft_context(
+        "/tmp/test_replication_worker_sender_closed_emits_peer_stream_error",
+        graceful_rx,
+        None,
+    );
+
+    ctx.membership = Arc::new(two_peer_membership());
+
+    ctx.handlers
+        .replication_handler
+        .expect_prepare_batch_requests()
+        .times(1)
+        .returning(|_, _, _, _, _| {
+            Ok(crate::PrepareResult {
+                append_requests: vec![(2, stub_request())],
+                snapshot_targets: vec![],
+            })
+        });
+
+    // The first stream's sender receiver is dropped so `send()` fails immediately;
+    // later reconnects park on a pending ACK stream so the worker stops reconnecting.
+    let open_count = Arc::new(AtomicUsize::new(0));
+    let open_count_clone = Arc::clone(&open_count);
+    let mut transport = MockTransport::<MockTypeConfig>::new();
+    transport.expect_open_replication_stream().times(..).returning(move |_, _, _| {
+        let attempt = open_count_clone.fetch_add(1, Ordering::SeqCst) + 1;
+        let (sender, send_receiver) = tokio::sync::mpsc::channel::<AppendEntriesRequest>(128);
+        if attempt == 1 {
+            drop(send_receiver);
+        }
+        // Keep the ACK stream pending so the biased select! reaches the Append arm
+        // (attempt 1) and the worker parks (later attempts).
+        let receiver =
+            futures::stream::pending::<Result<AppendEntriesResponse, tonic::Status>>().boxed();
+        Ok(crate::ReplicationStream { sender, receiver })
+    });
+    ctx.transport = Arc::new(transport);
+
+    let mut raft_log = MockRaftLog::new();
+    raft_log.expect_last_entry_id().returning(|| 0);
+    raft_log.expect_flush().returning(|| Ok(()));
+    raft_log.expect_save_hard_state().returning(|_| Ok(()));
+    ctx.storage.raft_log = Arc::new(raft_log);
+
+    let mut state = LeaderState::<MockTypeConfig>::new(1, ctx.node_config.clone());
+    state.init_cluster_metadata(&ctx.membership).await.unwrap();
+
+    let (internal_event_tx, mut internal_event_rx) = mpsc::unbounded_channel();
+    state.process_batch(one_entry_batch(), &internal_event_tx, &ctx).await.unwrap();
+
+    let event = tokio::time::timeout(std::time::Duration::from_secs(2), internal_event_rx.recv())
+        .await
+        .expect("timed out waiting for PeerStreamError")
+        .expect("event channel closed before PeerStreamError");
+    assert!(
+        matches!(event, InternalEvent::PeerStreamError { peer_id: 2 }),
+        "expected PeerStreamError for peer 2, got {event:?}"
+    );
+}

--- a/d-engine-core/src/raft_test/process_inbound_events_tests.rs
+++ b/d-engine-core/src/raft_test/process_inbound_events_tests.rs
@@ -283,3 +283,41 @@ async fn test_process_internal_events_propagates_fatal_error() {
     let err = raft.process_internal_events().await.unwrap_err();
     assert!(err.is_fatal());
 }
+
+// -----------------------------------------------------------------------
+// handle_shutdown (#438)
+// -----------------------------------------------------------------------
+
+/// Events still queued when shutdown fires are dropped, not answered — their
+/// resp_tx senders are never called. Drives the real `handle_shutdown` path,
+/// not a re-implementation of it.
+#[tokio::test]
+async fn test_handle_shutdown_drops_pending_events_without_responding() {
+    let (_graceful_tx, graceful_rx) = watch::channel(());
+    let mut raft = MockBuilder::new(graceful_rx).build_raft();
+
+    let (tx1, rx1) = MaybeCloneOneshot::new();
+    let (tx2, rx2) = MaybeCloneOneshot::new();
+    let mut queue = VecDeque::new();
+    queue.push_back(InboundEvent::AppendEntries(
+        make_request(5, 9, 5, 1),
+        vec![tx1],
+    ));
+    queue.push_back(InboundEvent::AppendEntries(
+        make_request(5, 14, 5, 1),
+        vec![tx2],
+    ));
+    raft.buffered_inbound_event = queue;
+
+    raft.handle_shutdown().await.unwrap();
+    drop(raft); // matches production: Raft is dropped shortly after run() returns
+
+    assert!(
+        rx1.await.is_err(),
+        "pending event must be dropped, not answered"
+    );
+    assert!(
+        rx2.await.is_err(),
+        "pending event must be dropped, not answered"
+    );
+}

--- a/d-engine-server/Cargo.toml
+++ b/d-engine-server/Cargo.toml
@@ -69,7 +69,7 @@ d-engine-client = { workspace = true }
 d-engine-core = { workspace = true, features = ["__test_support"] }
 serial_test = "3.2.0"
 temp-env = "0.3.6"
-tracing-test = "0.2"
+tracing-test = { version = "0.2", features = ["no-env-filter"] }
 tokio-stream = "0.1.16"
 uuid = { version = "1", features = ["v4"] }
 tokio = { version = "1", features = ["test-util", "process"] }

--- a/d-engine-server/src/node/builder.rs
+++ b/d-engine-server/src/node/builder.rs
@@ -635,6 +635,7 @@ where
             _watch_dispatcher_handle: watch_system.map(|(_, _, handle, _)| handle),
             sm_worker_handle: std::sync::Mutex::new(Some(sm_worker_handle)),
             read_actor_handle: std::sync::Mutex::new(Some(read_actor_handle)),
+            rpc_server_handle: std::sync::Mutex::new(None),
             _commit_handler_handle: Some(commit_handler_handle),
             _lease_cleanup_handle: lease_cleanup_handle,
             shutdown_signal: self.shutdown_signal.clone(),
@@ -763,7 +764,7 @@ where
             let shutdown = self.shutdown_signal.clone();
             let listen_address = self.node_config.cluster.listen_address;
             let node_config = self.node_config.clone();
-            tokio::spawn(async move {
+            let handle = tokio::spawn(async move {
                 if let Err(e) =
                     grpc::start_rpc_server(node_clone, listen_address, node_config, shutdown).await
                 {
@@ -771,6 +772,7 @@ where
                     error!("RPC server stops. {:?}", e);
                 }
             });
+            *node.rpc_server_handle.lock().unwrap() = Some(handle);
             self
         } else {
             panic!("failed to start RPC server");

--- a/d-engine-server/src/node/mod.rs
+++ b/d-engine-server/src/node/mod.rs
@@ -38,6 +38,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
+use std::time::Duration;
 
 use d_engine_core::InboundEvent;
 use d_engine_core::Membership;
@@ -109,6 +110,10 @@ where
     /// ReadActor task handle. Aborted in run() after sm_worker exits so that the
     /// `Arc<SM>` (and the RocksDB LOCK) is released before run() returns.
     pub(crate) read_actor_handle: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
+
+    /// gRPC server task handle. tonic's graceful shutdown waits indefinitely for
+    /// long-lived streams (the Raft replication bidi stream never ends on its own)
+    pub(crate) rpc_server_handle: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
 
     /// Commit handler task handle (background log application)
     pub(crate) _commit_handler_handle: Option<tokio::task::JoinHandle<()>>,
@@ -183,6 +188,17 @@ where
         // Start Raft main loop.
         // Note: IO thread is closed inside Raft::run() on shutdown before returning.
         self.start_raft_loop().await?;
+
+        // Give tonic's graceful shutdown a bounded chance (fast path when no stream is
+        // active), then force-abort — it would otherwise wait indefinitely for the
+        // long-lived replication bidi stream to end on its own, which never happens (#438).
+        let rpc_handle = self.rpc_server_handle.lock().unwrap().take();
+        if let Some(rpc_handle) = rpc_handle {
+            let abort_handle = rpc_handle.abort_handle();
+            if tokio::time::timeout(Duration::from_millis(200), rpc_handle).await.is_err() {
+                abort_handle.abort();
+            }
+        }
 
         // Shutdown in reverse startup order: join sm-worker thread first so its
         // Arc<DB> clone is dropped before we return, releasing the RocksDB LOCK.

--- a/d-engine-server/src/node/mod.rs
+++ b/d-engine-server/src/node/mod.rs
@@ -104,11 +104,12 @@ where
 
     /// State machine worker thread handle (dedicated OS thread, not a tokio task).
     /// Wrapped in Mutex so run(&self) can take it for joining after Raft loop exits,
-    /// ensuring `Arc<DB>` is released before run() returns.
+    /// ensuring `Arc<SM>` is released before run() returns.
     pub(crate) sm_worker_handle: std::sync::Mutex<Option<std::thread::JoinHandle<()>>>,
 
     /// ReadActor task handle. Aborted in run() after sm_worker exits so that the
-    /// `Arc<SM>` (and the RocksDB LOCK) is released before run() returns.
+    /// `Arc<SM>` (and any exclusive resources the storage backend holds) is
+    /// released before run() returns.
     pub(crate) read_actor_handle: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
 
     /// gRPC server task handle. tonic's graceful shutdown waits indefinitely for
@@ -189,19 +190,22 @@ where
         // Note: IO thread is closed inside Raft::run() on shutdown before returning.
         self.start_raft_loop().await?;
 
-        // Give tonic's graceful shutdown a bounded chance (fast path when no stream is
-        // active), then force-abort — it would otherwise wait indefinitely for the
-        // long-lived replication bidi stream to end on its own, which never happens (#438).
+        // Bounded wait for graceful shutdown, then force-abort — the replication
+        // bidi stream never ends on its own (#438).
         let rpc_handle = self.rpc_server_handle.lock().unwrap().take();
-        if let Some(rpc_handle) = rpc_handle {
-            let abort_handle = rpc_handle.abort_handle();
-            if tokio::time::timeout(Duration::from_millis(200), rpc_handle).await.is_err() {
-                abort_handle.abort();
+        if let Some(mut rpc_handle) = rpc_handle {
+            let finished_in_time =
+                tokio::time::timeout(Duration::from_millis(200), &mut rpc_handle).await.is_ok();
+
+            if !finished_in_time {
+                rpc_handle.abort();
+                let _ = rpc_handle.await;
             }
         }
 
         // Shutdown in reverse startup order: join sm-worker thread first so its
-        // Arc<DB> clone is dropped before we return, releasing the RocksDB LOCK.
+        // Arc<SM> clone is dropped before we return, letting the storage backend
+        // release any exclusive resources it holds.
         let handle = self.sm_worker_handle.lock().unwrap().take();
         if let Some(handle) = handle {
             tokio::task::spawn_blocking(move || {
@@ -211,8 +215,9 @@ where
             .ok();
         }
 
-        // Abort ReadActor after sm_worker exits so Arc<SM> ref-count goes to zero
-        // and RocksDB LOCK is released before run() returns.
+        // Abort ReadActor after sm_worker exits so Arc<SM> ref-count reaches zero,
+        // letting the storage backend release any exclusive resources (e.g. an
+        // on-disk lock file) before run() returns.
         let ra_handle = self.read_actor_handle.lock().unwrap().take();
         if let Some(ra_handle) = ra_handle {
             ra_handle.abort();

--- a/d-engine-server/src/node/node_test.rs
+++ b/d-engine-server/src/node/node_test.rs
@@ -34,6 +34,37 @@ async fn test_readiness_state_transition() {
     assert!(node.is_rpc_ready());
 }
 
+/// build_node_with_rpc_server() must produce a Node whose gRPC server is
+/// actually reachable — that's the entire point of this builder variant vs
+/// plain build_node(), which leaves rpc_server_handle unset.
+#[tokio::test]
+async fn test_build_node_with_rpc_server_starts_reachable_server() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let listen_address = listener.local_addr().unwrap();
+    drop(listener); // free the port for start_rpc_server to bind
+
+    let mut node_config =
+        RaftNodeConfig::new().expect("default config").validate().expect("valid config");
+    node_config.cluster.listen_address = listen_address;
+
+    let (_shutdown_tx, shutdown_rx) = watch::channel(());
+    let _node = MockBuilder::new(shutdown_rx)
+        .with_node_config(node_config)
+        .build_node_with_rpc_server();
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        if tokio::net::TcpStream::connect(listen_address).await.is_ok() {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "RPC server never became reachable at {listen_address}"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
 #[tokio::test]
 #[traced_test]
 async fn test_run_sequence_with_mock_peers() {

--- a/d-engine-server/src/test_utils/mock/mock_node_builder.rs
+++ b/d-engine-server/src/test_utils/mock/mock_node_builder.rs
@@ -340,6 +340,7 @@ impl MockBuilder {
             #[cfg(feature = "watch")]
             _watch_dispatcher_handle: None,
             sm_worker_handle: std::sync::Mutex::new(None),
+            rpc_server_handle: std::sync::Mutex::new(None),
             read_actor_handle: std::sync::Mutex::new(None),
             _commit_handler_handle: None,
             _lease_cleanup_handle: None,
@@ -398,6 +399,7 @@ impl MockBuilder {
             #[cfg(feature = "watch")]
             _watch_dispatcher_handle: None,
             sm_worker_handle: std::sync::Mutex::new(None),
+            rpc_server_handle: std::sync::Mutex::new(None),
             read_actor_handle: std::sync::Mutex::new(None),
             _commit_handler_handle: None,
             _lease_cleanup_handle: None,

--- a/d-engine-server/tests/failover_and_recovery/sm_wal_disabled_crash_recovery_embedded.rs
+++ b/d-engine-server/tests/failover_and_recovery/sm_wal_disabled_crash_recovery_embedded.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 use d_engine_server::RocksDBUnifiedEngine;
 use d_engine_server::api::DefaultEmbeddedEngine;
 use tracing::info;
-use tracing_test::traced_test;
 
 use crate::common::create_node_config;
 use crate::common::create_rejoin_node_config;
@@ -53,7 +52,6 @@ fn copy_dir_all(
 /// and cannot resurrect the MemTable data we just excluded from the snapshot.
 /// Restart opens the snapshot copy rather than the original path.
 #[tokio::test]
-#[traced_test]
 async fn test_follower_sm_recovers_after_abrupt_crash() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = tempfile::tempdir()?;
     let db_root = temp_dir.path().join("db");
@@ -266,7 +264,6 @@ async fn test_follower_sm_recovers_after_abrupt_crash() -> Result<(), Box<dyn st
 /// With `disableWAL=true`, entries applied by the leader's SM before the crash
 /// may not have reached SST. Raft log WAL guarantees they can be replayed on restart.
 #[tokio::test]
-#[traced_test]
 async fn test_leader_sm_recovers_after_abrupt_crash() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = tempfile::tempdir()?;
     let db_root = temp_dir.path().join("db");

--- a/d-engine-server/tests/reliability/mod.rs
+++ b/d-engine-server/tests/reliability/mod.rs
@@ -8,3 +8,4 @@ mod data_dir_lock_crash_recovery_embedded;
 mod data_dir_lock_rejects_concurrent_start_embedded;
 mod data_dir_lock_released_after_stop_embedded;
 mod data_dir_lock_released_after_storage_init_failure_embedded;
+mod network_listener_released_after_stop_embedded;

--- a/d-engine-server/tests/reliability/network_listener_released_after_stop_embedded.rs
+++ b/d-engine-server/tests/reliability/network_listener_released_after_stop_embedded.rs
@@ -1,0 +1,125 @@
+//! Regression test for #438: graceful stop() doesn't guarantee the network layer
+//! (and its existing peer connections) has actually closed before returning.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use d_engine_server::DefaultEmbeddedEngine;
+use d_engine_server::RocksDBUnifiedEngine;
+use tracing::info;
+use tracing_test::traced_test;
+
+use crate::common::get_available_ports;
+
+/// Purpose: when a follower calls `stop()`, the leader's *already-open* replication
+/// connection to it must be noticed as broken within a short, bounded window —
+/// not "eventually, whenever the transport layer's keepalive happens to fire" (#438).
+///
+/// This reuses the 3-node cluster bootstrap pattern from
+/// `snapshot_and_recovery/snapshot_correctness_after_install_embedded.rs`, stripped
+/// down to the minimum needed to exercise #438: no data writes, no snapshot config —
+/// just start a cluster, stop a follower, and check how fast the leader notices.
+///
+/// Poll window is generous (a few seconds) purely as a CI/OS-jitter tolerance — a
+/// correct fix should make this near-instant, not "eventually within the window."
+#[tokio::test]
+#[traced_test]
+async fn test_leader_detects_follower_stop_within_bounded_window()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempfile::tempdir()?;
+    let data_dir = temp_dir.path().join("db");
+
+    let mut port_guard = get_available_ports(3).await;
+    port_guard.release_listeners();
+    let ports = port_guard.as_slice();
+
+    let mut engines: Vec<Option<DefaultEmbeddedEngine>> = Vec::new();
+
+    for node_id in 1u64..=3 {
+        let config = format!(
+            r#"
+[cluster]
+node_id = {node_id}
+listen_address = '127.0.0.1:{}'
+initial_cluster = [
+    {{ id = 1, name = 'n1', address = '127.0.0.1:{}', role = 1, status = 3 }},
+    {{ id = 2, name = 'n2', address = '127.0.0.1:{}', role = 1, status = 3 }},
+    {{ id = 3, name = 'n3', address = '127.0.0.1:{}', role = 1, status = 3 }}
+]
+
+[raft]
+general_raft_timeout_duration_in_ms = 5000
+"#,
+            ports[node_id as usize - 1],
+            ports[0],
+            ports[1],
+            ports[2],
+        );
+
+        let config_path = temp_dir.path().join(format!("node{node_id}.toml"));
+        tokio::fs::write(&config_path, &config).await?;
+
+        let db_path = data_dir.join(format!("node{node_id}/db"));
+        tokio::fs::create_dir_all(&db_path).await?;
+
+        let (storage, sm) = RocksDBUnifiedEngine::open(&db_path)?;
+        let engine = DefaultEmbeddedEngine::start_custom(
+            &db_path,
+            Arc::new(storage),
+            Arc::new(sm),
+            Some(config_path.to_str().unwrap()),
+        )
+        .await?;
+        engines.push(Some(engine));
+    }
+
+    let leader_info = engines[0].as_ref().unwrap().wait_ready(Duration::from_secs(15)).await?;
+    let leader_idx = engines
+        .iter()
+        .position(|e| e.as_ref().map(|e| e.node_id() == leader_info.leader_id).unwrap_or(false))
+        .expect("leader must be one of the 3 engines");
+    let leader_client = engines[leader_idx].as_ref().unwrap().client().clone();
+
+    let follower_idx = engines
+        .iter()
+        .position(|e| e.as_ref().map(|e| !e.is_leader()).unwrap_or(false))
+        .expect("must have at least one non-leader");
+    let follower_node_id = engines[follower_idx].as_ref().unwrap().node_id();
+    info!("Stopping follower node {follower_node_id}");
+
+    // Force definite replication activity (not just relying on heartbeats) so we
+    // can conclusively tell whether logs_contain sees worker-task logs at all.
+    leader_client.put(b"diag_key".to_vec(), b"diag_value".to_vec()).await?;
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let stopped = engines[follower_idx].take().unwrap();
+    stopped.stop().await?;
+
+    // The leader's worker for this peer should notice the connection is gone.
+    // A graceful stop ends the stream cleanly (EOF), not with an error — so check
+    // for every way the worker's recv_handle can report termination, not just the
+    // error path. Poll window is a CI tolerance, not an expected delay: see doc
+    // comment above.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    let mut detected = false;
+    while tokio::time::Instant::now() < deadline {
+        if logs_contain("Bidi stream recv error")
+            || logs_contain("Bidi stream sender closed")
+            || logs_contain("Bidi stream ended (EOF)")
+            || logs_contain("Replication stream receiver exited")
+        {
+            detected = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    assert!(
+        detected,
+        "leader did not detect follower {follower_node_id}'s stop() within 3s — \
+         the replication stream should have errored out promptly, not been left \
+         dangling waiting on a transport-level keepalive timeout (#438)"
+    );
+
+    Ok(())
+}

--- a/examples/client-usage-standalone/Cargo.lock
+++ b/examples/client-usage-standalone/Cargo.lock
@@ -933,9 +933,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.17.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0b564323a0fb6d54b864f625ae139de9612e27edb944dda37c109f05aac531"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]

--- a/examples/single-node-expansion/Cargo.lock
+++ b/examples/single-node-expansion/Cargo.lock
@@ -1240,9 +1240,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.17.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0b564323a0fb6d54b864f625ae139de9612e27edb944dda37c109f05aac531"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]

--- a/examples/three-nodes-embedded/Cargo.lock
+++ b/examples/three-nodes-embedded/Cargo.lock
@@ -1406,9 +1406,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.17.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0b564323a0fb6d54b864f625ae139de9612e27edb944dda37c109f05aac531"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]


### PR DESCRIPTION
## What Does This PR Do?

Leader's replication worker now detects a peer's graceful stream shutdown (clean EOF), not just stream errors — fixes #438. Also bumps `lru` off a RUSTSEC advisory (RUSTSEC-2026-0253).

**Type:**

- [x] Bug Fix (with test)

---

## Why Is This Needed?

**For bugs:** The recv loop in `run_replication_worker` only treated `Err` on the replication stream as a disconnect signal. A clean EOF — exactly what a peer's graceful `stop()` produces — was silently ignored: the leader never reconnected, never re-probed, and kept pushing heartbeats into a channel nobody was reading. Fixed by having the main loop `select!` directly on the recv task's own completion (any exit reason), instead of only checking a flag when the next task happened to arrive.

---

## Checklist

**Required:**

- [x] `test_leader_detects_follower_stop_within_bounded_window` passes (`cargo test -p d-engine-server --all-features`); full `integration_test` suite passes in isolation (3 tests flaky under `--test-threads=4` due to shared-CPU contention across embedded clusters, all green individually)
- [x] Added tests for new code
- [x] Commits squashed to 2 logical units (#438 fix; unrelated `lru` security bump)

**If changing APIs:** N/A — no public API changes (`rpc_server_handle` is `pub(crate)`)

---

## Testing

**How tested:**

- Integration tests: `test_leader_detects_follower_stop_within_bounded_window` — real 3-node embedded cluster, gracefully stops a follower, polls leader-side logs for disconnect detection within a 3s bounded window
- Manual testing: N/A

**For bug fixes:**

- [x] Added test that fails without this fix (verified red before / green after)

---

## Does This Follow d-engine's Principles?

- [x] Solves a real problem for most users — any graceful follower restart/rolling upgrade hits this
- [x] Keeps implementation simple — `select!` restructure, no new abstractions
- [x] Doesn't bloat the API surface — one `pub(crate)` field

---

## Reviewer Notes

Focus review on `run_replication_worker` in `leader_state.rs` — that's the actual fix. Everything else in this PR is supporting/unrelated: `rpc_server_handle` (bounded shutdown wait, layer-1 fix kept for resource cleanup, not the root cause), `mock_node_builder.rs` (unrelated pre-existing gap that blocked `--lib` tests from compiling), `tracing-test` no-env-filter (test-only, required to trust the log-based assertions).

**Estimated review complexity:**

- [x] Medium (< 300 lines)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of interrupted replication connections so leaders reconnect promptly when followers stop or become unreachable.
  * Improved handling of replication stream closures and communication errors.
  * Prevented RPC server tasks from lingering during node shutdown, enabling cleaner and more reliable stopping.
  * Ensured pending requests are discarded cleanly during shutdown.

* **Tests**
  * Added reliability coverage for stopped-follower detection.
  * Added coverage for RPC server availability, replication failures, and orderly shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->